### PR TITLE
Proper loading keyboard animation

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -16,9 +16,12 @@
 
 package dev.patrickgold.florisboard.ime.text
 
+import android.animation.ObjectAnimator
+import android.animation.ValueAnimator
 import android.content.Context
 import android.os.Handler
 import android.view.KeyEvent
+import android.view.View
 import android.view.inputmethod.*
 import android.widget.LinearLayout
 import android.widget.Toast
@@ -38,6 +41,7 @@ import dev.patrickgold.florisboard.ime.text.smartbar.SmartbarView
 import kotlinx.coroutines.*
 import timber.log.Timber
 import java.util.*
+import kotlin.math.roundToLong
 
 /**
  * TextInputManager is responsible for managing everything which is related to text input. All of
@@ -58,12 +62,13 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
         get() = florisboard.activeEditorInstance
 
     private var activeKeyboardMode: KeyboardMode? = null
+    private var animator: ObjectAnimator? = null
     private val keyboardViews = EnumMap<KeyboardMode, KeyboardView>(KeyboardMode::class.java)
     private var editingKeyboardView: EditingKeyboardView? = null
     private var loadingPlaceholderKeyboard: KeyboardView? = null
     private val osHandler = Handler()
     private var textViewFlipper: ViewFlipper? = null
-    var textViewGroup: LinearLayout? = null
+    private var textViewGroup: LinearLayout? = null
 
     var keyVariation: KeyVariation = KeyVariation.NORMAL
     val layoutManager = LayoutManager(florisboard)
@@ -116,8 +121,13 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
         }
     }
 
+    override fun onCreateInputView() {
+        keyboardViews.clear()
+    }
+
     private suspend fun addKeyboardView(mode: KeyboardMode) {
         val keyboardView = KeyboardView(florisboard.context)
+        keyboardView.id = View.generateViewId()
         keyboardView.computedLayout = layoutManager.fetchComputedLayoutAsync(mode, florisboard.activeSubtype, florisboard.prefs).await()
         keyboardViews[mode] = keyboardView
         textViewFlipper?.addView(keyboardView)
@@ -129,16 +139,38 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
     override fun onRegisterInputView(inputView: InputView) {
         Timber.i("onRegisterInputView(inputView)")
 
-        launch(Dispatchers.Main) {
-            textViewGroup = inputView.findViewById(R.id.text_input)
-            textViewFlipper = inputView.findViewById(R.id.text_input_view_flipper)
-            editingKeyboardView = inputView.findViewById(R.id.editing)
-            loadingPlaceholderKeyboard = inputView.findViewById(R.id.keyboard_preview)
+        textViewGroup = inputView.findViewById(R.id.text_input)
+        textViewFlipper = inputView.findViewById(R.id.text_input_view_flipper)
+        editingKeyboardView = inputView.findViewById(R.id.editing)
+        loadingPlaceholderKeyboard = inputView.findViewById(R.id.keyboard_preview)
 
+        launch(Dispatchers.Main) {
+            textViewGroup?.let {
+                animator = ObjectAnimator.ofFloat(it, "alpha", 0.9f, 1.0f).apply {
+                    duration = 125
+                    repeatCount = ValueAnimator.INFINITE
+                    repeatMode = ValueAnimator.REVERSE
+                    start()
+                    launch {
+                        delay(duration)
+                        try {
+                            duration = 500
+                            setFloatValues(1.0f, 0.4f)
+                        } catch (_: Exception) {}
+                    }
+                }
+            }
             val activeKeyboardMode = getActiveKeyboardMode()
             addKeyboardView(activeKeyboardMode)
             setActiveKeyboardMode(activeKeyboardMode)
-            loadingPlaceholderKeyboard?.animator?.end()
+            animator?.cancel()
+            textViewGroup?.let {
+                animator = ObjectAnimator.ofFloat(it, "alpha", it.alpha, 1.0f).apply {
+                    duration = (((1.0f - it.alpha) / 0.6f) * 125f).roundToLong()
+                    repeatCount = 0
+                    start()
+                }
+            }
             for (mode in KeyboardMode.values()) {
                 if (mode != activeKeyboardMode && mode != KeyboardMode.SMARTBAR_NUMBER_ROW) {
                     addKeyboardView(mode)
@@ -249,11 +281,11 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
     /**
      * Sets [activeKeyboardMode] and updates the [SmartbarView.isQuickActionsVisible] state.
      */
-    fun setActiveKeyboardMode(mode: KeyboardMode) {
+    private fun setActiveKeyboardMode(mode: KeyboardMode) {
         textViewFlipper?.displayedChild = textViewFlipper?.indexOfChild(when (mode) {
             KeyboardMode.EDITING -> editingKeyboardView
             else -> keyboardViews[mode]
-        }) ?: 0
+        })?.coerceAtLeast(0) ?: 0
         keyboardViews[mode]?.updateVisibility()
         keyboardViews[mode]?.requestLayout()
         keyboardViews[mode]?.requestLayoutAllKeys()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -60,6 +60,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
     private var activeKeyboardMode: KeyboardMode? = null
     private val keyboardViews = EnumMap<KeyboardMode, KeyboardView>(KeyboardMode::class.java)
     private var editingKeyboardView: EditingKeyboardView? = null
+    private var loadingPlaceholderKeyboard: KeyboardView? = null
     private val osHandler = Handler()
     private var textViewFlipper: ViewFlipper? = null
     var textViewGroup: LinearLayout? = null
@@ -132,10 +133,12 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
             textViewGroup = inputView.findViewById(R.id.text_input)
             textViewFlipper = inputView.findViewById(R.id.text_input_view_flipper)
             editingKeyboardView = inputView.findViewById(R.id.editing)
+            loadingPlaceholderKeyboard = inputView.findViewById(R.id.keyboard_preview)
 
             val activeKeyboardMode = getActiveKeyboardMode()
             addKeyboardView(activeKeyboardMode)
             setActiveKeyboardMode(activeKeyboardMode)
+            loadingPlaceholderKeyboard?.animator?.end()
             for (mode in KeyboardMode.values()) {
                 if (mode != activeKeyboardMode && mode != KeyboardMode.SMARTBAR_NUMBER_ROW) {
                     addKeyboardView(mode)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -480,35 +480,53 @@ class KeyView(
     }
 
     override fun onThemeUpdated(theme: Theme) {
-        if (keyboardView.isSmartbarKeyboardView) {
-            themeValueCache.apply {
-                keyBackground = theme.getAttr(Theme.Attr.SMARTBAR_BACKGROUND)
-                keyBackgroundPressed = theme.getAttr(Theme.Attr.SMARTBAR_BUTTON_BACKGROUND)
-                keyForeground = theme.getAttr(Theme.Attr.SMARTBAR_FOREGROUND)
-                keyForegroundAlt = theme.getAttr(Theme.Attr.SMARTBAR_FOREGROUND_ALT)
-                keyForegroundPressed = theme.getAttr(Theme.Attr.SMARTBAR_FOREGROUND)
-                shouldShowBorder = false
-            }
-        } else {
-            val label = data.label
-            val capsSpecific = when {
-                florisboard?.textInputManager?.capsLock == true -> {
-                    "capslock"
-                }
-                florisboard?.textInputManager?.caps == true -> {
-                    "caps"
-                }
-                else -> {
-                    null
+        when {
+            keyboardView.isLoadingPlaceholderKeyboard -> {
+                val label = data.label
+                themeValueCache.apply {
+                    shouldShowBorder = theme.getAttr(Theme.Attr.KEY_SHOW_BORDER, label).toOnOff().state
+                    keyBackground = if (shouldShowBorder) {
+                        theme.getAttr(Theme.Attr.KEY_BACKGROUND, label)
+                    } else {
+                        theme.getAttr(Theme.Attr.SMARTBAR_BUTTON_BACKGROUND, label)
+                    }
+                    keyBackgroundPressed = theme.getAttr(Theme.Attr.KEY_BACKGROUND_PRESSED, label)
+                    keyForeground = keyBackground
+                    keyForegroundAlt = ThemeValue.SolidColor(0)
+                    keyForegroundPressed = keyBackgroundPressed
                 }
             }
-            themeValueCache.apply {
-                keyBackground = theme.getAttr(Theme.Attr.KEY_BACKGROUND, label, capsSpecific)
-                keyBackgroundPressed = theme.getAttr(Theme.Attr.KEY_BACKGROUND_PRESSED, label, capsSpecific)
-                keyForeground = theme.getAttr(Theme.Attr.KEY_FOREGROUND, label, capsSpecific)
-                keyForegroundAlt = ThemeValue.SolidColor(0)
-                keyForegroundPressed = theme.getAttr(Theme.Attr.KEY_FOREGROUND_PRESSED, label, capsSpecific)
-                shouldShowBorder = theme.getAttr(Theme.Attr.KEY_SHOW_BORDER, label, capsSpecific).toOnOff().state
+            keyboardView.isSmartbarKeyboardView -> {
+                themeValueCache.apply {
+                    keyBackground = theme.getAttr(Theme.Attr.SMARTBAR_BACKGROUND)
+                    keyBackgroundPressed = theme.getAttr(Theme.Attr.SMARTBAR_BUTTON_BACKGROUND)
+                    keyForeground = theme.getAttr(Theme.Attr.SMARTBAR_FOREGROUND)
+                    keyForegroundAlt = theme.getAttr(Theme.Attr.SMARTBAR_FOREGROUND_ALT)
+                    keyForegroundPressed = theme.getAttr(Theme.Attr.SMARTBAR_FOREGROUND)
+                    shouldShowBorder = false
+                }
+            }
+            else -> {
+                val label = data.label
+                val capsSpecific = when {
+                    florisboard?.textInputManager?.capsLock == true -> {
+                        "capslock"
+                    }
+                    florisboard?.textInputManager?.caps == true -> {
+                        "caps"
+                    }
+                    else -> {
+                        null
+                    }
+                }
+                themeValueCache.apply {
+                    keyBackground = theme.getAttr(Theme.Attr.KEY_BACKGROUND, label, capsSpecific)
+                    keyBackgroundPressed = theme.getAttr(Theme.Attr.KEY_BACKGROUND_PRESSED, label, capsSpecific)
+                    keyForeground = theme.getAttr(Theme.Attr.KEY_FOREGROUND, label, capsSpecific)
+                    keyForegroundAlt = ThemeValue.SolidColor(0)
+                    keyForegroundPressed = theme.getAttr(Theme.Attr.KEY_FOREGROUND_PRESSED, label, capsSpecific)
+                    shouldShowBorder = theme.getAttr(Theme.Attr.KEY_SHOW_BORDER, label, capsSpecific).toOnOff().state
+                }
             }
         }
         updateKeyPressedBackground()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -16,8 +16,6 @@
 
 package dev.patrickgold.florisboard.ime.text.keyboard
 
-import android.animation.ObjectAnimator
-import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
@@ -55,7 +53,6 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
     private var activeX: Float = 0.0f
     private var activeY: Float = 0.0f
 
-    var animator: ObjectAnimator? = null
     var computedLayout: ComputedLayoutData? = null
         set(v) {
             field = v
@@ -90,13 +87,10 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
         florisboard?.addEventListener(this)
         onWindowShown()
         if (isLoadingPlaceholderKeyboard) {
-            computedLayout = ComputedLayoutData.PREGENERATED_LOADING_KEYBOARD
-            animator = ObjectAnimator.ofFloat(this, "alpha", 0.4f, 1.0f).apply {
-                duration = 650
-                repeatCount = ValueAnimator.INFINITE
-                repeatMode = ValueAnimator.REVERSE
-                start()
-            }
+            computedLayout = ComputedLayoutData.PRE_GENERATED_LOADING_KEYBOARD
+            /*for ((i, row) in children.withIndex()) {
+                row.alpha = (i + 1) * 0.25f
+            }*/
         }
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -16,6 +16,8 @@
 
 package dev.patrickgold.florisboard.ime.text.keyboard
 
+import android.animation.ObjectAnimator
+import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
@@ -53,6 +55,7 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
     private var activeX: Float = 0.0f
     private var activeY: Float = 0.0f
 
+    var animator: ObjectAnimator? = null
     var computedLayout: ComputedLayoutData? = null
         set(v) {
             field = v
@@ -64,6 +67,7 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
     private var initialKeyCode: Int = 0
     private val isPreviewMode: Boolean
     val isSmartbarKeyboardView: Boolean
+    val isLoadingPlaceholderKeyboard: Boolean
     var popupManager = PopupManager<KeyboardView, KeyView>(this, florisboard?.popupLayerView)
     private val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)
     private val themeManager: ThemeManager = ThemeManager.default()
@@ -75,6 +79,7 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
         context.obtainStyledAttributes(attrs, R.styleable.KeyboardView).apply {
             isPreviewMode = getBoolean(R.styleable.KeyboardView_isPreviewKeyboard, false)
             isSmartbarKeyboardView = getBoolean(R.styleable.KeyboardView_isSmartbarKeyboard, false)
+            isLoadingPlaceholderKeyboard = getBoolean(R.styleable.KeyboardView_isLoadingPlaceholderKeyboard, false)
             recycle()
         }
         orientation = VERTICAL
@@ -84,6 +89,15 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
         )
         florisboard?.addEventListener(this)
         onWindowShown()
+        if (isLoadingPlaceholderKeyboard) {
+            computedLayout = ComputedLayoutData.PREGENERATED_LOADING_KEYBOARD
+            animator = ObjectAnimator.ofFloat(this, "alpha", 0.4f, 1.0f).apply {
+                duration = 650
+                repeatCount = ValueAnimator.INFINITE
+                repeatMode = ValueAnimator.REVERSE
+                start()
+            }
+        }
     }
 
     /**
@@ -166,7 +180,7 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent?): Boolean {
         event ?: return false
-        if (isPreviewMode) {
+        if (isPreviewMode || isLoadingPlaceholderKeyboard) {
             return false
         }
         val eventFloris = MotionEvent.obtainNoHistory(event)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutData.kt
@@ -57,7 +57,7 @@ data class ComputedLayoutData(
     val arrangement: ComputedLayoutDataArrangement = mutableListOf()
 ) {
     companion object {
-        val PREGENERATED_LOADING_KEYBOARD = ComputedLayoutData(
+        val PRE_GENERATED_LOADING_KEYBOARD = ComputedLayoutData(
             mode = KeyboardMode.CHARACTERS,
             name = "__loading_keyboard__",
             direction = "ltr",

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutData.kt
@@ -17,6 +17,9 @@
 package dev.patrickgold.florisboard.ime.text.layout
 
 import dev.patrickgold.florisboard.ime.text.key.FlorisKeyData
+import dev.patrickgold.florisboard.ime.text.key.KeyCode
+import dev.patrickgold.florisboard.ime.text.key.KeyData
+import dev.patrickgold.florisboard.ime.text.key.KeyType
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
 
 typealias LayoutDataArrangement = List<List<FlorisKeyData>>
@@ -52,4 +55,56 @@ data class ComputedLayoutData(
     val name: String,
     val direction: String,
     val arrangement: ComputedLayoutDataArrangement = mutableListOf()
-)
+) {
+    companion object {
+        val PREGENERATED_LOADING_KEYBOARD = ComputedLayoutData(
+            mode = KeyboardMode.CHARACTERS,
+            name = "__loading_keyboard__",
+            direction = "ltr",
+            arrangement = mutableListOf(
+                mutableListOf(
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0)
+                ),
+                mutableListOf(
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0)
+                ),
+                mutableListOf(
+                    FlorisKeyData(code = KeyCode.SHIFT, type = KeyType.MODIFIER, label = "shift"),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = KeyCode.DELETE, type = KeyType.ENTER_EDITING, label = "delete")
+                ),
+                mutableListOf(
+                    FlorisKeyData(code = KeyCode.VIEW_SYMBOLS, type = KeyType.SYSTEM_GUI, label = "view_symbols"),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = KeyCode.SPACE, label = "space"),
+                    FlorisKeyData(code = 0),
+                    FlorisKeyData(code = KeyCode.ENTER, type = KeyType.ENTER_EDITING, label = "enter")
+                )
+            )
+        )
+    }
+}

--- a/app/src/main/res/layout/text_input_layout.xml
+++ b/app/src/main/res/layout/text_input_layout.xml
@@ -5,7 +5,8 @@
     android:id="@+id/text_input"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:alpha="0.9">
 
     <include layout="@layout/smartbar"/>
 

--- a/app/src/main/res/layout/text_input_layout.xml
+++ b/app/src/main/res/layout/text_input_layout.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/text_input"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -15,21 +16,11 @@
         android:layout_height="wrap_content"
         android:measureAllChildren="true">
 
-        <LinearLayout
+        <dev.patrickgold.florisboard.ime.text.keyboard.KeyboardView
             android:id="@+id/keyboard_preview"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            tools:ignore="UselessParent">
-
-            <!-- TODO: make a good looking keyboard preview -->
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="200dp"
-                android:text="Loading keyboard, please wait..."/>
-
-        </LinearLayout>
+            app:isLoadingPlaceholderKeyboard="true"/>
 
         <include layout="@layout/editing_layout"/>
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -17,6 +17,7 @@
     <declare-styleable name="KeyboardView">
         <attr name="isPreviewKeyboard" format="boolean"/>
         <attr name="isSmartbarKeyboard" format="boolean"/>
+        <attr name="isLoadingPlaceholderKeyboard" format="boolean"/>
     </declare-styleable>
 
     <declare-styleable name="EditingKeyView">


### PR DESCRIPTION
This PR adds a proper loading placeholder keyboard, which replaces the old "Loading keyboard, please wait..." screen. Additionally, the selection keyboard flash bug has been eliminated. Many thanks to @Glitchy-Tozier who gave me a lot of ideas and helped in testing and fine-tuning the animation. Note, that the animation is visible to devices of all "speed" classes, but especially for older devices this should be a more pleasant loading screen than the old ugly screen.

For screen recordings of the animation see the last ones in the referenced issue.

Closes #207