### PR TITLE
Fix delete and shift key width for 9+ char rows

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -397,25 +397,30 @@ class KeyView(
      *  by Devunwired
      */
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        desiredWidth = when (keyboardView.computedLayout?.mode) {
+        desiredWidth = (keyboardView.desiredKeyWidth * when (keyboardView.computedLayout?.mode) {
             KeyboardMode.NUMERIC,
             KeyboardMode.PHONE,
-            KeyboardMode.PHONE2 -> (keyboardView.desiredKeyWidth * 2.68f).toInt()
+            KeyboardMode.PHONE2 -> 2.68f
             KeyboardMode.NUMERIC_ADVANCED -> when (data.code) {
-                44, 46 -> keyboardView.desiredKeyWidth
-                KeyCode.VIEW_SYMBOLS, 61 -> (keyboardView.desiredKeyWidth * 1.34f).toInt()
-                else -> (keyboardView.desiredKeyWidth * 1.56f).toInt()
+                44, 46 -> 1.00f
+                KeyCode.VIEW_SYMBOLS, 61 -> 1.34f
+                else -> 1.56f
             }
             else -> when (data.code) {
                 KeyCode.SHIFT,
+                KeyCode.DELETE ->
+                        if ((keyboardView.computedLayout?.arrangement?.get(2)?.size ?: 0) > 10) {
+                            1.12f
+                        } else {
+                            1.56f
+                        }
                 KeyCode.VIEW_CHARACTERS,
                 KeyCode.VIEW_SYMBOLS,
                 KeyCode.VIEW_SYMBOLS2,
-                KeyCode.DELETE,
-                KeyCode.ENTER -> (keyboardView.desiredKeyWidth * 1.56f).toInt()
-                else -> keyboardView.desiredKeyWidth
+                KeyCode.ENTER -> 1.56f
+                else -> 1.00f
             }
-        }
+        }).toInt()
         desiredHeight = keyboardView.desiredKeyHeight
 
         val widthMode = MeasureSpec.getMode(widthMeasureSpec)


### PR DESCRIPTION
This PR fixes a common issue with the key width of shift and delete for 9+ character keys in between by reducing the width of those 2 keys. Relevant #202. 8 characters or less will have the default delete/shift width.

Closes #205 

### Screenshots

| 7 characters inbetween | 8 characters inbetween |
|------------------------|---------------------------|
| ![delete-shift-key-width-9char](https://user-images.githubusercontent.com/19412843/104949796-d1e4f200-59bf-11eb-9e94-04ae91b9cba4.jpg) | ![delete-shift-key-width-10char](https://user-images.githubusercontent.com/19412843/104949808-d7dad300-59bf-11eb-9068-172185bab8a2.jpg) |

| 9 characters inbetween | 10 characters inbetween |
|------------------------|---------------------------|
|  ![delete-shift-key-width-11char](https://user-images.githubusercontent.com/19412843/104949442-41a6ad00-59bf-11eb-985b-88536a50042a.jpg) |  ![delete-shift-key-width-12char](https://user-images.githubusercontent.com/19412843/104949451-4703f780-59bf-11eb-9737-227c9f6aa388.jpg) |

