### PR TITLE
Delete Key gesture Improvents

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -327,6 +327,15 @@ class KeyView(
                             shouldBlockNextKeyCode = true
                             true
                         }
+                        SwipeAction.DELETE_WORDS_PRECISELY -> {
+                            florisboard?.activeEditorInstance?.apply {
+                                leftAppendWordToSelection()
+                            }
+
+                            hasTriggeredGestureMove = true
+                            shouldBlockNextKeyCode = true
+                            true
+                        }
                         else -> false
                     }
                     SwipeGesture.Direction.RIGHT -> when (prefs.gestures.deleteKeySwipeLeft) {
@@ -336,6 +345,14 @@ class KeyView(
                                     if (selection.start < selection.end) { selection.start + 1 } else { selection.start },
                                     selection.end
                                 )
+                            }
+                            shouldBlockNextKeyCode = true
+                            true
+                        }
+
+                        SwipeAction.DELETE_WORDS_PRECISELY -> {
+                            florisboard?.activeEditorInstance?.apply {
+                                leftPopWordFromSelection()
                             }
                             shouldBlockNextKeyCode = true
                             true

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -71,13 +71,13 @@
         <item>@string/pref__gestures__swipe_action__no_action</item>
         <item>@string/pref__gestures__swipe_action__delete_characters_precisely</item>
         <item>@string/pref__gestures__swipe_action__delete_word</item>
-        <!--<item>@string/pref__gestures__swipe_action__delete_words_precisely</item>-->
+        <item>@string/pref__gestures__swipe_action__delete_words_precisely</item>
     </string-array>
     <string-array name="pref__gestures__swipe_action_delete__values">
         <item>no_action</item>
         <item>delete_characters_precisely</item>
         <item>delete_word</item>
-        <!--<item>delete_words_precisely</item>-->
+        <item>delete_words_precisely</item>
     </string-array>
 
     <string-array name="pref__gestures__swipe_velocity_threshold__entries">


### PR DESCRIPTION
## Fixes Bug in "Delete current Word" where it stops working after deleting one word. If this was the intended behaviour, I think it feels better if it keeps deleting.

### Before

https://user-images.githubusercontent.com/20506602/103137817-7f7f2100-46f2-11eb-9703-caa2eeef7a66.mp4

### Now

https://user-images.githubusercontent.com/20506602/103137820-86a62f00-46f2-11eb-961f-64920cd0a1d4.mp4

## Adds "Delete words precisely"

https://user-images.githubusercontent.com/20506602/103137824-8c037980-46f2-11eb-89d8-7cd450c6122f.mp4

closes #25