### PR TITLE
Added an Arabic keyboard and mod, and changed persian ID to 801

### DIFF
--- a/app/src/main/assets/ime/config.json
+++ b/app/src/main/assets/ime/config.json
@@ -12,7 +12,8 @@
     "swiss_german": "Swiss German (QWERTZ)",
     "swiss_french": "Swiss French (QWERTZ)",
     "swiss_italian": "Swiss Italian (QWERTZ)",
-    "persian": "Persian"
+    "persian": "Persian",
+    "arabic": "Arabic"
   },
   "defaultSubtypes": [
     {
@@ -177,9 +178,16 @@
       "isEmojiCapable": true
     },
     {
-      "id": 800,
+      "id": 801,
       "languageTag": "fa-FA",
       "preferredLayout": "persian",
+      "isAsciiCapable": true,
+      "isEmojiCapable": true
+    },
+    {
+      "id": 901,
+      "languageTag": "ar",
+      "preferredLayout": "arabic",
       "isAsciiCapable": true,
       "isEmojiCapable": true
     }

--- a/app/src/main/assets/ime/text/characters/arabic.json
+++ b/app/src/main/assets/ime/text/characters/arabic.json
@@ -1,0 +1,46 @@
+{
+  "type": "characters",
+  "name": "arabic",
+  "direction": "rtl",
+  "modifier": "arabic",
+  "arrangement": [
+    [
+      { "code":  1590, "label": "ض" },
+      { "code":  1589, "label": "ص" },
+      { "code":  1579, "label": "ث" },
+      { "code":  1602, "label": "ق" },
+      { "code":  1601, "label": "ف" },
+      { "code":  1594, "label": "غ" },
+      { "code":  1593, "label": "ع" },
+      { "code":  1607, "label": "ه" },
+      { "code":  1582, "label": "خ" },
+      { "code":  1581, "label": "ح" },
+      { "code":  1580, "label": "ج" }
+    ],
+    [
+      { "code":  1588, "label": "ش" },
+      { "code":  1587, "label": "س" },
+      { "code":  1610, "label": "ي" },
+      { "code":  1576, "label": "ب" },
+      { "code":  1604, "label": "ل" },
+      { "code":  1575, "label": "ا" },
+      { "code":  1578, "label": "ت" },
+      { "code":  1606, "label": "ن" },
+      { "code":  1605, "label": "م" },
+      { "code":  1603, "label": "ك" },
+      { "code":  1591, "label": "ط" }
+    ],
+    [
+      { "code":  1584, "label": "ذ" },
+      { "code":  1569, "label": "ء" },
+      { "code":  65157, "label": "ﺅ" },
+      { "code":  1585, "label": "ر" },
+      { "code":  1609, "label": "ى" },
+      { "code":  1577, "label": "ة" },
+      { "code":  1608, "label": "و" },
+      { "code":  1586, "label": "ز" },
+      { "code":  1592, "label": "ظ" },
+      { "code":  1583, "label": "د" }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/characters/extended_popups/ar.json
+++ b/app/src/main/assets/ime/text/characters/extended_popups/ar.json
@@ -1,0 +1,97 @@
+{
+  "ض": [
+    { "code": 1633, "label": "١" }
+  ],
+  "ص": [
+    { "code": 1634, "label": "٢" }
+  ],
+  "ث": [
+    { "code": 1635, "label": "٣" }
+  ],
+  "ق": [
+    { "code": 1704, "label": "ڨ"},
+    { "code": 1636, "label": "٤" }
+  ],
+  "ف": [
+    { "code": 1701, "label": "ڥ" },
+    { "code": 1700, "label": "ڤ" },
+    { "code": 1698, "label": "ڢ" },
+    { "code": 1637, "label": "٥" }
+  ],
+  "غ": [
+    { "code": 1638, "label": "٦" }
+  ],
+  "ع": [
+    { "code": 1639, "label": "٧" }
+  ],
+  "ه": [
+    { "code": 1726, "label": "ھ" },
+    { "code": 1640, "label": "٨" }
+  ],
+  "خ": [
+    { "code": 1641, "label": "٩" }
+  ],
+  "ح": [
+    { "code": 1632, "label": "٠" }
+  ],
+  "ج": [
+    { "code": 1670, "label": "چ" }
+  ],
+  "ش": [
+    { "code": 1692, "label": "ڜ" }
+  ],
+  "ي": [
+    { "code": 1574, "label": "ئ" },
+    { "code": 1609, "label": "ى" }
+  ],
+  "ب": [
+    { "code": 1662, "label": "پ" }
+  ],
+  "ل": [
+    { "code": 65275, "label": "لا" },
+    { "code": 65273, "label": "لإ" },
+    { "code": 65271, "label": "لأ" },
+    { "code": 65269, "label": "لآ" }
+  ],
+  "ا": [
+    { "code": 1570, "label": "آ" },
+    { "code": 1569, "label": "ء" },
+    { "code": 1571, "label": "أ" },
+    { "code": 1573, "label": "إ" },
+    { "code": 1649, "label": "ٱ" }
+  ],
+  "ك": [
+    { "code": 1705, "label": "ک"},
+    { "code": 1711, "label": "گ" }
+  ],
+  "ى": [
+    { "code": 1574, "label": "ئ" }
+  ],
+  "ز": [
+    { "code": 1688, "label": "ژ" }
+  ],
+  ".~normal": [
+    { "code": 1611, "label": "ً" },
+    { "code": 1622, "label": "ٖ" },
+    { "code": 1648, "label": "ٰ" },
+    { "code": 1619, "label": "ٓ" },
+    { "code": 1615, "label": "ُ" },
+    { "code": 1616, "label": "ِ" },
+    { "code": 1614, "label": "َ" },
+    { "code": 1600, "label": "ـ" },
+    { "code": 1621, "label": "ٕ" },
+    { "code": 1620, "label": "ٔ" },
+    { "code": 1617, "label": "ّ" },
+    { "code": 1612, "label": "ٌ" },
+    { "code": 1613, "label": "ٍ" },
+    { "code": 1618, "label": "ْ" }
+  ],
+  ".~uri": [
+    { "code": -255, "label": ".ir"},
+    { "code": -255, "label": ".gov" },
+    { "code": -255, "label": ".edu" },
+    { "code": -255, "label": ".org" },
+    { "code": -255, "label": ".com" },
+    { "code": -255, "label": ".net" }
+  ]
+}

--- a/app/src/main/assets/ime/text/characters/mod/arabic.json
+++ b/app/src/main/assets/ime/text/characters/mod/arabic.json
@@ -1,0 +1,32 @@
+{
+  "type": "characters/mod",
+  "name": "arabic",
+  "direction": "rtl",
+  "arrangement": [
+    [
+      { "code":    0 },
+      { "code":   -5, "label": "delete", "type": "enter_editing" }
+    ],
+    [
+      { "code": -202, "label": "view_symbols", "type": "system_gui" },
+      { "code":   64, "label": "@", "variation": "email_address" },
+      { "code": 1548, "label": "،", "variation": "normal" },
+      { "code":   47, "label": "/", "variation": "uri" },
+      { "code": -210, "label": "language_switch", "type": "system_gui", "popup": [
+        { "code": -213, "label": "switch_to_media_context", "type": "system_gui" },
+        { "code": -100, "label": "settings", "type": "system_gui" }
+      ] },
+      { "code": -213, "label": "switch_to_media_context", "type": "system_gui", "popup": [
+        { "code": -100, "label": "settings", "type": "system_gui" }
+      ] },
+      { "code":   32, "label": " " },
+      { "code":   46, "label": ".", "variation": "email_address" },
+      { "code":   46, "label": ".", "variation": "normal" },
+      { "code":   46, "label": ".", "variation": "uri" },
+      { "code":   10, "label": "enter", "type": "enter_editing", "popup": [
+        { "code": -215, "label": "toggle_one_handed_mode", "type": "system_gui" },
+        { "code": -213, "label": "switch_to_media_context", "type": "system_gui" }
+      ] }
+    ]
+  ]
+}


### PR DESCRIPTION
I've added an Arabic keyboard based on AOSP Arabic layout by following PR #6 
There are two other things I wanted to add but didn't figure out how to or if it is allowed :

1. Arabic keyboards usually come with Arabic-Indic digits which I have added to the top row as a popup but I would've preferred if they were lower in priority than the default digits like AOSP keyboard, here's how it is right now in both Persian and Arabic keyboards:
![Screenshot_20201204-001818_TinyBit_launcher (1)](https://user-images.githubusercontent.com/12894695/101100209-63420580-35c6-11eb-8893-8fb44db7d25c.jpg)


2. I wanted to edit the digits and symbols layout to change the digits as well as some symbols to the Arabic ones just like here in the screenshot below taken from AOSP keyboard.
![Screenshot_20201204-000519_TinyBit_launcher (1)](https://user-images.githubusercontent.com/12894695/101099936-f464ac80-35c5-11eb-9cac-732d9c8dee78.jpg)


  
