### PR TITLE
Add hint priority mode setting

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -24,6 +24,7 @@ import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.text.gestures.DistanceThreshold
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.gestures.VelocityThreshold
+import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
 import dev.patrickgold.florisboard.util.VersionName
 import kotlin.collections.HashMap
 
@@ -311,8 +312,8 @@ class PrefHelper(
             const val FONT_SIZE_MULTIPLIER_LANDSCAPE =  "keyboard__font_size_multiplier_landscape"
             const val HEIGHT_FACTOR =                   "keyboard__height_factor"
             const val HEIGHT_FACTOR_CUSTOM =            "keyboard__height_factor_custom"
-            const val HINTED_NUMBER_ROW =               "keyboard__hinted_number_row"
-            const val HINTED_SYMBOLS =                  "keyboard__hinted_symbols"
+            const val HINTED_NUMBER_ROW_MODE =          "keyboard__hinted_number_row_mode"
+            const val HINTED_SYMBOLS_MODE =             "keyboard__hinted_symbols_mode"
             const val LONG_PRESS_DELAY =                "keyboard__long_press_delay"
             const val NUMBER_ROW =                      "keyboard__number_row"
             const val ONE_HANDED_MODE =                 "keyboard__one_handed_mode"
@@ -338,12 +339,12 @@ class PrefHelper(
         var heightFactorCustom: Int
             get() =  prefHelper.getPref(HEIGHT_FACTOR_CUSTOM, 100)
             set(v) = prefHelper.setPref(HEIGHT_FACTOR_CUSTOM, v)
-        var hintedNumberRow: Boolean
-            get() =  prefHelper.getPref(HINTED_NUMBER_ROW, true)
-            set(v) = prefHelper.setPref(HINTED_NUMBER_ROW, v)
-        var hintedSymbols: Boolean
-            get() =  prefHelper.getPref(HINTED_SYMBOLS, true)
-            set(v) = prefHelper.setPref(HINTED_SYMBOLS, v)
+        var hintedNumberRowMode: KeyHintMode
+            get() =  KeyHintMode.fromString(prefHelper.getPref(HINTED_NUMBER_ROW_MODE, KeyHintMode.ENABLED_ACCENT_PRIORITY.toString()))
+            set(v) = prefHelper.setPref(HINTED_NUMBER_ROW_MODE, v)
+        var hintedSymbolsMode: KeyHintMode
+            get() =  KeyHintMode.fromString(prefHelper.getPref(HINTED_SYMBOLS_MODE, KeyHintMode.ENABLED_ACCENT_PRIORITY.toString()))
+            set(v) = prefHelper.setPref(HINTED_SYMBOLS_MODE, v)
         var longPressDelay: Int = 0
             get() = prefHelper.getPref(LONG_PRESS_DELAY, 300)
             private set

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyHintMode.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyHintMode.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.text.key
+
+import java.util.*
+
+/**
+ * Enum for the key hint modes.
+ */
+enum class KeyHintMode {
+    DISABLED,
+    ENABLED_HINT_PRIORITY,
+    ENABLED_ACCENT_PRIORITY,
+    ENABLED_SMART_PRIORITY;
+
+    companion object {
+        fun fromString(string: String): KeyHintMode {
+            return valueOf(string.toUpperCase(Locale.ROOT))
+        }
+    }
+
+    override fun toString(): String {
+        return super.toString().toLowerCase(Locale.ROOT)
+    }
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -146,19 +146,26 @@ class KeyView(
         elevation = 4.0f
 
         var hintKeyData: KeyData? = null
+        var hintKeyMode: KeyHintMode = KeyHintMode.DISABLED
         val hintedNumber = data.hintedNumber
-        if (prefs.keyboard.hintedNumberRow && hintedNumber != null) {
+        if (prefs.keyboard.hintedNumberRowMode != KeyHintMode.DISABLED && hintedNumber != null) {
             hintKeyData = hintedNumber
+            hintKeyMode = prefs.keyboard.hintedNumberRowMode
         }
         val hintedSymbol = data.hintedSymbol
-        if (prefs.keyboard.hintedSymbols && hintedSymbol != null) {
+        if (prefs.keyboard.hintedSymbolsMode != KeyHintMode.DISABLED && hintedSymbol != null) {
             hintKeyData = hintedSymbol
+            hintKeyMode = prefs.keyboard.hintedSymbolsMode
         }
         dataPopupWithHint = if (hintKeyData == null) {
             data.popup.toMutableList()
         } else {
             val popupList = data.popup.toMutableList()
-            popupList.add(hintKeyData)
+            if (hintKeyMode == KeyHintMode.ENABLED_HINT_PRIORITY) {
+                popupList.add(0, hintKeyData)
+            } else {
+                popupList.add(hintKeyData)
+            }
             popupList
         }
 
@@ -646,11 +653,11 @@ class KeyView(
         ) {
             label = getComputedLetter()
             val hintedNumber = data.hintedNumber
-            if (prefs.keyboard.hintedNumberRow && hintedNumber != null) {
+            if (prefs.keyboard.hintedNumberRowMode != KeyHintMode.DISABLED && hintedNumber != null) {
                 hintedLabel = getComputedLetter(hintedNumber)
             }
             val hintedSymbol = data.hintedSymbol
-            if (prefs.keyboard.hintedSymbols && hintedSymbol != null) {
+            if (prefs.keyboard.hintedSymbolsMode != KeyHintMode.DISABLED && hintedSymbol != null) {
                 hintedLabel = getComputedLetter(hintedSymbol)
             }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -93,10 +93,6 @@
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">المفاتيح</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">صف الأعداد</string>
     <string name="pref__keyboard__number_row__summary" comment="Preference summary">إظهار صف الأعداد فوق تخطيط الحروف</string>
-    <string name="pref__keyboard__hinted_number_row__label" comment="Preference title">تلميح لصف الأعداد</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">الصف الأول لتخطيط الحروف يشير إلى صف الأرقام</string>
-    <string name="pref__keyboard__hinted_symbols__label" comment="Preference title">تلميح للرموز</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">الصف الثاني و الثالث لتخطيط الحروف يشير إلى الرموز</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">مضاعف حجم الخط (عمودي)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">مضاعف حجم الخط (أفقي)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">نظام التخطيط</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -91,8 +91,6 @@
     <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Nastavte na Zapnuto pro tmavé nebo vypnuté pro světlé popředí.</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Předvolby Klávesnice</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Šipka</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">První řádek rozvržení znaků naznačuje číslo řádku</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">Druhá a třetí řada znakových symbolů nápovědy</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Multiplikátor velikosti písma (portrét)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Multiplikátor velikosti písma (Krajina)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Rozložení</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -91,8 +91,6 @@
     <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">EIN für dunklen oder AUS für hellen Vordergrund.</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Tastatur-Einstellungen</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Tasten</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">Erste Reihe der Tastatur deutet Zahlenreihe im Hintergrund an</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">Zweite und dritte Reihe der Tastatur deuten Symbole im Hintergrund an</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Schriftgröße anpassen (Hochformat)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Schriftgröße anpassen (Querformat)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Layout</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -91,8 +91,6 @@
     <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Ορίστε ΕΝΕΡΓΟΠΟΙΗΜΈΝΟ για σκούρο ή ΑΠΕΝΕΡΓΟΠΟΙΗΜΈΝΟ για φωτεινό προσκήνιο.</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Προτιμήσεις Πληκτρολογίου</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Πλήκτρα</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">Η πρώτη σειρά χαρακτήρων υπονοεί τη σειρά αριθμών</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">Η δεύτερη και τρίτη σειρά διάταξης χαρακτήρων υπονοούν σύμβολα</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Πολλαπλασιαστής μεγέθους γραμματοσειράς (πορτραίτο)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Πολλαπλασιαστής μεγέθους γραμματοσειράς (τοπίο)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Διάταξη</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -43,10 +43,6 @@
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">کلیدها</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">ردیف عدد</string>
     <string name="pref__keyboard__number_row__summary" comment="Preference summary">ردیف عددی که بالای چیدمان کاراکتر ها نمایش داده می شود</string>
-    <string name="pref__keyboard__hinted_number_row__label" comment="Preference title">ردیف عددی همیار</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">اولین ردیف از چیدمان کاراکتر ها به ردیف عدد اشاره می کند</string>
-    <string name="pref__keyboard__hinted_symbols__label" comment="Preference title">نشانه های همیار</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">دومین و سویم ردیف از کاراکتر ها در چیدمان به نماد ها اشاره می کند</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">اندازه فونت چند برابری(عمودی)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">اندازه فونت چند برابری(افقی)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">چیدمان</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -91,8 +91,6 @@
     <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Aseta päälle tummia tai pois päältä vaaleita painikkeita varten.</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Näppäimistön asetukset</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Painikkeet</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">Numerot ensimmäisen näppäinrivin painikkeilla</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">Symbolit toisen ja kolmannen näppäinrivin painikkeilla</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Fonttikoon kerroin (pystysuunnassa)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Fonttikoon kerroin (vaakasuunnassa)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Ulkoasu</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -93,10 +93,6 @@
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Touches</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Rangée de numéros</string>
     <string name="pref__keyboard__number_row__summary" comment="Preference summary">Afficher la rangée de numéros au dessus de la disposition des caractères</string>
-    <string name="pref__keyboard__hinted_number_row__label" comment="Preference title">Rangée de numéros subtile</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">Première rangée de la configuration des caractères indique la rangée des numéros</string>
-    <string name="pref__keyboard__hinted_symbols__label" comment="Preference title">Astuce des symboles</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">Deuxième et troisième rangées de la configuration des caractères indique des symboles</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Multiplicateur de la taille de la police (portrait)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Multiplicateur de la taille de la police (paysage)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Disposition</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -93,8 +93,6 @@
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Billentyűk</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Számsor</string>
     <string name="pref__keyboard__number_row__summary" comment="Preference summary">Számsor megjelenítése a karakterelrendezés felett</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">A karakterelrendezés első sora utal a számsorra</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">Második és harmadik sor karakter elrendezés tipp szimbólumok</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Betűméret szorzó (álló)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Betűméret szorzó (fekvő)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Elrendezés</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -91,8 +91,6 @@
     <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Imposta a ON per un colore di primo piano scuro e OFF per uno chiaro.</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Tastiera preferenze</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Tasti</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">Prima riga dei tasti contiene suggerimenti per i numeri</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">La seconda e terza riga suggeriscono simboli</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Moltiplicatore della dimensione del testo (ritratto)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Moltiplicatore della dimensione del testo (panorama)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Layout</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -91,8 +91,6 @@
     <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Start op voor donker of uit voor lichte voorgrond.</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Toetsenbordvoorkeuren</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Toets</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">Eerste rij tekenopmaak geeft nummer rij</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">Tweede en derde rij tekenopmaak hint symbolen</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Lettergrootte multiplier (portret)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Lettergrootte multiplier (landschap)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Lay</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -93,10 +93,6 @@
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Teclas</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Linha de números</string>
     <string name="pref__keyboard__number_row__summary" comment="Preference summary">Mostrar linha de números em cima do teclado</string>
-    <string name="pref__keyboard__hinted_number_row__label" comment="Preference title">Sugerir linha de números</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">A primeira linha de letras sugere números</string>
-    <string name="pref__keyboard__hinted_symbols__label" comment="Preference title">Sugerir símbolos</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">As segunda e terceira linhas de letras sugere símbolos</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Multiplicador de tamanho da fonte (retrato)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Multiplicador de tamanho da fonte (paisagem)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Layout</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -93,8 +93,6 @@
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Teclas</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Linha de números</string>
     <string name="pref__keyboard__number_row__summary" comment="Preference summary">Mostrar linha de números em cima do teclado</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">Mostrar números na primeira linha do teclado</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">Mostrar símbolos na segunda e na terceira linha do teclado</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Multiplicador do tipo de letra (vertical)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Multiplicador do tipo de letra (horizontal)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Disposição</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -21,6 +21,20 @@
         <item>custom</item>
     </string-array>
 
+    <!-- TODO: implement smart priority -->
+    <string-array name="pref__keyboard__hint_mode__entries">
+        <item>@string/pref__keyboard__hint_mode__disabled</item>
+        <item>@string/pref__keyboard__hint_mode__enabled_hint_priority</item>
+        <item>@string/pref__keyboard__hint_mode__enabled_accent_priority</item>
+        <!--<item>@string/pref__keyboard__hint_mode__enabled_smart_priority</item>-->
+    </string-array>
+    <string-array name="pref__keyboard__hint_mode__values">
+        <item>disabled</item>
+        <item>enabled_hint_priority</item>
+        <item>enabled_accent_priority</item>
+        <!--<item>enabled_smart_priority</item>-->
+    </string-array>
+
     <string-array name="pref__keyboard__one_handed_mode__entries">
         <item>@string/pref__keyboard__one_handed_mode__off</item>
         <item>@string/pref__keyboard__one_handed_mode__right</item>
@@ -66,7 +80,6 @@
         <item>switch_to_next_subtype</item>
     </string-array>
 
-    <!-- TODO: Implement precise word deleting -->
     <string-array name="pref__gestures__swipe_action_delete__entries">
         <item>@string/pref__gestures__swipe_action__no_action</item>
         <item>@string/pref__gestures__swipe_action__delete_characters_precisely</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,10 +113,12 @@
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Keys</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Number row</string>
     <string name="pref__keyboard__number_row__summary" comment="Preference summary">Show number row on top of character layout</string>
-    <string name="pref__keyboard__hinted_number_row__label" comment="Preference title">Hinted number row</string>
-    <string name="pref__keyboard__hinted_number_row__summary" comment="Preference summary">First row of character layout hints number row</string>
-    <string name="pref__keyboard__hinted_symbols__label" comment="Preference title">Hinted symbols</string>
-    <string name="pref__keyboard__hinted_symbols__summary" comment="Preference summary">Second and third row of character layout hint symbols</string>
+    <string name="pref__keyboard__hinted_number_row_mode__label" comment="Preference title">Hinted number row</string>
+    <string name="pref__keyboard__hinted_symbols_mode__label" comment="Preference title">Hinted symbols</string>
+    <string name="pref__keyboard__hint_mode__disabled" comment="Preference value">Disabled</string>
+    <string name="pref__keyboard__hint_mode__enabled_hint_priority" comment="Preference value">Enabled (Hint is prioritized)</string>
+    <string name="pref__keyboard__hint_mode__enabled_accent_priority" comment="Preference value">Enabled (Accent is prioritized)</string>
+    <string name="pref__keyboard__hint_mode__enabled_smart_priority" comment="Preference value">Enabled (Smart prioritization)</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Font size multiplier (portrait)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Font size multiplier (landscape)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Layout</string>

--- a/app/src/main/res/xml/prefs_keyboard.xml
+++ b/app/src/main/res/xml/prefs_keyboard.xml
@@ -13,19 +13,23 @@
             app:title="@string/pref__keyboard__number_row__label"
             app:summary="@string/pref__keyboard__number_row__summary"/>
 
-        <SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:key="keyboard__hinted_number_row"
+        <ListPreference
+            android:defaultValue="enabled_accent_priority"
+            app:entries="@array/pref__keyboard__hint_mode__entries"
+            app:entryValues="@array/pref__keyboard__hint_mode__values"
+            app:key="keyboard__hinted_number_row_mode"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__keyboard__hinted_number_row__label"
-            app:summary="@string/pref__keyboard__hinted_number_row__summary"/>
+            app:title="@string/pref__keyboard__hinted_number_row_mode__label"
+            app:useSimpleSummaryProvider="true"/>
 
-        <SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:key="keyboard__hinted_symbols"
+        <ListPreference
+            android:defaultValue="enabled_accent_priority"
+            app:entries="@array/pref__keyboard__hint_mode__entries"
+            app:entryValues="@array/pref__keyboard__hint_mode__values"
+            app:key="keyboard__hinted_symbols_mode"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__keyboard__hinted_symbols__label"
-            app:summary="@string/pref__keyboard__hinted_symbols__summary"/>
+            app:title="@string/pref__keyboard__hinted_symbols_mode__label"
+            app:useSimpleSummaryProvider="true"/>
 
         <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
             app:allowDividerAbove="false"


### PR DESCRIPTION
This PR is finally a solution for the discussion, whether a hinted symbol or the accent character should take priority in the extended popup. The preference toggles for the hinted number row and the hinted symbols have been replaced by a hint priority setting for both, which can separately be set to `Disabled`, `Enabled (Hint takes priority)` and `Enabled (Accent takes priority)`.

In the future it is also planned to add an `Enabled (Smart prioritization)` mode, which decides based on the current subtype, which of the two possibilities should be selected.

Closes #39 