### PR TITLE
Fix space bar long press

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -245,13 +245,22 @@ class KeyView(
                             }
                         }
                     }
-                    longKeyPressHandler.postDelayed(delayMillis) {
-                        if (data.popup.isNotEmpty()) {
-                            keyboardView.popupManager.extend(this, keyHintMode)
+                    if (data.code == KeyCode.SPACE) {
+                        longKeyPressHandler.postDelayed((delayMillis * 2.5f).toLong()) {
+                            when (prefs.gestures.spaceBarLongPress) {
+                                SwipeAction.NO_ACTION,
+                                SwipeAction.INSERT_SPACE -> {}
+                                else -> {
+                                    florisboard?.executeSwipeAction(prefs.gestures.spaceBarLongPress)
+                                    shouldBlockNextKeyCode = true
+                                }
+                            }
                         }
-                        if (data.code == KeyCode.SPACE) {
-                            florisboard?.executeSwipeAction(prefs.gestures.spaceBarLongPress)
-                            shouldBlockNextKeyCode = true
+                    } else {
+                        longKeyPressHandler.postDelayed(delayMillis) {
+                            if (data.popup.isNotEmpty()) {
+                                keyboardView.popupManager.extend(this, keyHintMode)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR fixes the space bar long press action in several ways:

- The long press delay is now exactly twice as long as the time set in the preferences. This ensures that it is more difficult to accidentally trigger the long-press action while using the space swipe left/right. The long-press time of any other key is not affected by this change.
- `No action` as well as `Insert space` now both insert a space exactly when the space bar is released, regardless how long it has been pressed. This enables the space bar to behave like a space bar when set to these cases. Previously, `No action` did nothing and `Insert space` did insert the space after exactly the `delay time` set in the preferences, which is not how this should behave. Both actions do not block the swipe left/right action. Closes #228.