### PR TITLE
Add Bépo french keyboard layout

### DIFF
--- a/app/src/main/assets/ime/config.json
+++ b/app/src/main/assets/ime/config.json
@@ -4,6 +4,7 @@
     "qwerty": "QWERTY",
     "qwertz": "QWERTZ",
     "azerty": "AZERTY",
+    "bepo": "BÉPO",
     "spanish": "Spanish (QWERTY)",
     "norwegian": "Norwegian (QWERTY)",
     "swedish_finnish": "Swedish/Finnish (QWERTY)",

--- a/app/src/main/assets/ime/text/characters/bepo.json
+++ b/app/src/main/assets/ime/text/characters/bepo.json
@@ -1,0 +1,51 @@
+{
+    "type": "characters",
+    "name": "bepo",
+    "authors": [ "salamandar" ],
+    "direction": "ltr",
+    "arrangement": [
+      [
+        { "code":   98, "label": "b" },
+        { "code":  233, "label": "é" },
+        { "code":  112, "label": "p" },
+        { "code":  111, "label": "o" },
+        { "code":  232, "label": "è" },
+        { "code":  118, "label": "v" },
+        { "code":  100, "label": "d" },
+        { "code":  108, "label": "l" },
+        { "code":  106, "label": "j" },
+        { "code":  122, "label": "z" },
+        { "code":  119, "label": "w" }
+      ],
+      [
+        { "code":   97, "label": "a" },
+        { "code":  117, "label": "u" },
+        { "code":  105, "label": "i" },
+        { "code":  101, "label": "e" },
+        { "code":   99, "label": "c" },
+        { "code":  116, "label": "t" },
+        { "code":  115, "label": "s" },
+        { "code":  114, "label": "r" },
+        { "code":  110, "label": "n" },
+        { "code":  109, "label": "m" },
+        { "code":  231, "label": "ç" }
+      ],
+      [
+        { "code":  121, "label": "y" },
+        { "code":  120, "label": "x" },
+        { "code":  107, "label": "k" },
+        { "code":  113, "label": "q", "popup": {
+          "relevant": [
+            { "code": 8218, "label": "‚" },
+            { "code": 8216, "label": "‘" },
+            { "code": 8217, "label": "’" },
+            { "code": 8249, "label": "‹" },
+            { "code": 8250, "label": "›" }
+          ]
+        } },
+        { "code":  103, "label": "g" },
+        { "code":  104, "label": "h" },
+        { "code":  102, "label": "f" }
+      ]
+    ]
+  }


### PR DESCRIPTION
Closes #181 

This layout has a large bottom line so thin shift and backspace keys would be great.

Also, i only implemented first layer characters so long-press chars are not yet customized for bépo.

![Screenshot_20210118-120807_Firefox](https://user-images.githubusercontent.com/6552989/104907985-1fdd0400-5986-11eb-931c-645caef00b3f.png)
