### PR TITLE
Added Undo Redo Buttons to Quick Actions in Smart Bar

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -450,19 +450,21 @@ class EditorInstance private constructor(private val ims: InputMethodService?) {
      * @return True on success, false if an error occurred or the input connection is invalid.
      */
     fun performClipboardPaste(): Boolean {
-        val clipData: ClipData? = clipboardManager?.primaryClip
-        val item: ClipData.Item? = clipData?.getItemAt(0)
-        return when {
-            item?.text != null -> {
-                commitText(item.text.toString())
-            }
-            item?.uri != null -> {
-                commitContent(item.uri, clipData.description)
-            }
-            else -> {
-                false
-            }
-        }
+//        val clipData: ClipData? = clipboardManager?.primaryClip
+//        val item: ClipData.Item? = clipData?.getItemAt(0)
+//        return when {
+//            item?.text != null -> {
+//                commitText(item.text.toString())
+//            }
+//            item?.uri != null -> {
+//                commitContent(item.uri, clipData.description)
+//            }
+//            else -> {
+//                false
+//            }
+//        }
+        sendSystemKeyEventCtrl(KeyEvent.KEYCODE_V)
+        return true
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -23,10 +23,13 @@ import android.content.Context
 import android.inputmethodservice.InputMethodService
 import android.net.Uri
 import android.os.Build
+import android.os.SystemClock
 import android.text.InputType
+import android.view.KeyCharacterMap
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.ExtractedTextRequest
+import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
 import androidx.annotation.RequiresApi
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
@@ -294,7 +297,7 @@ class EditorInstance private constructor(private val ims: InputMethodService?) {
             markComposingRegion(null)
 
             getWordsInString(cachedText.substring(0, selection.start)).run {
-                get(size-n.coerceAtLeast(0)).range
+                get(size - n.coerceAtLeast(0)).range
             }.run {
                 ic.setSelection(first, selection.start)
             }
@@ -320,6 +323,54 @@ class EditorInstance private constructor(private val ims: InputMethodService?) {
         return wordRegexPattern.findAll(
             string
         ).toList()
+    }
+
+    /**
+     * Undoes the last action
+     *
+     * @return True on success, false if an error occurred or the input connection is invalid.
+     */
+    fun performUndo(): Boolean{
+        val ic = ims?.currentInputConnection ?: return false
+        return if (isRawInputEditor) {
+            sendSystemKeyEventCtrl(KeyEvent.KEYCODE_Z)
+            true
+        } else {
+            ic.beginBatchEdit()
+            markComposingRegion(null)
+            sendSystemKeyEventCtrl(KeyEvent.KEYCODE_Z)
+            updateEditorState()
+            reevaluateCurrentWord()
+            if (isComposingEnabled) {
+                markComposingRegion(currentWord)
+            }
+            ic.endBatchEdit()
+            true
+        }
+    }
+
+    /**
+     * Redoes the last Undo action
+     *
+     * @return True on success, false if an error occurred or the input connection is invalid.
+     */
+    fun performRedo(): Boolean{
+        val ic = ims?.currentInputConnection ?: return false
+        return if (isRawInputEditor) {
+            sendSystemKeyEventCtrlShift(KeyEvent.KEYCODE_Z)
+            true
+        } else {
+            ic.beginBatchEdit()
+            markComposingRegion(null)
+            sendSystemKeyEventCtrlShift(KeyEvent.KEYCODE_Z)
+            updateEditorState()
+            reevaluateCurrentWord()
+            if (isComposingEnabled) {
+                markComposingRegion(currentWord)
+            }
+            ic.endBatchEdit()
+            true
+        }
     }
 
     /**
@@ -469,6 +520,66 @@ class EditorInstance private constructor(private val ims: InputMethodService?) {
                 KeyEvent.ACTION_DOWN, keyCode,
                 0,
                 KeyEvent.META_ALT_LEFT_ON
+            )
+        )
+    }
+
+    /**
+     * Sends a given [keyCode] with Ctrl pressed with [sendDownUpKeyEvents]
+     *
+     * @param keyCode The key code to send, use a key code defined in Android's [KeyEvent], not in
+     *  [KeyCode] or this call may send a weird character, as this key codes do not match!!
+     */
+    fun sendSystemKeyEventCtrl(keyCode: Int) {
+        val ic = ims?.currentInputConnection ?: return
+        sendDownUpKeyEvents(keyCode, KeyEvent.META_CTRL_ON)
+    }
+
+
+    /**
+     * Sends a given [keyCode] with Ctrl and Shift pressed with [sendDownUpKeyEvents]
+     *
+     * @param keyCode The key code to send, use a key code defined in Android's [KeyEvent], not in
+     *  [KeyCode] or this call may send a weird character, as this key codes do not match!!
+     */
+    fun sendSystemKeyEventCtrlShift(keyCode: Int) {
+        val ic = ims?.currentInputConnection ?: return
+        sendDownUpKeyEvents(keyCode, KeyEvent.META_SHIFT_ON or KeyEvent.META_CTRL_ON)
+    }
+
+    /**
+     * Same as [InputMethodService.sendDownUpKeyEvents] but also allows to set metaStae
+     *
+     * @param keyEventCode The key code to send, use a key code defined in Android's [KeyEvent]
+     * @param metaState Flags indicating which meta keys are currently pressed.
+     */
+    fun sendDownUpKeyEvents(keyEventCode: Int, metaState: Int) {
+        val ic = ims?.currentInputConnection ?: return
+        val eventTime = SystemClock.uptimeMillis()
+        ic.sendKeyEvent(
+            KeyEvent(
+                eventTime,
+                eventTime,
+                KeyEvent.ACTION_DOWN,
+                keyEventCode,
+                0,
+                metaState,
+                KeyCharacterMap.VIRTUAL_KEYBOARD,
+                0,
+                KeyEvent.FLAG_SOFT_KEYBOARD or KeyEvent.FLAG_KEEP_TOUCH_MODE
+            )
+        )
+        ic.sendKeyEvent(
+            KeyEvent(
+                eventTime,
+                SystemClock.uptimeMillis(),
+                KeyEvent.ACTION_UP,
+                keyEventCode,
+                0,
+                metaState,
+                KeyCharacterMap.VIRTUAL_KEYBOARD,
+                0,
+                KeyEvent.FLAG_SOFT_KEYBOARD or KeyEvent.FLAG_KEEP_TOUCH_MODE
             )
         )
     }
@@ -733,7 +844,7 @@ class ImeOptions private constructor(imeOptions: Int) {
                 PREVIOUS -> EditorInfo.IME_ACTION_PREVIOUS
                 SEARCH -> EditorInfo.IME_ACTION_SEARCH
                 SEND -> EditorInfo.IME_ACTION_SEND
-                UNSPECIFIED-> EditorInfo.IME_ACTION_UNSPECIFIED
+                UNSPECIFIED -> EditorInfo.IME_ACTION_UNSPECIFIED
             }
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -335,9 +335,25 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
             R.id.quick_action_switch_to_media_context -> florisboard.setActiveInput(R.id.media_input)
             R.id.quick_action_open_settings -> florisboard.launchSettings()
             R.id.quick_action_one_handed_toggle -> florisboard.toggleOneHandedMode()
+            R.id.quick_action_undo -> {
+                handleUndo()
+                return
+            }
+            R.id.quick_action_redo -> {
+                handleRedo()
+                return
+            }
         }
         smartbarView?.isQuickActionsVisible = false
         smartbarView?.updateSmartbarState()
+    }
+
+    private fun handleUndo(){
+        activeEditorInstance.performUndo()
+    }
+
+    private fun handleRedo(){
+        activeEditorInstance.performRedo()
     }
 
     /**

--- a/app/src/main/res/drawable/ic_redo.xml
+++ b/app/src/main/res/drawable/ic_redo.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M18.4,10.6C16.55,8.99 14.15,8 11.5,8c-4.65,0 -8.58,3.03 -9.96,7.22L3.9,16c1.05,-3.19 4.05,-5.5 7.6,-5.5 1.95,0 3.73,0.72 5.12,1.88L13,16h9V7l-3.6,3.6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_undo.xml
+++ b/app/src/main/res/drawable/ic_undo.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12.5,8c-2.65,0 -5.05,0.99 -6.9,2.6L2,7v9h9l-3.62,-3.62c1.39,-1.16 3.16,-1.88 5.12,-1.88 3.54,0 6.55,2.31 7.6,5.5l2.37,-0.78C21.08,11.03 17.15,8 12.5,8z"/>
+</vector>

--- a/app/src/main/res/layout/smartbar.xml
+++ b/app/src/main/res/layout/smartbar.xml
@@ -80,6 +80,18 @@
             style="@style/SmartbarContainer">
 
             <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+                android:id="@+id/quick_action_undo"
+                style="@style/SmartbarQuickAction"
+                android:contentDescription="@string/smartbar__quick_action__undo"
+                android:src="@drawable/ic_undo"/>
+
+            <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
+                android:id="@+id/quick_action_redo"
+                style="@style/SmartbarQuickAction"
+                android:contentDescription="@string/smartbar__quick_action__redo"
+                android:src="@drawable/ic_redo"/>
+
+            <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
                 android:id="@+id/quick_action_switch_to_media_context"
                 style="@style/SmartbarQuickAction"
                 android:contentDescription="@string/smartbar__quick_action__switch_to_media_context"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="smartbar__quick_action__open_settings" comment="Content-description for the settings quick action in Smartbar">Open settings.</string>
     <string name="smartbar__quick_action__switch_to_editing_context" comment="Content-description for the editing quick action in Smartbar">Switch to text editing panel.</string>
     <string name="smartbar__quick_action__switch_to_media_context" comment="Content-description for the media quick action in Smartbar">Switch to media input view.</string>
+    <string name="smartbar__quick_action__undo" comment="Content-description for the undo quick action in Smartbar">Undo button to reverse the last action</string>
+    <string name="smartbar__quick_action__redo" comment="Content-description for the redo quick action in Smartbar">Redo button to reverse the last Undo</string>
 
     <!-- Settings UI strings -->
     <string name="settings__title" comment="Title of Settings">Settings</string>


### PR DESCRIPTION
On Whatsapp, telegram and chrome, It works without any issues.
On Keep notes, it works but Quick Action Bar automatically closes after single-use (This shouldn't happen and I can't figure out why it does so) 

## Demo

https://user-images.githubusercontent.com/20506602/103149604-e4895400-4790-11eb-84c6-53d69df6ad30.mp4

closes #70 