### PR TITLE
Fix left and right arrow in clipboard cursor row

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -233,15 +233,21 @@ class KeyView(
                 isKeyPressed = true
                 florisboard?.keyPressVibrate()
                 florisboard?.keyPressSound(data)
-                if (data.code == KeyCode.DELETE && data.type == KeyType.ENTER_EDITING) {
-                    osTimer = Timer()
-                    osTimer?.scheduleAtFixedRate(500, 50) {
-                        mainScope.launch(Dispatchers.Main) {
-                            florisboard?.textInputManager?.sendKeyPress(data)
-                        }
-                        if (!isKeyPressed) {
-                            osTimer?.cancel()
-                            osTimer = null
+                when (data.code) {
+                    KeyCode.ARROW_DOWN,
+                    KeyCode.ARROW_LEFT,
+                    KeyCode.ARROW_RIGHT,
+                    KeyCode.ARROW_UP,
+                    KeyCode.DELETE -> {
+                        osTimer = Timer()
+                        osTimer?.scheduleAtFixedRate(500, 50) {
+                            mainScope.launch(Dispatchers.Main) {
+                                florisboard?.textInputManager?.sendKeyPress(data)
+                            }
+                            if (!isKeyPressed) {
+                                osTimer?.cancel()
+                                osTimer = null
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Left and Right arrows in clipboard cursor row work only once if they are pressed and held. I think they work like the delete key.

## Before

https://user-images.githubusercontent.com/20506602/103139783-c6c2dd00-4705-11eb-8db4-4cf5dc87c851.mp4

## Now

https://user-images.githubusercontent.com/20506602/103139786-d2ae9f00-4705-11eb-92b6-462e8a41cad7.mp4


