### PR TITLE
Fix precise character deletion behaviour

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -103,6 +103,7 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
         }
         if (!isPreviewMode) {
             themeManager.requestThemeUpdate(this)
+            onWindowShown()
         } else {
             updateVisibility()
         }
@@ -137,6 +138,18 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
         swipeGestureDetector.apply {
             distanceThreshold = prefs.gestures.swipeDistanceThreshold
             velocityThreshold = prefs.gestures.swipeVelocityThreshold
+        }
+        for (row in children) {
+            if (row is ViewGroup) {
+                for (keyView in row.children) {
+                    if (keyView is KeyView) {
+                        keyView.swipeGestureDetector.apply {
+                            distanceThreshold = prefs.gestures.swipeDistanceThreshold
+                            velocityThreshold = prefs.gestures.swipeVelocityThreshold
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -244,10 +257,10 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
      * Swipe event handler. Listens to touch_up swipes and executes the swipe action defined for it
      * in the prefs.
      */
-    override fun onSwipe(direction: SwipeGesture.Direction, type: SwipeGesture.Type): Boolean {
+    override fun onSwipe(event: SwipeGesture.Event): Boolean {
         return when {
             initialKeyCode == KeyCode.DELETE -> {
-                if (type == SwipeGesture.Type.TOUCH_UP && direction == SwipeGesture.Direction.LEFT &&
+                if (event.type == SwipeGesture.Type.TOUCH_UP && event.direction == SwipeGesture.Direction.LEFT &&
                     prefs.gestures.deleteKeySwipeLeft == SwipeAction.DELETE_WORD) {
                     florisboard?.executeSwipeAction(prefs.gestures.deleteKeySwipeLeft)
                     true
@@ -256,9 +269,9 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
                 }
             }
             initialKeyCode > KeyCode.SPACE && !popupManager.isShowingExtendedPopup -> when {
-                !prefs.glide.enabled -> when (type) {
+                !prefs.glide.enabled -> when (event.type) {
                     SwipeGesture.Type.TOUCH_UP -> {
-                        val swipeAction = when (direction) {
+                        val swipeAction = when (event.direction) {
                             SwipeGesture.Direction.UP -> prefs.gestures.swipeUp
                             SwipeGesture.Direction.DOWN -> prefs.gestures.swipeDown
                             SwipeGesture.Direction.LEFT -> prefs.gestures.swipeLeft

--- a/app/src/main/res/xml/prefs_gestures.xml
+++ b/app/src/main/res/xml/prefs_gestures.xml
@@ -26,7 +26,7 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
-        app:key="gestures"
+        app:key="general_gestures"
         app:title="@string/pref__gestures__general_title">
 
         <ListPreference
@@ -73,7 +73,7 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
-        app:key="gestures"
+        app:key="space_bar_gestures"
         app:title="@string/pref__gestures__space_bar_title">
 
         <ListPreference
@@ -116,7 +116,7 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
-        app:key="gestures"
+        app:key="other_gestures"
         app:title="@string/pref__gestures__other_title">
 
         <ListPreference


### PR DESCRIPTION
This PR is an attempt to fix the precise character deletion behavior for the delete key. Until now, the amount of characters the swipe selected was dependent on the speed of the swipe as well as on the current CPU load. Now, the amount of characters is calculated based on the distance you swiped and thus the behavior is way more consistent in all situations, independent of the speed and CPU load.

Closes #154 

The delete swipe is now also generally more fast and accurate, similar to OpenBoard or Gboard. Please note that the amount of charcters is dependent on the `Swipe distance threshold` value in the Gesture preferences.

Closes #124 

### Demo (old v0.3.3 vs new v0.3.4)

https://user-images.githubusercontent.com/19412843/105382125-0a7b0a80-5c10-11eb-9ef2-7780258a4fcd.mp4
