### PR TITLE
Add clipboard cursor related tools

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
     implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -104,6 +104,11 @@ class FlorisBoard : InputMethodService() {
         fun getInstance(): FlorisBoard {
             return florisboardInstance!!
         }
+
+        @Synchronized
+        fun getInstanceOrNull(): FlorisBoard? {
+            return florisboardInstance
+        }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -258,11 +258,15 @@ class PrefHelper(
     class Suggestion(private val prefHelper: PrefHelper) {
         companion object {
             const val ENABLED =                 "suggestion__enabled"
+            const val SHOW_INSTEAD =            "suggestion__show_instead"
             const val USE_PREV_WORDS =          "suggestion__use_prev_words"
         }
 
         var enabled: Boolean = false
             get() = prefHelper.getPref(ENABLED, true)
+            private set
+        var showInstead: String = ""
+            get() = prefHelper.getPref(SHOW_INSTEAD, "number_row")
             private set
         var usePrevWords: Boolean = false
             get() = prefHelper.getPref(USE_PREV_WORDS, true)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/editing/EditingKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/editing/EditingKeyView.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2020 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.editing
+
+import android.content.Context
+import android.content.res.Configuration
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.util.AttributeSet
+import android.widget.Button
+import androidx.appcompat.widget.AppCompatImageButton
+import dev.patrickgold.florisboard.R
+import dev.patrickgold.florisboard.ime.core.FlorisBoard
+import dev.patrickgold.florisboard.ime.text.key.KeyCode
+import dev.patrickgold.florisboard.ime.text.key.KeyData
+import dev.patrickgold.florisboard.util.getColorFromAttr
+
+class EditingKeyView : AppCompatImageButton {
+    private val florisboard: FlorisBoard? = FlorisBoard.getInstanceOrNull()
+    private val data: KeyData
+
+    private var label: String? = null
+    private var labelPaint: Paint = Paint().apply {
+        alpha = 255
+        color = 0
+        isAntiAlias = true
+        isFakeBoldText = false
+        textAlign = Paint.Align.CENTER
+        textSize = Button(context).textSize
+        typeface = Typeface.DEFAULT
+    }
+
+    constructor(context: Context) : this(context, null)
+    constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, R.style.TextEditingButton)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+        val code = when (id) {
+            R.id.arrow_down -> KeyCode.ARROW_DOWN
+            R.id.arrow_left -> KeyCode.ARROW_LEFT
+            R.id.arrow_right -> KeyCode.ARROW_RIGHT
+            R.id.arrow_up -> KeyCode.ARROW_UP
+            R.id.clipboard_copy -> KeyCode.CLIPBOARD_COPY
+            R.id.clipboard_cut -> KeyCode.CLIPBOARD_CUT
+            R.id.clipboard_paste -> KeyCode.CLIPBOARD_PASTE
+            R.id.move_home -> KeyCode.MOVE_HOME
+            R.id.move_end -> KeyCode.MOVE_END
+            R.id.select -> KeyCode.CLIPBOARD_SELECT
+            R.id.select_all -> KeyCode.CLIPBOARD_SELECT_ALL
+            else -> 0
+        }
+        data = KeyData(code)
+        context.obtainStyledAttributes(attrs, R.styleable.EditingKeyView).apply {
+            label = getString(R.styleable.EditingKeyView_android_text)
+            recycle()
+        }
+    }
+
+    /**
+     * Draw the key label / drawable.
+     */
+    override fun onDraw(canvas: Canvas?) {
+        super.onDraw(canvas)
+
+        canvas ?: return
+
+        // Draw label
+        val label = label
+        if (label != null) {
+            labelPaint.color = if (data.code == KeyCode.CLIPBOARD_SELECT && false) {
+                getColorFromAttr(context, R.attr.colorAccent)
+            } else {
+                getColorFromAttr(context, R.attr.key_fgColor)
+            }
+            val isPortrait =
+                resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+            if (!isPortrait) {
+                labelPaint.textSize *= 0.9f
+            }
+            val centerX = measuredWidth / 2.0f
+            val centerY = measuredHeight / 2.0f + (labelPaint.textSize - labelPaint.descent()) / 2
+            if (label.contains("\n")) {
+                // Even if more lines may be existing only the first 2 are shown
+                val labelLines = label.split("\n")
+                canvas.drawText(labelLines[0], centerX, centerY * 0.70f, labelPaint)
+                canvas.drawText(labelLines[1], centerX, centerY * 1.30f, labelPaint)
+            } else {
+                canvas.drawText(label, centerX, centerY, labelPaint)
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/editing/EditingKeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/editing/EditingKeyboardView.kt
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package dev.patrickgold.florisboard.ime.text.keyboard
+package dev.patrickgold.florisboard.ime.editing
 
-enum class KeyboardMode {
-    CHARACTERS,
-    EDITING,
-    SYMBOLS,
-    SYMBOLS2,
-    NUMERIC,
-    NUMERIC_ADVANCED,
-    PHONE,
-    PHONE2
+import android.content.Context
+import android.util.AttributeSet
+import androidx.constraintlayout.widget.ConstraintLayout
+
+class EditingKeyboardView : ConstraintLayout {
+    constructor(context: Context) : this(context, null)
+    constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+
+    }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/editing/EditingKeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/editing/EditingKeyboardView.kt
@@ -18,12 +18,65 @@ package dev.patrickgold.florisboard.ime.editing
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
+import android.view.inputmethod.CursorAnchorInfo
 import androidx.constraintlayout.widget.ConstraintLayout
+import dev.patrickgold.florisboard.R
+import dev.patrickgold.florisboard.ime.core.FlorisBoard
 
-class EditingKeyboardView : ConstraintLayout {
+/**
+ * View class for updating the key views depending on the current selection and clipboard state.
+ */
+class EditingKeyboardView : ConstraintLayout, FlorisBoard.EventListener {
+    private val florisboard: FlorisBoard? = FlorisBoard.getInstanceOrNull()
+
+    private var arrowUpKey: EditingKeyView? = null
+    private var arrowDownKey: EditingKeyView? = null
+    private var selectKey: EditingKeyView? = null
+    private var selectAllKey: EditingKeyView? = null
+    private var cutKey: EditingKeyView? = null
+    private var copyKey: EditingKeyView? = null
+    private var pasteKey: EditingKeyView? = null
+
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+        florisboard?.addEventListener(this)
+    }
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        arrowUpKey = findViewById(R.id.arrow_up)
+        arrowDownKey = findViewById(R.id.arrow_down)
+        selectKey = findViewById(R.id.select)
+        selectAllKey = findViewById(R.id.select_all)
+        cutKey = findViewById(R.id.clipboard_cut)
+        copyKey = findViewById(R.id.clipboard_copy)
+        pasteKey = findViewById(R.id.clipboard_paste)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+
+        florisboard?.removeEventListener(this)
+    }
+
+    override fun onUpdateCursorAnchorInfo(cursorAnchorInfo: CursorAnchorInfo?) {
+        val isSelectionActive = florisboard?.textInputManager?.isTextSelected ?: false
+        val isSelectionMode = florisboard?.textInputManager?.isManualSelectionMode ?: false
+        arrowUpKey?.isEnabled = !(isSelectionActive || isSelectionMode)
+        arrowDownKey?.isEnabled = !(isSelectionActive || isSelectionMode)
+        selectKey?.isHighlighted = isSelectionActive || isSelectionMode
+        selectAllKey?.visibility = when {
+            isSelectionActive -> View.GONE
+            else -> View.VISIBLE
+        }
+        cutKey?.visibility = when {
+            isSelectionActive -> View.VISIBLE
+            else -> View.GONE
+        }
+        copyKey?.isEnabled = isSelectionActive
+        pasteKey?.isEnabled = florisboard?.clipboardManager?.hasPrimaryClip() ?: false
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
@@ -71,6 +71,10 @@ class MediaInputManager private constructor() : CoroutineScope by MainScope(),
         }
     }
 
+    init {
+        florisboard.addEventListener(this)
+    }
+
     /**
      * Called when a new input view has been registered. Used to initialize all media-relevant
      * views and layouts.
@@ -125,6 +129,7 @@ class MediaInputManager private constructor() : CoroutineScope by MainScope(),
         if (BuildConfig.DEBUG) Log.i(this::class.simpleName, "onDestroy()")
 
         cancel()
+        florisboard.removeEventListener(this)
         instance = null
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -32,6 +32,7 @@ import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.InputView
 import dev.patrickgold.florisboard.ime.core.Subtype
+import dev.patrickgold.florisboard.ime.editing.EditingKeyboardView
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyData
 import dev.patrickgold.florisboard.ime.text.key.KeyType
@@ -62,6 +63,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
 
     private var activeKeyboardMode: KeyboardMode? = null
     private val keyboardViews = EnumMap<KeyboardMode, KeyboardView>(KeyboardMode::class.java)
+    private var editingKeyboardView: EditingKeyboardView? = null
     private val osHandler = Handler()
     private var textViewFlipper: ViewFlipper? = null
     var textViewGroup: LinearLayout? = null
@@ -142,6 +144,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
         launch(Dispatchers.Default) {
             textViewGroup = inputView.findViewById(R.id.text_input)
             textViewFlipper = inputView.findViewById(R.id.text_input_view_flipper)
+            editingKeyboardView = inputView.findViewById(R.id.editing)
 
             val activeKeyboardMode = getActiveKeyboardMode()
             addKeyboardView(activeKeyboardMode)
@@ -248,9 +251,11 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
     /**
      * Sets [activeKeyboardMode] and updates the [SmartbarManager.isQuickActionsVisible].
      */
-    private fun setActiveKeyboardMode(mode: KeyboardMode) {
-        textViewFlipper?.displayedChild =
-            textViewFlipper?.indexOfChild(keyboardViews[mode]) ?: 0
+    fun setActiveKeyboardMode(mode: KeyboardMode) {
+        textViewFlipper?.displayedChild = textViewFlipper?.indexOfChild(when (mode) {
+            KeyboardMode.EDITING -> editingKeyboardView
+            else -> keyboardViews[mode]
+        }) ?: 0
         keyboardViews[mode]?.updateVisibility()
         keyboardViews[mode]?.requestLayout()
         keyboardViews[mode]?.requestLayoutAllKeys()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -231,7 +231,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
             KeyboardMode.NUMERIC,
             KeyboardMode.PHONE,
             KeyboardMode.PHONE2 -> false
-            else -> keyVariation != KeyVariation.PASSWORD
+            else -> keyVariation != KeyVariation.PASSWORD && florisboard.prefs.suggestion.enabled
         }
         updateCapsState()
         resetComposingText()
@@ -335,6 +335,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
             isManualSelectionModeRight = false
         }
         updateCapsState()
+        smartbarManager.onUpdateCursorAnchorInfo(cursorAnchorInfo)
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarManager.kt
@@ -62,6 +62,13 @@ class SmartbarManager private constructor() :
     private val quickActionOnClickListener = View.OnClickListener { v ->
         isQuickActionsVisible = false
         when (v.id) {
+            R.id.quick_action_switch_to_editing_context -> {
+                if (florisboard.textInputManager.getActiveKeyboardMode() == KeyboardMode.EDITING) {
+                    florisboard.textInputManager.setActiveKeyboardMode(KeyboardMode.CHARACTERS)
+                } else {
+                    florisboard.textInputManager.setActiveKeyboardMode(KeyboardMode.EDITING)
+                }
+            }
             R.id.quick_action_switch_to_media_context -> florisboard.setActiveInput(R.id.media_input)
             R.id.quick_action_open_settings -> florisboard.launchSettings()
             R.id.quick_action_one_handed_toggle -> florisboard.toggleOneHandedMode()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -19,9 +19,12 @@ package dev.patrickgold.florisboard.ime.text.smartbar
 import android.content.Context
 import android.util.AttributeSet
 import android.util.Log
+import android.view.View
+import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageButton
 import android.widget.LinearLayout
+import androidx.annotation.IdRes
 import dev.patrickgold.florisboard.BuildConfig
 import dev.patrickgold.florisboard.R
 
@@ -34,15 +37,10 @@ class SmartbarView : LinearLayout {
 
     private val smartbarManager = SmartbarManager.getInstance()
 
-    var candidatesView: LinearLayout? = null
-        private set
+    private var variants: MutableList<ViewGroup> = mutableListOf()
+    private var containers: MutableList<ViewGroup> = mutableListOf()
+
     var candidateViewList: MutableList<Button> = mutableListOf()
-        private set
-    var numberRowView: LinearLayout? = null
-        private set
-    var quickActionsView: LinearLayout? = null
-        private set
-    var quickActionToggle: ImageButton? = null
         private set
 
     constructor(context: Context) : this(context, null)
@@ -54,16 +52,52 @@ class SmartbarView : LinearLayout {
 
         super.onAttachedToWindow()
 
-        candidatesView = findViewById(R.id.candidates)
+        variants.add(findViewById(R.id.smartbar_variant_default))
+        variants.add(findViewById(R.id.smartbar_variant_back_only))
+
+        containers.add(findViewById(R.id.candidates))
+        containers.add(findViewById(R.id.clipboard_cursor_row))
+        containers.add(findViewById(R.id.number_row))
+        containers.add(findViewById(R.id.quick_actions))
+
         candidateViewList.add(findViewById(R.id.candidate0))
         candidateViewList.add(findViewById(R.id.candidate1))
         candidateViewList.add(findViewById(R.id.candidate2))
 
-        numberRowView = findViewById(R.id.number_row)
-        quickActionsView = findViewById(R.id.quick_actions)
-        quickActionToggle = findViewById(R.id.quick_action_toggle)
-
         smartbarManager.registerSmartbarView(this)
+    }
+
+    /**
+     * Sets the active Smartbar variant based on the given id. Pass null to hide all variants and
+     * show an empty Smartbar.
+     *
+     * @param which Which variant to show. Pass null to hide all.
+     */
+    fun setActiveVariant(@IdRes which: Int?) {
+        for (variant in variants) {
+            if (variant.id == which) {
+                variant.visibility = View.VISIBLE
+            } else {
+                variant.visibility = View.GONE
+            }
+        }
+    }
+
+    /**
+     * Sets the active Smartbar container based on the given id. Does only work if the currently
+     * shown Smartbar variant is [R.id.smartbar_variant_default]. Pass null to hide all containers
+     * and show only the quick action toggle.
+     *
+     * @param which Which container to show. Pass null to hide all.
+     */
+    fun setActiveContainer(@IdRes which: Int?) {
+        for (container in containers) {
+            if (container.id == which) {
+                container.visibility = View.VISIBLE
+            } else {
+                container.visibility = View.GONE
+            }
+        }
     }
 
     /**

--- a/app/src/main/res/drawable/button_key_enable_color_selector.xml
+++ b/app/src/main/res/drawable/button_key_enable_color_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="?android:colorButtonNormal"/>
+    <item android:color="?smartbar_button_fgColor"/>
+</selector>

--- a/app/src/main/res/drawable/button_transparent_bg_on_press_with_border.xml
+++ b/app/src/main/res/drawable/button_transparent_bg_on_press_with_border.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="?semiTransparentColor"/>
+            <stroke android:width="0.5dp" android:color="?semiTransparentColor"/>
+        </shape>
+    </item>
+    <item android:state_focused="true">
+        <shape>
+            <solid android:color="?semiTransparentColor"/>
+            <stroke android:width="0.5dp" android:color="?semiTransparentColor"/>
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="@android:color/transparent"/>
+            <stroke android:width="0.5dp" android:color="?semiTransparentColor"/>
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_content_copy.xml
+++ b/app/src/main/res/drawable/ic_content_copy.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_content_cut.xml
+++ b/app/src/main/res/drawable/ic_content_cut.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M9.64,7.64c0.23,-0.5 0.36,-1.05 0.36,-1.64 0,-2.21 -1.79,-4 -4,-4S2,3.79 2,6s1.79,4 4,4c0.59,0 1.14,-0.13 1.64,-0.36L10,12l-2.36,2.36C7.14,14.13 6.59,14 6,14c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4c0,-0.59 -0.13,-1.14 -0.36,-1.64L12,14l7,7h3v-1L9.64,7.64zM6,8c-1.1,0 -2,-0.89 -2,-2s0.9,-2 2,-2 2,0.89 2,2 -0.9,2 -2,2zM6,20c-1.1,0 -2,-0.89 -2,-2s0.9,-2 2,-2 2,0.89 2,2 -0.9,2 -2,2zM12,12.5c-0.28,0 -0.5,-0.22 -0.5,-0.5s0.22,-0.5 0.5,-0.5 0.5,0.22 0.5,0.5 -0.22,0.5 -0.5,0.5zM19,3l-6,6 2,2 7,-7L22,3z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_content_paste.xml
+++ b/app/src/main/res/drawable/ic_content_paste.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M19,2h-4.18C14.4,0.84 13.3,0 12,0c-1.3,0 -2.4,0.84 -2.82,2L5,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,4c0,-1.1 -0.9,-2 -2,-2zM12,2c0.55,0 1,0.45 1,1s-0.45,1 -1,1 -1,-0.45 -1,-1 0.45,-1 1,-1zM19,20L5,20L5,4h2v3h10L17,4h2v16z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_first_page.xml
+++ b/app/src/main/res/drawable/ic_first_page.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M18.41,16.59L13.82,12l4.59,-4.59L17,6l-6,6 6,6zM6,6h2v12H6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_format_italic.xml
+++ b/app/src/main/res/drawable/ic_format_italic.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M10,4v3h2.21l-3.42,8H6v3h8v-3h-2.21l3.42,-8H18V4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_last_page.xml
+++ b/app/src/main/res/drawable/ic_last_page.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M5.59,7.41L10.18,12l-4.59,4.59L7,18l6,-6 -6,-6zM16,6h2v12h-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_select_all.xml
+++ b/app/src/main/res/drawable/ic_select_all.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M3,5h2L5,3c-1.1,0 -2,0.9 -2,2zM3,13h2v-2L3,11v2zM7,21h2v-2L7,19v2zM3,9h2L5,7L3,7v2zM13,3h-2v2h2L13,3zM19,3v2h2c0,-1.1 -0.9,-2 -2,-2zM5,21v-2L3,19c0,1.1 0.9,2 2,2zM3,17h2v-2L3,15v2zM9,3L7,3v2h2L9,3zM11,21h2v-2h-2v2zM19,13h2v-2h-2v2zM19,21c1.1,0 2,-0.9 2,-2h-2v2zM19,9h2L21,7h-2v2zM19,17h2v-2h-2v2zM15,21h2v-2h-2v2zM15,5h2L17,3h-2v2zM7,17h10L17,7L7,7v10zM9,9h6v6L9,15L9,9z"/>
+</vector>

--- a/app/src/main/res/layout/editing_layout.xml
+++ b/app/src/main/res/layout/editing_layout.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dev.patrickgold.florisboard.ime.editing.EditingKeyboardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/editing"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/arrow_left"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.2"
+        app:layout_constraintHeight_percent="0.75"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/move_home"
+        android:src="@drawable/ic_keyboard_arrow_left"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/arrow_up"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.3"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toRightOf="@+id/arrow_left"
+        android:src="@drawable/ic_keyboard_arrow_up"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/select"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.3"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintTop_toBottomOf="@+id/arrow_up"
+        app:layout_constraintLeft_toRightOf="@+id/arrow_left"
+        android:text="@android:string/selectTextMode"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/arrow_down"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.3"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintTop_toBottomOf="@+id/select"
+        app:layout_constraintLeft_toRightOf="@+id/arrow_left"
+        android:src="@drawable/ic_keyboard_arrow_down"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/arrow_right"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.2"
+        app:layout_constraintHeight_percent="0.75"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/move_end"
+        app:layout_constraintLeft_toRightOf="@+id/select"
+        android:src="@drawable/ic_keyboard_arrow_right"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/move_home"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.35"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:src="@drawable/ic_first_page"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/move_end"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.35"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintLeft_toRightOf="@+id/move_home"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:src="@drawable/ic_last_page"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/select_all"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.3"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toRightOf="@+id/arrow_right"
+        app:layout_constraintRight_toRightOf="parent"
+        android:text="@android:string/selectAll"
+        android:visibility="gone"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/clipboard_cut"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.3"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toRightOf="@+id/arrow_right"
+        app:layout_constraintRight_toRightOf="parent"
+        android:text="@android:string/cut"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/clipboard_copy"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.3"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintTop_toBottomOf="@+id/clipboard_cut"
+        app:layout_constraintLeft_toRightOf="@+id/arrow_right"
+        app:layout_constraintRight_toRightOf="parent"
+        android:text="@android:string/copy"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/clipboard_paste"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.3"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintTop_toBottomOf="@+id/clipboard_copy"
+        app:layout_constraintLeft_toRightOf="@+id/arrow_right"
+        app:layout_constraintRight_toRightOf="parent"
+        android:text="@android:string/paste"/>
+
+    <dev.patrickgold.florisboard.ime.editing.EditingKeyView
+        android:id="@+id/backspace"
+        style="@style/TextEditingButton"
+        app:layout_constraintWidth_percent="0.3"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintTop_toBottomOf="@+id/clipboard_paste"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toRightOf="@+id/move_end"
+        app:layout_constraintRight_toRightOf="parent"
+        android:src="@drawable/ic_backspace"/>
+
+</dev.patrickgold.florisboard.ime.editing.EditingKeyboardView>

--- a/app/src/main/res/layout/editing_layout.xml
+++ b/app/src/main/res/layout/editing_layout.xml
@@ -87,17 +87,26 @@
         style="@style/TextEditingButton"
         app:layout_constraintWidth_percent="0.3"
         app:layout_constraintHeight_percent="0.25"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/select_all"
         app:layout_constraintLeft_toRightOf="@+id/arrow_right"
         app:layout_constraintRight_toRightOf="parent"
         android:text="@android:string/cut"/>
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="select_all,clipboard_cut"/>
 
     <dev.patrickgold.florisboard.ime.editing.EditingKeyView
         android:id="@+id/clipboard_copy"
         style="@style/TextEditingButton"
         app:layout_constraintWidth_percent="0.3"
         app:layout_constraintHeight_percent="0.25"
-        app:layout_constraintTop_toBottomOf="@+id/clipboard_cut"
+        app:layout_constraintTop_toBottomOf="@+id/barrier1"
+        app:layout_constraintBottom_toTopOf="@+id/clipboard_paste"
         app:layout_constraintLeft_toRightOf="@+id/arrow_right"
         app:layout_constraintRight_toRightOf="parent"
         android:text="@android:string/copy"/>
@@ -108,6 +117,7 @@
         app:layout_constraintWidth_percent="0.3"
         app:layout_constraintHeight_percent="0.25"
         app:layout_constraintTop_toBottomOf="@+id/clipboard_copy"
+        app:layout_constraintBottom_toTopOf="@+id/backspace"
         app:layout_constraintLeft_toRightOf="@+id/arrow_right"
         app:layout_constraintRight_toRightOf="parent"
         android:text="@android:string/paste"/>

--- a/app/src/main/res/layout/smartbar.xml
+++ b/app/src/main/res/layout/smartbar.xml
@@ -45,20 +45,27 @@
             android:id="@+id/quick_action_switch_to_media_context"
             style="@style/SmartbarQuickAction"
             android:contentDescription="@string/smartbar__quick_action__switch_to_media_context"
-            android:src="@drawable/ic_sentiment_satisfied" />
+            android:src="@drawable/ic_sentiment_satisfied"/>
 
         <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
             android:id="@+id/quick_action_open_settings"
             style="@style/SmartbarQuickAction"
             android:contentDescription="@string/smartbar__quick_action__open_settings"
-            android:src="@drawable/ic_settings" />
+            android:src="@drawable/ic_settings"/>
 
         <!-- TODO: find better icon for one-handed mode -->
         <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
             android:id="@+id/quick_action_one_handed_toggle"
             style="@style/SmartbarQuickAction"
             android:contentDescription="@string/smartbar__quick_action__one_handed_mode"
-            android:src="@drawable/ic_keyboard_arrow_right" />
+            android:src="@drawable/ic_keyboard_arrow_right"/>
+
+        <!-- TODO: find better icon for editing -->
+        <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+            android:id="@+id/quick_action_switch_to_editing_context"
+            style="@style/SmartbarQuickAction"
+            android:contentDescription="@string/smartbar__quick_action__switch_to_editing_context"
+            android:src="@drawable/ic_format_italic"/>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/smartbar.xml
+++ b/app/src/main/res/layout/smartbar.xml
@@ -7,133 +7,202 @@
     android:layout_height="@dimen/smartbar_height"
     android:background="?smartbar_bgColor">
 
-    <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
-        android:id="@+id/quick_action_toggle"
-        style="@style/SmartbarQuickAction.Toggle"
-        android:contentDescription="@string/smartbar__quick_action_toggle__alt"
-        android:src="@drawable/ic_keyboard_arrow_right" />
-
     <LinearLayout
-        android:id="@+id/candidates"
-        style="@style/SmartbarContainer"
-        android:visibility="gone">
-
-        <Button
-            android:id="@+id/candidate0"
-            style="@style/SmartbarCandidate" />
-
-        <View style="@style/SmartbarDivider" />
-
-        <Button
-            android:id="@+id/candidate1"
-            style="@style/SmartbarCandidate" />
-
-        <View style="@style/SmartbarDivider" />
-
-        <Button
-            android:id="@+id/candidate2"
-            style="@style/SmartbarCandidate" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/quick_actions"
-        style="@style/SmartbarContainer"
-        android:visibility="gone">
-
-        <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
-            android:id="@+id/quick_action_switch_to_media_context"
-            style="@style/SmartbarQuickAction"
-            android:contentDescription="@string/smartbar__quick_action__switch_to_media_context"
-            android:src="@drawable/ic_sentiment_satisfied"/>
-
-        <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
-            android:id="@+id/quick_action_open_settings"
-            style="@style/SmartbarQuickAction"
-            android:contentDescription="@string/smartbar__quick_action__open_settings"
-            android:src="@drawable/ic_settings"/>
-
-        <!-- TODO: find better icon for one-handed mode -->
-        <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
-            android:id="@+id/quick_action_one_handed_toggle"
-            style="@style/SmartbarQuickAction"
-            android:contentDescription="@string/smartbar__quick_action__one_handed_mode"
-            android:src="@drawable/ic_keyboard_arrow_right"/>
-
-        <!-- TODO: find better icon for editing -->
-        <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
-            android:id="@+id/quick_action_switch_to_editing_context"
-            style="@style/SmartbarQuickAction"
-            android:contentDescription="@string/smartbar__quick_action__switch_to_editing_context"
-            android:src="@drawable/ic_format_italic"/>
-
-    </LinearLayout>
-
-    <!-- TODO: integrate a KeyboardView instead of hardcoding these buttons -->
-    <LinearLayout
-        android:id="@+id/number_row"
-        style="@style/SmartbarContainer"
-        android:visibility="gone"
-        tools:ignore="HardcodedText">
-
-        <Button
-            android:id="@+id/number_row_1"
-            style="@style/SmartbarCandidate"
-            android:text="1" />
-
-        <Button
-            android:id="@+id/number_row_2"
-            style="@style/SmartbarCandidate"
-            android:text="2" />
-
-        <Button
-            android:id="@+id/number_row_3"
-            style="@style/SmartbarCandidate"
-            android:text="3" />
-
-        <Button
-            android:id="@+id/number_row_4"
-            style="@style/SmartbarCandidate"
-            android:text="4" />
-
-        <Button
-            android:id="@+id/number_row_5"
-            style="@style/SmartbarCandidate"
-            android:text="5" />
-
-        <Button
-            android:id="@+id/number_row_6"
-            style="@style/SmartbarCandidate"
-            android:text="6" />
-
-        <Button
-            android:id="@+id/number_row_7"
-            style="@style/SmartbarCandidate"
-            android:text="7" />
-
-        <Button
-            android:id="@+id/number_row_8"
-            style="@style/SmartbarCandidate"
-            android:text="8" />
-
-        <Button
-            android:id="@+id/number_row_9"
-            style="@style/SmartbarCandidate"
-            android:text="9" />
-
-        <Button
-            android:id="@+id/number_row_0"
-            style="@style/SmartbarCandidate"
-            android:text="0" />
-
-    </LinearLayout>
-
-    <!-- Placeholder on the right which reserves the space for a second button -->
-    <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
-        android:layout_width="wrap_content"
+        android:id="@+id/smartbar_variant_default"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_margin="@dimen/smartbar_button_margin"
-        android:clickable="false"
-        android:visibility="invisible" />
+        android:orientation="horizontal"
+        android:visibility="gone">
+
+        <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+            android:id="@+id/quick_action_toggle"
+            style="@style/SmartbarQuickAction.Toggle"
+            android:contentDescription="@string/smartbar__quick_action_toggle__alt"
+            android:src="@drawable/ic_keyboard_arrow_right" />
+
+        <LinearLayout
+            android:id="@+id/candidates"
+            style="@style/SmartbarContainer"
+            android:visibility="gone">
+
+            <Button
+                android:id="@+id/candidate0"
+                style="@style/SmartbarCandidate"/>
+
+            <View style="@style/SmartbarDivider"/>
+
+            <Button
+                android:id="@+id/candidate1"
+                style="@style/SmartbarCandidate"/>
+
+            <View style="@style/SmartbarDivider"/>
+
+            <Button
+                android:id="@+id/candidate2"
+                style="@style/SmartbarCandidate"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/quick_actions"
+            style="@style/SmartbarContainer"
+            android:visibility="gone">
+
+            <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+                android:id="@+id/quick_action_switch_to_media_context"
+                style="@style/SmartbarQuickAction"
+                android:contentDescription="@string/smartbar__quick_action__switch_to_media_context"
+                android:src="@drawable/ic_sentiment_satisfied"/>
+
+            <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+                android:id="@+id/quick_action_open_settings"
+                style="@style/SmartbarQuickAction"
+                android:contentDescription="@string/smartbar__quick_action__open_settings"
+                android:src="@drawable/ic_settings"/>
+
+            <!-- TODO: find better icon for one-handed mode -->
+            <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+                android:id="@+id/quick_action_one_handed_toggle"
+                style="@style/SmartbarQuickAction"
+                android:contentDescription="@string/smartbar__quick_action__one_handed_mode"
+                android:src="@drawable/ic_keyboard_arrow_right"/>
+
+            <!-- TODO: find better icon for editing -->
+            <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+                android:id="@+id/quick_action_switch_to_editing_context"
+                style="@style/SmartbarQuickAction"
+                android:contentDescription="@string/smartbar__quick_action__switch_to_editing_context"
+                android:src="@drawable/ic_format_italic"/>
+
+        </LinearLayout>
+
+        <!-- TODO: integrate a KeyboardView instead of hardcoding these buttons -->
+        <LinearLayout
+            android:id="@+id/number_row"
+            style="@style/SmartbarContainer"
+            android:visibility="gone"
+            tools:ignore="HardcodedText">
+
+            <Button
+                android:id="@+id/number_row_1"
+                style="@style/SmartbarCandidate"
+                android:text="1"/>
+
+            <Button
+                android:id="@+id/number_row_2"
+                style="@style/SmartbarCandidate"
+                android:text="2"/>
+
+            <Button
+                android:id="@+id/number_row_3"
+                style="@style/SmartbarCandidate"
+                android:text="3"/>
+
+            <Button
+                android:id="@+id/number_row_4"
+                style="@style/SmartbarCandidate"
+                android:text="4"/>
+
+            <Button
+                android:id="@+id/number_row_5"
+                style="@style/SmartbarCandidate"
+                android:text="5"/>
+
+            <Button
+                android:id="@+id/number_row_6"
+                style="@style/SmartbarCandidate"
+                android:text="6"/>
+
+            <Button
+                android:id="@+id/number_row_7"
+                style="@style/SmartbarCandidate"
+                android:text="7"/>
+
+            <Button
+                android:id="@+id/number_row_8"
+                style="@style/SmartbarCandidate"
+                android:text="8"/>
+
+            <Button
+                android:id="@+id/number_row_9"
+                style="@style/SmartbarCandidate"
+                android:text="9"/>
+
+            <Button
+                android:id="@+id/number_row_0"
+                style="@style/SmartbarCandidate"
+                android:text="0"/>
+
+        </LinearLayout>
+
+        <!-- TODO: integrate a KeyboardView instead of hardcoding these buttons -->
+        <LinearLayout
+            android:id="@+id/clipboard_cursor_row"
+            style="@style/SmartbarContainer"
+            android:visibility="gone"
+            tools:ignore="HardcodedText">
+
+            <ImageButton
+                android:id="@+id/cc_select_all"
+                style="@style/SmartbarCandidate"
+                android:src="@drawable/ic_select_all"
+                android:tint="@drawable/button_key_enable_color_selector"/>
+
+            <ImageButton
+                android:id="@+id/cc_copy"
+                style="@style/SmartbarCandidate"
+                android:src="@drawable/ic_content_copy"
+                android:tint="@drawable/button_key_enable_color_selector"/>
+
+            <ImageButton
+                android:id="@+id/cc_arrow_left"
+                style="@style/SmartbarCandidate"
+                android:src="@drawable/ic_keyboard_arrow_left"
+                android:tint="@drawable/button_key_enable_color_selector"/>
+
+            <ImageButton
+                android:id="@+id/cc_arrow_right"
+                style="@style/SmartbarCandidate"
+                android:src="@drawable/ic_keyboard_arrow_right"
+                android:tint="@drawable/button_key_enable_color_selector"/>
+
+            <ImageButton
+                android:id="@+id/cc_cut"
+                style="@style/SmartbarCandidate"
+                android:src="@drawable/ic_content_cut"
+                android:tint="@drawable/button_key_enable_color_selector"/>
+
+            <ImageButton
+                android:id="@+id/cc_paste"
+                style="@style/SmartbarCandidate"
+                android:src="@drawable/ic_content_paste"
+                android:tint="@drawable/button_key_enable_color_selector"/>
+
+        </LinearLayout>
+
+        <!-- Placeholder on the right which reserves the space for a second button -->
+        <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_margin="@dimen/smartbar_button_margin"
+            android:clickable="false"
+            android:visibility="invisible"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/smartbar_variant_back_only"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        android:visibility="gone">
+
+        <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+            android:id="@+id/back_button"
+            style="@style/SmartbarQuickAction"
+            android:contentDescription="@string/smartbar__quick_action__exit_editing"
+            android:src="@drawable/ic_arrow_back"/>
+
+    </LinearLayout>
 
 </dev.patrickgold.florisboard.ime.text.smartbar.SmartbarView>

--- a/app/src/main/res/layout/text_input_layout.xml
+++ b/app/src/main/res/layout/text_input_layout.xml
@@ -13,7 +13,7 @@
         android:id="@+id/text_input_view_flipper"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:measureAllChildren="false">
+        android:measureAllChildren="true">
 
         <LinearLayout
             android:id="@+id/keyboard_preview"
@@ -30,6 +30,8 @@
                 android:text="Loading keyboard, please wait..."/>
 
         </LinearLayout>
+
+        <include layout="@layout/editing_layout"/>
 
     </ViewFlipper>
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -41,6 +41,15 @@
         <item>dark</item>
     </string-array>
 
+    <string-array name="pref__suggestion__show_instead__entries">
+        <item>@string/pref__suggestion__show_instead__number_row</item>
+        <item>@string/pref__suggestion__show_instead__clipboard_cursor_tools</item>
+    </string-array>
+    <string-array name="pref__suggestion__show_instead__values">
+        <item>number_row</item>
+        <item>clipboard_cursor_tools</item>
+    </string-array>
+
     <string-array name="pref__theme__name__entries">
         <item>Floris Light</item>
         <item>Floris Dark</item>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -10,6 +10,10 @@
         <attr name="unit" format="string"/>
     </declare-styleable>
 
+    <declare-styleable name="EditingKeyView">
+        <attr name="android:text" format="string|reference"/>
+    </declare-styleable>
+
     <declare-styleable name="KeyboardTheme">
         <attr name="keyboardViewStyle" format="reference" />
         <attr name="keyboardRowViewStyle" format="reference" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="smartbar__quick_action_toggle__alt">Quick action toggle. If pressed, toggles between the word suggestions and the quick action buttons.</string>
     <string name="smartbar__quick_action__one_handed_mode">Toggle the state of the one-handed mode.</string>
     <string name="smartbar__quick_action__open_settings">Open settings.</string>
+    <string name="smartbar__quick_action__switch_to_editing_context">Switch to text editing panel.</string>
     <string name="smartbar__quick_action__switch_to_media_context">Switch to media input view.</string>
 
     <!-- Settings UI strings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
 
     <!-- Smartbar strings -->
     <string name="smartbar__quick_action_toggle__alt">Quick action toggle. If pressed, toggles between the word suggestions and the quick action buttons.</string>
+    <string name="smartbar__quick_action__exit_editing">Exit text editing panel.</string>
     <string name="smartbar__quick_action__one_handed_mode">Toggle the state of the one-handed mode.</string>
     <string name="smartbar__quick_action__open_settings">Open settings.</string>
     <string name="smartbar__quick_action__switch_to_editing_context">Switch to text editing panel.</string>
@@ -58,6 +59,9 @@
     <string name="pref__suggestion__title">Suggestions</string>
     <string name="pref__suggestion__enabled__label">Display suggestions while you type</string>
     <string name="pref__suggestion__enabled__summary">Will show on top of the keyboard</string>
+    <string name="pref__suggestion__show_instead__label">What to show instead of suggestions</string>
+    <string name="pref__suggestion__show_instead__number_row">Number row</string>
+    <string name="pref__suggestion__show_instead__clipboard_cursor_tools">Clipboard cursor tools</string>
     <string name="pref__suggestion__use_pref_words__label">[NYI] Next-word suggestions</string>
     <string name="pref__suggestion__use_pref_words__summary">Use previous words for generating suggestions</string>
     <string name="pref__correction__title">Corrections</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
 
     <style name="OneHandedPanel">
         <item name="android:layout_width">@dimen/one_handed_width</item>
@@ -63,6 +62,15 @@
     <style name="SmartbarQuickAction.Toggle">
         <item name="android:layout_weight">0</item>
         <item name="android:autoMirrored">true</item>
+    </style>
+
+    <style name="TextEditingButton" parent="Widget.AppCompat.Button.Borderless">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">0dp</item>
+        <item name="android:background">@drawable/button_transparent_bg_on_press_with_border</item>
+        <item name="android:soundEffectsEnabled">false</item>
+        <item name="android:hapticFeedbackEnabled">false</item>
+        <item name="android:scaleType">center</item>
     </style>
 
     <style name="SettingsCardView" parent="Widget.MaterialComponents.CardView">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -13,6 +13,7 @@
         <item name="android:navigationBarColor" tools:targetApi="o_mr1">?keyboard_bgColor</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
         <item name="android:colorControlNormal">#8A000000</item><!-- Black, semi transparent -->
+        <item name="android:colorButtonNormal">#4A000000</item><!-- Black, semi transparent -->
         <item name="android:textColor">#000000</item><!-- Black -->
         <item name="semiTransparentColor">#20000000</item><!-- Black, semi transparent -->
 
@@ -53,6 +54,7 @@
         <item name="android:navigationBarColor" tools:targetApi="o_mr1">?keyboard_bgColor</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
         <item name="android:colorControlNormal">#B3FFFFFF</item><!-- White, semi transparent -->
+        <item name="android:colorButtonNormal">#73FFFFFF</item><!-- White, semi transparent -->
         <item name="android:textColor">#FFFFFF</item><!-- White -->
         <item name="semiTransparentColor">#20FFFFFF</item><!-- White, semi transparent -->
 

--- a/app/src/main/res/xml/prefs_keyboard.xml
+++ b/app/src/main/res/xml/prefs_keyboard.xml
@@ -13,6 +13,15 @@
             app:title="@string/pref__suggestion__enabled__label"
             app:summary="@string/pref__suggestion__enabled__summary"/>
 
+        <ListPreference
+            android:defaultValue="number_row"
+            app:entries="@array/pref__suggestion__show_instead__entries"
+            app:entryValues="@array/pref__suggestion__show_instead__values"
+            app:key="suggestion__show_instead"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__suggestion__show_instead__label"
+            app:useSimpleSummaryProvider="true"/>
+
         <SwitchPreferenceCompat
             android:defaultValue="true"
             app:dependency="suggestion__enabled"


### PR DESCRIPTION
This PR adds a clipboard/cursor keyboard layout (accessible via Smartbar quick actions) and the ability to show a number row or clipboard cursor toolbar above the keyboard if candidate suggestions are disabled.

Editing keyboard layout:
![image](https://user-images.githubusercontent.com/19412843/90337723-a3b05000-dfe4-11ea-92a6-edcc33c4f81e.png)

Smartbar clipboard/cursor toolbar (#9):
![image](https://user-images.githubusercontent.com/19412843/90337709-8a0f0880-dfe4-11ea-98aa-c40288eb60d8.png)

Number row (#3):
![image](https://user-images.githubusercontent.com/19412843/90337693-6c41a380-dfe4-11ea-8755-2abb2daec0c9.png)
