### PR TITLE
Add private mode (aka incognito mode) base

### DIFF
--- a/app/src/main/assets/ime/theme/floris_day.json
+++ b/app/src/main/assets/ime/theme/floris_day.json
@@ -47,6 +47,10 @@
     "oneHandedButton": {
       "fgColor": "#424242"
     },
+    "privateMode": {
+      "bgColor": "#A000FF",
+      "fgColor": "#FFFFFF"
+    },
     "smartbar": {
       "bgColor": "transparent",
       "fgColor": "@window/textColor",

--- a/app/src/main/assets/ime/theme/floris_night.json
+++ b/app/src/main/assets/ime/theme/floris_night.json
@@ -47,6 +47,10 @@
     "oneHandedButton": {
       "fgColor": "#EEEEEE"
     },
+    "privateMode": {
+      "bgColor": "#A000FF",
+      "fgColor": "#FFFFFF"
+    },
     "smartbar": {
       "bgColor": "transparent",
       "fgColor": "@window/textColor",

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -92,6 +92,7 @@ class EditorInstance private constructor(private val ims: InputMethodService?) {
         }
     var isNewSelectionInBoundsOfOld: Boolean = false
         private set
+    var isPrivateMode: Boolean = false
     var isRawInputEditor: Boolean = true
         private set
     var packageName: String = "undefined"

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -451,6 +451,8 @@ class PrefHelper(
             const val MEDIA_FG_COLOR_ALT =                  "theme__media_fgColorAlt"
             const val ONE_HANDED_BG_COLOR =                 "theme__oneHanded_bgColor"
             const val ONE_HANDED_BUTTON_FG_COLOR =          "theme__oneHandedButton_fgColor"
+            const val PRIVATE_MODE_BG_COLOR =               "theme__privateMode_bgColor"
+            const val PRIVATE_MODE_FG_COLOR =               "theme__privateMode_fgColor"
             const val SMARTBAR_BG_COLOR =                   "theme__smartbar_bgColor"
             const val SMARTBAR_FG_COLOR =                   "theme__smartbar_fgColor"
             const val SMARTBAR_FG_COLOR_ALT =               "theme__smartbar_fgColorAlt"
@@ -527,6 +529,12 @@ class PrefHelper(
         var oneHandedButtonFgColor: Int
             get() =  prefHelper.getPref(ONE_HANDED_BUTTON_FG_COLOR, 0)
             set(v) = prefHelper.setPref(ONE_HANDED_BUTTON_FG_COLOR, v)
+        var privateModeBgColor: Int
+            get() =  prefHelper.getPref(PRIVATE_MODE_BG_COLOR, 0)
+            set(v) = prefHelper.setPref(PRIVATE_MODE_BG_COLOR, v)
+        var privateModeFgColor: Int
+            get() =  prefHelper.getPref(PRIVATE_MODE_FG_COLOR, 0)
+            set(v) = prefHelper.setPref(PRIVATE_MODE_FG_COLOR, v)
         var smartbarBgColor: Int
             get() =  prefHelper.getPref(SMARTBAR_BG_COLOR, 0)
             set(v) = prefHelper.setPref(SMARTBAR_BG_COLOR, v)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -166,6 +166,7 @@ class PrefHelper(
         companion object {
             const val SETTINGS_THEME =          "advanced__settings_theme"
             const val SHOW_APP_ICON =           "advanced__show_app_icon"
+            const val FORCE_PRIVATE_MODE =      "advanced__force_private_mode"
         }
 
         var settingsTheme: String = ""
@@ -174,6 +175,9 @@ class PrefHelper(
         var showAppIcon: Boolean = false
             get() = prefHelper.getPref(SHOW_APP_ICON, true)
             private set
+        var forcePrivateMode: Boolean
+            get() =  prefHelper.getPref(FORCE_PRIVATE_MODE, false)
+            set(v) = prefHelper.setPref(FORCE_PRIVATE_MODE, v)
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -22,6 +22,7 @@ import android.util.Log
 import android.view.KeyEvent
 import android.view.inputmethod.*
 import android.widget.LinearLayout
+import android.widget.Toast
 import android.widget.ViewFlipper
 import dev.patrickgold.florisboard.BuildConfig
 import dev.patrickgold.florisboard.R
@@ -206,14 +207,18 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
                 KeyboardMode.CHARACTERS
             }
         }
-        instance.isComposingEnabled = when (keyboardMode) {
-            KeyboardMode.NUMERIC,
-            KeyboardMode.PHONE,
-            KeyboardMode.PHONE2 -> false
-            else -> keyVariation != KeyVariation.PASSWORD &&
-                    florisboard.prefs.suggestion.enabled// &&
-                    //!instance.inputAttributes.flagTextAutoComplete &&
-                    //!instance.inputAttributes.flagTextNoSuggestions
+        instance.apply {
+            isComposingEnabled = when (keyboardMode) {
+                KeyboardMode.NUMERIC,
+                KeyboardMode.PHONE,
+                KeyboardMode.PHONE2 -> false
+                else -> keyVariation != KeyVariation.PASSWORD &&
+                        florisboard.prefs.suggestion.enabled// &&
+                //!instance.inputAttributes.flagTextAutoComplete &&
+                //!instance.inputAttributes.flagTextNoSuggestions
+            }
+            isPrivateMode = florisboard.prefs.advanced.forcePrivateMode ||
+                    imeOptions.flagNoPersonalizedLearning
         }
         if (!florisboard.prefs.correction.rememberCapsLockState) {
             capsLock = false
@@ -321,6 +326,10 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
 
     override fun onSmartbarBackButtonPressed() {
         setActiveKeyboardMode(KeyboardMode.CHARACTERS)
+    }
+
+    override fun onSmartbarPrivateModeButtonClicked() {
+        Toast.makeText(florisboard.context, R.string.private_mode_dialog__title, Toast.LENGTH_LONG).show()
     }
 
     override fun onSmartbarQuickActionPressed(quickActionId: Int) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarQuickActionButton.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarQuickActionButton.kt
@@ -53,7 +53,10 @@ class SmartbarQuickActionButton : androidx.appcompat.widget.AppCompatImageButton
     }
 
     private fun updateTheme() {
-        if (id != R.id.private_mode_button) {
+        if (id == R.id.private_mode_button) {
+            setBackgroundTintColor2(this, prefs.theme.privateModeBgColor)
+            setColorFilter(prefs.theme.privateModeFgColor)
+        } else {
             setBackgroundTintColor2(this, prefs.theme.smartbarButtonBgColor)
             setColorFilter(prefs.theme.smartbarButtonFgColor)
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarQuickActionButton.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarQuickActionButton.kt
@@ -19,6 +19,7 @@ package dev.patrickgold.florisboard.ime.text.smartbar
 import android.content.Context
 import android.graphics.Canvas
 import android.util.AttributeSet
+import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.util.setBackgroundTintColor2
 
@@ -52,7 +53,9 @@ class SmartbarQuickActionButton : androidx.appcompat.widget.AppCompatImageButton
     }
 
     private fun updateTheme() {
-        setBackgroundTintColor2(this, prefs.theme.smartbarButtonBgColor)
-        setColorFilter(prefs.theme.smartbarButtonFgColor)
+        if (id != R.id.private_mode_button) {
+            setBackgroundTintColor2(this, prefs.theme.smartbarButtonBgColor)
+            setColorFilter(prefs.theme.smartbarButtonFgColor)
+        }
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -141,6 +141,10 @@ class SmartbarView : ConstraintLayout {
             }
         }
 
+        binding.privateModeButton.setOnClickListener {
+            eventListener?.get()?.onSmartbarPrivateModeButtonClicked()
+        }
+
         for (quickAction in binding.quickActions.children) {
             if (quickAction is SmartbarQuickActionButton) {
                 quickAction.setOnClickListener { eventListener?.get()?.onSmartbarQuickActionPressed(quickAction.id) }
@@ -258,15 +262,19 @@ class SmartbarView : ConstraintLayout {
                     KeyVariation.PASSWORD -> false
                     else -> true
                 },
-                actionEndAreaId = null
+                actionEndAreaId = when {
+                    florisboard.activeEditorInstance.isPrivateMode -> R.id.private_mode_button
+                    else -> null
+                }
             )
         }
     }
 
     fun onPrimaryClipChanged() {
-        if (prefs.suggestion.enabled && prefs.suggestion.suggestClipboardContent) {
+        if (prefs.suggestion.enabled && prefs.suggestion.suggestClipboardContent &&
+            florisboard?.activeEditorInstance?.isPrivateMode == false) {
             shouldSuggestClipboardContents = true
-            val item = florisboard?.clipboardManager?.primaryClip?.getItemAt(0)
+            val item = florisboard.clipboardManager?.primaryClip?.getItemAt(0)
             when {
                 item?.text != null -> {
                     binding.clipboardSuggestion.text = item.text
@@ -283,10 +291,8 @@ class SmartbarView : ConstraintLayout {
     }
 
     fun resetClipboardSuggestion() {
-        if (prefs.suggestion.enabled && prefs.suggestion.suggestClipboardContent) {
-            shouldSuggestClipboardContents = false
-            updateSmartbarState()
-        }
+        shouldSuggestClipboardContents = false
+        updateSmartbarState()
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -333,6 +339,7 @@ class SmartbarView : ConstraintLayout {
         fun onSmartbarBackButtonPressed() {}
         //fun onSmartbarCandidatePressed() {}
         //fun onSmartbarCandidateLongPressed() {}
+        fun onSmartbarPrivateModeButtonClicked() {}
         fun onSmartbarQuickActionPressed(@IdRes quickActionId: Int) {}
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/Theme.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/Theme.kt
@@ -162,6 +162,9 @@ data class Theme(
 
             prefs.theme.oneHandedButtonFgColor = theme.getAttr("oneHandedButton/fgColor", "#424242")
 
+            prefs.theme.privateModeBgColor = theme.getAttr("privateMode/bgColor", "#A000FF")
+            prefs.theme.privateModeFgColor = theme.getAttr("privateMode/fgColor", "#FFFFFF")
+
             prefs.theme.smartbarBgColor = theme.getAttr("smartbar/bgColor", "#E0E0E0")
             prefs.theme.smartbarFgColor = theme.getAttr("smartbar/fgColor", "#000000")
             prefs.theme.smartbarFgColorAlt = theme.getAttr("smartbar/fgColorAlt", "#4A000000")

--- a/app/src/main/res/drawable/ic_security.xml
+++ b/app/src/main/res/drawable/ic_security.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12L21,5l-9,-4zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94L12,12L5,12L5,6.3l7,-3.11v8.8z"/>
+</vector>

--- a/app/src/main/res/layout/smartbar.xml
+++ b/app/src/main/res/layout/smartbar.xml
@@ -140,14 +140,11 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <!-- Placeholder on the right which reserves the space for a second button -->
         <dev.patrickgold.florisboard.ime.text.smartbar.SmartbarQuickActionButton
-            android:id="@+id/placeholder"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_margin="@dimen/smartbar_button_margin"
-            android:clickable="false"
-            android:visibility="invisible"/>
+            android:id="@+id/private_mode_button"
+            style="@style/SmartbarQuickAction.PrivateModeButton"
+            android:contentDescription="@string/smartbar__quick_action__private_mode"
+            android:src="@drawable/ic_security"/>
 
     </dev.patrickgold.florisboard.ime.core.FlorisViewFlipper>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,12 @@
     <string name="one_handed__move_start_btn_content_description" comment="Content description for the one-handed move to left button">Move keyboard to the left.</string>
     <string name="one_handed__move_end_btn_content_description" comment="Content description for the one-handed move to right button">Move keyboard to the right.</string>
 
+    <!-- Private mode info dialog strings -->
+    <string name="private_mode_dialog__title" comment="Title of the private mode dialog">Private mode</string>
+<!--
+    <string name="private_mode_dialog__text" comment="Text of the private mode dialog">The icon you just clicked at indicates that FlorisBoard works in the private mode. This means that all features which require to process and temporarily save your input stop working. This applies at minimum to the following features (if they\'ve been turned on previously):\n\n - Next word algorithm adjustments\n\n - Clipboard paste suggestions\n\n - Clipboard history\n\nFlorisBoard enters this mode either if an app requests it or if it was specifically enabled in the advanced settings.</string>
+-->
+
     <!-- Media strings -->
     <string name="media__tab__emojis" comment="Tab description for emojis in the media UI">Emojis</string>
     <string name="media__tab__emoticons" comment="Tab description for emoticons in the media UI">Emoticons</string>
@@ -33,6 +39,7 @@
     <string name="smartbar__quick_action__switch_to_media_context" comment="Content-description for the media quick action in Smartbar">Switch to media input view.</string>
     <string name="smartbar__quick_action__undo" comment="Content-description for the undo quick action in Smartbar">Undo button to reverse the last action</string>
     <string name="smartbar__quick_action__redo" comment="Content-description for the redo quick action in Smartbar">Redo button to reverse the last Undo</string>
+    <string name="smartbar__quick_action__private_mode" comment="Content-description for the private mode button in Smartbar">If visible, indicates that private mode is active. When clicked, shows info about the private mode.</string>
 
     <!-- Settings UI strings -->
     <string name="settings__title" comment="Title of Settings">Settings</string>
@@ -198,6 +205,8 @@
     <string name="pref__advanced__settings_theme__light" comment="Possible value of Settings theme preference in Advanced">Light</string>
     <string name="pref__advanced__settings_theme__dark" comment="Possible value of Settings theme preference in Advanced">Dark</string>
     <string name="pref__advanced__show_app_icon__label" comment="Label of Show app icon preference in Advanced">Show app icon in launcher</string>
+    <string name="pref__advanced__force_private_mode__label" comment="Label of Force private mode preference in Advanced">Force private mode</string>
+    <string name="pref__advanced__force_private_mode__summary" comment="Summary of Force private mode preference in Advanced">Will disable any features which have to temporarily work with your input data</string>
 
     <!-- About UI strings -->
     <string name="about__title" comment="Title of About activity">About</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="settings__theme__group_media" comment="Theme group label">Media context</string>
     <string name="settings__theme__group_one_handed" comment="Theme group label">One-handed</string>
     <string name="settings__theme__group_one_handed_button" comment="Theme group label">One-handed button</string>
+    <string name="settings__theme__group_private_mode" comment="Theme group label">Private mode</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Smartbar</string>
     <string name="settings__theme__group_smartbar_button" comment="Theme group label">Smartbar button</string>
     <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Primary color</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -72,6 +72,12 @@
         <item name="android:autoMirrored">true</item>
     </style>
 
+    <style name="SmartbarQuickAction.PrivateModeButton">
+        <item name="android:background">@drawable/shape_rect_rounded</item>
+        <item name="android:backgroundTint">#a000ff</item>
+        <item name="android:tint">#ffffff</item>
+    </style>
+
     <style name="TextEditingButton" parent="Widget.AppCompat.Button.Borderless">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">0dp</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -74,8 +74,6 @@
 
     <style name="SmartbarQuickAction.PrivateModeButton">
         <item name="android:background">@drawable/shape_rect_rounded</item>
-        <item name="android:backgroundTint">#a000ff</item>
-        <item name="android:tint">#ffffff</item>
     </style>
 
     <style name="TextEditingButton" parent="Widget.AppCompat.Button.Borderless">

--- a/app/src/main/res/xml/prefs_advanced.xml
+++ b/app/src/main/res/xml/prefs_advanced.xml
@@ -18,4 +18,12 @@
         app:title="@string/pref__advanced__show_app_icon__label"
         app:useSimpleSummaryProvider="true"/>
 
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        app:key="advanced__force_private_mode"
+        app:iconSpaceReserved="false"
+        app:title="@string/pref__advanced__force_private_mode__label"
+        app:summary="@string/pref__advanced__force_private_mode__summary"
+        app:useSimpleSummaryProvider="true"/>
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/prefs_theme.xml
+++ b/app/src/main/res/xml/prefs_theme.xml
@@ -183,6 +183,24 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        app:title="@string/settings__theme__group_private_mode"
+        app:iconSpaceReserved="false">
+
+        <com.jaredrummler.android.colorpicker.ColorPreferenceCompat
+            android:defaultValue="0xFFA000FF"
+            android:key="theme__privateMode_bgColor"
+            android:title="@string/settings__theme__background"
+            app:iconSpaceReserved="false"/>
+
+        <com.jaredrummler.android.colorpicker.ColorPreferenceCompat
+            android:defaultValue="0xFFFFFFFF"
+            android:key="theme__privateMode_fgColor"
+            android:title="@string/settings__theme__foreground"
+            app:iconSpaceReserved="false"/>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
         app:title="@string/settings__theme__group_smartbar"
         app:iconSpaceReserved="false">
 


### PR DESCRIPTION
This PR adds a basic implementation of a private mode, which prevents features from temporarily saving the input data. This affects the clipboard history (NYI), clipboard suggestions and the next word algorithm adjustments (NYI). The private mode activates either if an app requests it or if the "Force private mode" flag is set in the Advanced Settings. In its current state also rather useless, but it will get important as soon as the composing suggestions are up and running. Below is a screenshot how the indication for the private mode looks like (purple icon in the Smartbar).

![Screenshot_20201226-232625-1](https://user-images.githubusercontent.com/19412843/103160215-533ad180-47d2-11eb-9d35-17c0c75f8386.jpg)

Closes #106