### PR TITLE
Improve theme editor UI and UX

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/Theme.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/Theme.kt
@@ -16,7 +16,9 @@
 
 package dev.patrickgold.florisboard.ime.theme
 
+import android.content.Context
 import android.graphics.Color
+import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.extension.Asset
 
 /**
@@ -66,6 +68,80 @@ open class Theme(
             authors = listOf("patrickgold"),
             isNightTheme = true
         )
+
+        /**
+         * Gets the Ui string for a given [attrName]. Used in the theme editor to properly display
+         * attributes for non-advanced users.
+         *
+         * @param context The current activity context, used for retrieving the Ui string.
+         * @param attrName The attribute name, which is used to determine which Ui string should be
+         *  fetched.
+         * @return The Ui string representation, which is localized and can be shown to the user.
+         */
+        fun getUiAttrNameString(context: Context, attrName: String): String {
+            val strId = when (attrName) {
+                "background" ->             R.string.settings__theme__attr_background
+                "backgroundActive" ->       R.string.settings__theme__attr_backgroundActive
+                "backgroundPressed" ->      R.string.settings__theme__attr_backgroundPressed
+                "foreground" ->             R.string.settings__theme__attr_foreground
+                "foregroundAlt" ->          R.string.settings__theme__attr_foregroundAlt
+                "foregroundPressed" ->      R.string.settings__theme__attr_foregroundPressed
+                "showBorder" ->             R.string.settings__theme__attr_showBorder
+                "colorPrimary" ->           R.string.settings__theme__attr_colorPrimary
+                "colorPrimaryDark" ->       R.string.settings__theme__attr_colorPrimaryDark
+                "colorAccent" ->            R.string.settings__theme__attr_colorAccent
+                "navigationBarColor" ->     R.string.settings__theme__attr_navBarColor
+                "navigationBarLight" ->     R.string.settings__theme__attr_navBarLight
+                "semiTransparentColor" ->   R.string.settings__theme__attr_semiTransparentColor
+                "textColor" ->              R.string.settings__theme__attr_textColor
+                else -> null
+            }
+            return if (strId != null) {
+                context.resources.getString(strId)
+            } else {
+                context.resources.getString(
+                    R.string.settings__theme__attr_custom, attrName
+                )
+            }
+        }
+
+        /**
+         * Gets the Ui string for a given [groupName]. Used in the theme editor to properly display
+         * group names for non-advanced users.
+         *
+         * @param context The current activity context, used for retrieving the Ui string.
+         * @param groupName The group name, which is used to determine which Ui string should be
+         *  fetched.
+         * @return The Ui string representation, which is localized and can be shown to the user.
+         */
+        fun getUiGroupNameString(context: Context, groupName: String): String {
+            return when {
+                groupName.startsWith("key:") -> context.resources.getString(
+                    R.string.settings__theme__group_key_specific, groupName.substring(4)
+                )
+                else -> {
+                    val strId = when (groupName) {
+                        "window" ->         R.string.settings__theme__group_window
+                        "keyboard" ->       R.string.settings__theme__group_keyboard
+                        "key" ->            R.string.settings__theme__group_key
+                        "media" ->          R.string.settings__theme__group_media
+                        "oneHanded" ->      R.string.settings__theme__group_oneHanded
+                        "popup" ->          R.string.settings__theme__group_popup
+                        "privateMode" ->    R.string.settings__theme__group_privateMode
+                        "smartbar" ->       R.string.settings__theme__group_smartbar
+                        "smartbarButton" -> R.string.settings__theme__group_smartbarButton
+                        else -> null
+                    }
+                    if (strId != null) {
+                        context.resources.getString(strId)
+                    } else {
+                        context.resources.getString(
+                            R.string.settings__theme__group_custom, groupName
+                        )
+                    }
+                }
+            }
+        }
 
         /**
          * Generate a base theme with the given meta data. For the argument info see [Theme].

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/components/ThemeAttrView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/components/ThemeAttrView.kt
@@ -19,6 +19,7 @@ package dev.patrickgold.florisboard.settings.components
 import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.content.Context
+import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -52,7 +53,7 @@ class ThemeAttrView : LinearLayout {
     var attrName: String = ""
         set(v) {
             field = v
-            binding.title.text = v
+            binding.title.text = Theme.getUiAttrNameString(context, v)
             themeAttrGroupView?.refreshTheme()
         }
     var attrValue: ThemeValue = ThemeValue.Other("")
@@ -137,7 +138,7 @@ class ThemeAttrView : LinearLayout {
                 ThemeValue.UI_STRING_MAP.keys.indexOf(ThemeValue.SolidColor::class.simpleName!!)
                     .coerceAtLeast(0)
             )
-            configureDialogUi(dialogView, ThemeValue.SolidColor(0))
+            configureDialogUi(dialogView, ThemeValue.SolidColor(Color.BLACK))
         }
         var userTouched = false
         dialogView.attrType.setOnTouchListener { _, _ ->
@@ -208,12 +209,14 @@ class ThemeAttrView : LinearLayout {
             dialog = show()
             dialog.getButton(AlertDialog.BUTTON_POSITIVE)?.setOnClickListener {
                 val tempAttrName = dialogView.attrName.text.toString().trim()
-                if (Theme.validateField(Theme.ValidationField.ATTR_NAME, tempAttrName)) {
+                val attrUnique = themeAttrGroupView?.hasAttr(id, tempAttrName) != true
+                if (Theme.validateField(Theme.ValidationField.ATTR_NAME, tempAttrName) && attrUnique) {
                     attrName = tempAttrName
                     attrValue = getThemeValueFromDialogUi(dialogView)
                     dialog.dismiss()
                 } else {
                     dialogView.attrNameLabel.error = resources.getString(when {
+                        !attrUnique -> R.string.settings__theme_editor__error_attr_name_already_exists
                         tempAttrName.isEmpty() -> R.string.settings__theme_editor__error_attr_name_empty
                         else -> R.string.settings__theme_editor__error_attr_name
                     })

--- a/app/src/main/res/layout/theme_editor_activity.xml
+++ b/app/src/main/res/layout/theme_editor_activity.xml
@@ -58,7 +58,10 @@
                         <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/theme_name_value"
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content"/>
+                            android:layout_height="wrap_content"
+                            android:importantForAutofill="no"
+                            android:inputType="textFilter"
+                            android:imeOptions="flagForceAscii|flagNoExtractUi"/>
 
                     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/theme_editor_attr_dialog.xml
+++ b/app/src/main/res/layout/theme_editor_attr_dialog.xml
@@ -22,7 +22,10 @@
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/attr_name"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:importantForAutofill="no"
+            android:inputType="textFilter"
+            android:imeOptions="flagForceAscii|flagNoExtractUi"/>
 
     </com.google.android.material.textfield.TextInputLayout>
 
@@ -48,7 +51,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:gravity="center_vertical">
+        android:gravity="center_vertical"
+        android:baselineAligned="false">
 
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="0dp"
@@ -64,7 +68,10 @@
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/attr_value_reference_group"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content"
+                android:importantForAutofill="no"
+                android:inputType="textFilter"
+                android:imeOptions="flagForceAscii|flagNoExtractUi"/>
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -82,7 +89,10 @@
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/attr_value_reference_attr"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content"
+                android:importantForAutofill="no"
+                android:inputType="textFilter"
+                android:imeOptions="flagForceAscii|flagNoExtractUi"/>
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -157,7 +167,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:gravity="center_vertical">
+        android:gravity="center_vertical"
+        android:baselineAligned="false">
 
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="0dp"
@@ -173,7 +184,10 @@
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/attr_value_other_text"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content"
+                android:importantForAutofill="no"
+                android:inputType="textFilter"
+                android:imeOptions="flagForceAscii|flagNoExtractUi"/>
 
         </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/theme_editor_group_dialog.xml
+++ b/app/src/main/res/layout/theme_editor_group_dialog.xml
@@ -21,7 +21,10 @@
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/group_name"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:importantForAutofill="no"
+            android:inputType="textFilter"
+            android:imeOptions="flagForceAscii|flagNoExtractUi"/>
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">هذا النوع الفرعي موجود مسبقا!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">مظهر لوحة المفاتيح</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">غير محدد</string>
-    <string name="settings__theme__background" comment="General label for a background preference">لون الخلفية</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">لون الخلفية عند التنشيط</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">لون الخلفية عند الضغط</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">لون الواجهة</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">لون الواجهة (البديل)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">لون الواجهة (وضع الحروف الكبيرة)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">اختر اللون</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">لون الخلفية</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">لون الخلفية عند التنشيط</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">لون الخلفية عند الضغط</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">لون الواجهة</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">لون الواجهة (البديل)</string>
     <string name="settings__theme__group_window" comment="Theme group label">النافذة والنظام</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">لوحة المفاتيح</string>
     <string name="settings__theme__group_key" comment="Theme group label">المفتاح</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">مفتاح الإدخال</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">نافذة المفتاح المنبثقة</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">مفتاح التحويل</string>
     <string name="settings__theme__group_media" comment="Theme group label">سياق الوسائط</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">اليد الواحدة</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">زر اليد الواحدة</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">الوضع الخاص</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">اليد الواحدة</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">الوضع الخاص</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">الشريط الذكـي</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">زر الشريط الذكي</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">اللون الأساسي</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">يتم تطبيقه على تموج علامة تبويب الوسائط الرئيسية وإبراز الاختيار</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">اللون الأساسي (داكن)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">غير مستخدم حاليا ، محجوز للتنفيذ المستقبلي</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">لون التمييز</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">يتم تطبيقه على علامة تبويب الإيموجي</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">لون شريط التصفّح</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">خلفية شريط التصفّح.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">واجهة شريط التصفّح</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">ضبط على التشغيل للواجهة الداكنة أو على إيقاف التشغيل للواجهة الفاتحة.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">إطار المفتاح</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">اضبط على التفعيل لإظهار الإطار أو على الإيقاف لإخفائه</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">زر الشريط الذكي</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">اللون الأساسي</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">اللون الأساسي (داكن)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">لون التمييز</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">لون شريط التصفّح</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">واجهة شريط التصفّح</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">إطار المفتاح</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">تفضيلات لوحة المفاتيح</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">المفاتيح</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">صف الأعداد</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -60,34 +60,23 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Tento podtyp již existuje!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Motiv klávesnice</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Definován</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Pozadí</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Barva pozadí při aktivní</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Barva pozadí při stisknutí</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Barva popředí</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Barva popředí (alternativní)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Barva popředí (caps lock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Vyberte barvu</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Pozadí</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Barva pozadí při aktivní</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Barva pozadí při stisknutí</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Barva popředí</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Barva popředí (alternativní)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Okno &amp; systém</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Klávesnice</string>
     <string name="settings__theme__group_key" comment="Theme group label">Klíč</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Klávesa</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Vyskakovací okno klíče</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Shift</string>
     <string name="settings__theme__group_media" comment="Theme group label">Mediální kontext</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Jednoruční</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Tlačítko s jednou rukou</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Jednoruční</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Smartbar</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Tlačítko Smartbar</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Primární barva</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Aplikováno na hlavní kartu Media ripple a zvýraznění výběru</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Primární barva (tmavá)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">V současné době se nepoužívá, vyhrazeno pro budoucí implementaci</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Barva přízvuku</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Aplikováno na kartu Emoji ripple</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Barva navigačního panelu</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">Pozadí navigační lišty.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Navigační lišta tmavé popředí</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Nastavte na Zapnuto pro tmavé nebo vypnuté pro světlé popředí.</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Tlačítko Smartbar</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Primární barva</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Primární barva (tmavá)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Barva přízvuku</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Barva navigačního panelu</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Navigační lišta tmavé popředí</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Předvolby Klávesnice</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Šipka</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Multiplikátor velikosti písma (portrét)</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -64,26 +64,20 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Dette undertastatur findes allerede!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tastaturtema</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Ikke defineret</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Baggrundsfarve</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Baggrundsfarve når aktiv</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Baggrundsfarve ved tryk</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Forgrundsfarve</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Forgrundsfarve (alternativ)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Forgrundsfarve (caps lock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Vælg en farve</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Baggrundsfarve</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Baggrundsfarve når aktiv</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Baggrundsfarve ved tryk</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Forgrundsfarve</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Forgrundsfarve (alternativ)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Vindue &amp; System</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Tastatur</string>
     <string name="settings__theme__group_key" comment="Theme group label">Tast</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Enter-tast</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Tast popup</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Shift-tast</string>
     <string name="settings__theme__group_media" comment="Theme group label">Mediekontekst</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">En-håndstilstand</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">En-håndstilstand knap</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Privattilstand</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">En-håndstilstand</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Privattilstand</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">SmartBjælke</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Smartbjælke knap</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Primær farve</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Smartbjælke knap</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Primær farve</string>
     <string name="pref__keyboard__height_factor__normal" comment="Preference value">Normal</string>
     <string name="pref__keyboard__height_factor__mid_tall" comment="Preference value">Middel-høj</string>
     <string name="pref__keyboard__height_factor__tall" comment="Preference value">Høj</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Dieser Eingabestil ist bereits vorhanden!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tastaturdesign</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Nicht definiert</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Hintergrundfarbe</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Hintergrundfarbe wenn aktiv</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Hintergrundfarbe wenn gedrückt</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Vordergrundfarbe</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Vordergrundfarbe (Alternativ)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Vordergrundfarbe (Umschalttaste festgestellt)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Farbe wählen</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Hintergrundfarbe</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Hintergrundfarbe wenn aktiv</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Hintergrundfarbe wenn gedrückt</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Vordergrundfarbe</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Vordergrundfarbe (Alternativ)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Fenster &amp; System</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Tastatur</string>
     <string name="settings__theme__group_key" comment="Theme group label">Taste</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Eingabetaste</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Tasten Pop-Up</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Umschalttaste</string>
     <string name="settings__theme__group_media" comment="Theme group label">Medienkontext</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Einhandmodus</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Einhandmodus Schalter</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Privater Modus</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Einhandmodus</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Privater Modus</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Schnellzugriffsleiste</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Schnellzugriffsleiste Schalter</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Hauptfarbe</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Wird auf Medien-Reiter und aktuelle Auswahl angewandt</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Hauptfarbe (dunkel)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Zurzeit nicht in Benutzung, für zukünftige Funktionen reserviert</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Akzentfarbe</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Wird auf den Emoji-Reiter angewandt</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Farbe der Navigationsleiste</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">Der Hintergrund der Navigationsleiste.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Dunkler Vordergrund der Navigationsleiste</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">EIN für dunklen oder AUS für hellen Vordergrund.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Umrandung der Tasten</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Stellen Sie auf AN, um den Rand anzuzeigen, oder AUS, um ihn auszublenden</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Schnellzugriffsleiste Schalter</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Hauptfarbe</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Hauptfarbe (dunkel)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Akzentfarbe</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Farbe der Navigationsleiste</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Dunkler Vordergrund der Navigationsleiste</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Umrandung der Tasten</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Tastatur-Einstellungen</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Tasten</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Zahlenreihe</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Αυτός ο υποτύπος υπάρχει ήδη!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Θέμα πληκτρολογίου</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Μη ορισμένο</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Χρώμα φόντου</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Χρώμα φόντου όταν είναι ενεργό</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Χρώμα φόντου όταν πατηθεί</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Χρώμα προσκηνίου</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Χρώμα προσκηνίου (εναλλακτικό)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Χρώμα προσκηνίου (κεφαλαία)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Επιλέξτε ένα χρώμα</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Χρώμα φόντου</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Χρώμα φόντου όταν είναι ενεργό</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Χρώμα φόντου όταν πατηθεί</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Χρώμα προσκηνίου</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Χρώμα προσκηνίου (εναλλακτικό)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Παράθυρο &amp; Σύστημα</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Πληκτρολόγιο</string>
     <string name="settings__theme__group_key" comment="Theme group label">Πλήκτρο</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Πλήκτρο εισαγωγής</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Εμφάνιση πλήκτρων</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Πλήκτρο κεφαλαίων</string>
     <string name="settings__theme__group_media" comment="Theme group label">Περιεχόμενο μέσων</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Με το ένα χέρι</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Πλήκτρο λειτουργίας ενός-χεριού</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Ιδιωτική λειτουργία</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Με το ένα χέρι</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Ιδιωτική λειτουργία</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Έξυπνη Μπάρα</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Πλήκτρο έξυπνης μπάρας</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Κυρίως χρώμα</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Εφαρμόζεται στην μπάρα κυματισμού των κυρίως μέσων και στην επισήμανση επιλογής</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Κυρίως χρώμα (σκούρο)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Δεν χρησιμοποιείται προς το παρόν, δεσμευμένο για μελλοντική εφαρμογή</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Χρώμα έμφασης</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Εφαρμόζεται στον κυματισμό μπάρας των emoji</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Χρώμα μπάρας πλοήγησης</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">To φόντο της μπάρας πλοήγησης.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Σκούρο προσκήνιο μπάρας πλοήγησης</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Ορίστε ΕΝΕΡΓΟΠΟΙΗΜΈΝΟ για σκούρο ή ΑΠΕΝΕΡΓΟΠΟΙΗΜΈΝΟ για φωτεινό προσκήνιο.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Περίγραμμα Πλήκτρου</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Ενεργοποιείστε για εμφάνιση των περιγραμμάτων ή απενεργοποιείστε για απόκρυψη</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Πλήκτρο έξυπνης μπάρας</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Κυρίως χρώμα</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Κυρίως χρώμα (σκούρο)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Χρώμα έμφασης</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Χρώμα μπάρας πλοήγησης</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Σκούρο προσκήνιο μπάρας πλοήγησης</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Περίγραμμα Πλήκτρου</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Προτιμήσεις Πληκτρολογίου</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Πλήκτρα</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Σειρά αριθμών</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -44,12 +44,11 @@
     <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Klavaro</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Klavaro etoso</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Nedifinita</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Fona koloro</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Fona koloro kiam aktiva</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Fona koloro kiam depremos</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Malfona koloro</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Malfona koloro (alternativo)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Malfona koloro (fiksiĝema ĉeflitera registrumo)</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Fona koloro</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Fona koloro kiam aktiva</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Fona koloro kiam depremos</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Malfona koloro</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Malfona koloro (alternativo)</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Klavaro</string>
     <string name="settings__theme__group_key" comment="Theme group label">Klavo</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Klavaro agordoj</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">¡Este subtipo ya existe!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tema de teclado</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Sin definir</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Color de fondo</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Color de fondo cuando está activo</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Color de fondo cuando está pulsado</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Color principal</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Color principal (alternativo)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Color principal (bloqueo de mayúsculas)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Seleccionar un color</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Color de fondo</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Color de fondo cuando está activo</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Color de fondo cuando está pulsado</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Color principal</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Color principal (alternativo)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Ventana y sistema</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Teclado</string>
     <string name="settings__theme__group_key" comment="Theme group label">Tecla</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Tecla Intro</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Tecla emergente</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Tecla Shift</string>
     <string name="settings__theme__group_media" comment="Theme group label">Contexto de multimedia</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">A una mano</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Botón a una mano</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Modo privado</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">A una mano</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Modo privado</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Barra inteligente</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Bóton de barra inteligente</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Color principal</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Aplicado al indicador de la pestaña principal de multimedia y al resaltado de la selección</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Color principal (oscuro)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Actualmente no se utiliza, reservado para su futura aplicación</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Color de acento</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Aplicado al indicador de la pestaña de los emojis</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Color de la barra de navegación</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">El fondo de la barra de navegación.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Color principal oscuro de la barra de navegación</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Establecer en ENCENDIDO para el oscuro o en APAGADO para el claro en el color principal.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Borde de la tecla</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Establecer en ENCENDIDO para mostrar el borde o en APAGADO para ocultarlo</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Bóton de barra inteligente</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Color principal</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Color principal (oscuro)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Color de acento</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Color de la barra de navegación</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Color principal oscuro de la barra de navegación</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Borde de la tecla</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Preferencias de teclado</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Teclas</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Número de filas</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -51,22 +51,16 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">این زیرنوع درحال حاضر وجود دارد!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">طرح زمینه صفحه کلید</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">تعریف نشده</string>
-    <string name="settings__theme__background" comment="General label for a background preference">رنگ پس‌زمینه</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">رنگ پس‌زمینه هنگامی که فعال است</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">رنگ پس‌زمینه هنگامی که انتخاب شود</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">رنگ روی‌زمینه</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">رنگ روی‌زمینه (جایگزین)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">رنگ روی‌زمینه (caps lock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">انتخاب یک رنگ</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">رنگ پس‌زمینه</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">رنگ پس‌زمینه هنگامی که فعال است</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">رنگ پس‌زمینه هنگامی که انتخاب شود</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">رنگ روی‌زمینه</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">رنگ روی‌زمینه (جایگزین)</string>
     <string name="settings__theme__group_window" comment="Theme group label">پنجره &amp; سیستم</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">صفحه‌کلید</string>
     <string name="settings__theme__group_key" comment="Theme group label">کلید</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">کلید را وارد کنید</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">پاپ‌آپ کلید</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">کلید Shift</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">حالت خصوصی</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">حاشیه کلید</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">روی روشن بزارید تا حاشیه را نمایش دهد یا روی خاموش بزنید تا مخفی‌اش کند</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">حالت خصوصی</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">حاشیه کلید</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">تنظیمات صفحه‌کلید</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">کلیدها</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">ردیف عدد</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -60,34 +60,23 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Tämä asettelu on jo lisätty!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Näppäimistön teema</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Ei määritelty</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Taustaväri</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Taustaväri aktiivisena</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Taustaväri painettuna</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Merkin väri</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Merkin väri (vaihtoehtoinen)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Merkin väri (caps lock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Valitse väri</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Taustaväri</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Taustaväri aktiivisena</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Taustaväri painettuna</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Merkin väri</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Merkin väri (vaihtoehtoinen)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Ikkuna &amp; järjestelmä</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Näppäimistö</string>
     <string name="settings__theme__group_key" comment="Theme group label">Painike</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Enter-painike</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Painikkeen ponnahdus</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Shift-painike</string>
     <string name="settings__theme__group_media" comment="Theme group label">Mediakonteksti</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Yksikätinen</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Yksikätisyyspainike</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Yksikätinen</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Älypalkki</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Älypalkin painike</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Ensisijainen väri</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Sovelletaan tärkein media välilehti aaltoilu ja valinta korosta</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Ensisijainen väri (tumma teema)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Ei toistaiseksi käytössä, valmiina tulevia toimintoja varten</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Aksenttiväri</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Sovellettu emoji-välilehteen ripple</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Navigointipalkin väri</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">Navigointipalkin tausta.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Navigointipalkin tummat painikkeet</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Aseta päälle tummia tai pois päältä vaaleita painikkeita varten.</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Älypalkin painike</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Ensisijainen väri</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Ensisijainen väri (tumma teema)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Aksenttiväri</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Navigointipalkin väri</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Navigointipalkin tummat painikkeet</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Näppäimistön asetukset</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Painikkeet</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Fonttikoon kerroin (pystysuunnassa)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Cette disposition existe déjà !</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Thème du clavier</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Non défini</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Couleur d\'arrière-plan</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Couleur d\'arrière-plan lorsque actif</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Couleur d\'arrière-plan lorsqu\'on appuie sur une touche</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Couleur du premier plan</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Couleur d\'avant-plan (alternative)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Couleur d\'avant-plan (verrouillage des majuscules)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Sélectionnez une couleur</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Couleur d\'arrière-plan</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Couleur d\'arrière-plan lorsque actif</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Couleur d\'arrière-plan lorsqu\'on appuie sur une touche</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Couleur du premier plan</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Couleur d\'avant-plan (alternative)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Fenêtre &amp; Système</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Clavier</string>
     <string name="settings__theme__group_key" comment="Theme group label">Touche</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">La touche Entrer</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Pop-up de touche</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">La touche Maj</string>
     <string name="settings__theme__group_media" comment="Theme group label">Contexte médiatique</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">À une main</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Bouton à une main</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Mode privé</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">À une main</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Mode privé</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Barre intelligente</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Bouton de la barre intelligente</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Couleur primaire</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Appliqué à la sélection et à l\'ondulation de l\'onglet principal des médias</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Couleur primaire (sombre)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Non utilisé actuellement, réservé pour une implémentation future</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Couleur d\'accentuation</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Appliqué à l\'ondulation de l\'onglet emoji</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Couleur de la barre de navigation</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">L\'arrière-plan de la barre de navigation.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Avant-plan sombre de la barre de navigation</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Réglez sur ON pour sombre ou sur OFF pour clair en avant-plan.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Bordure des touches</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Réglez sur ON pour montrer la bordure ou sur OFF pour la cacher</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Bouton de la barre intelligente</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Couleur primaire</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Couleur primaire (sombre)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Couleur d\'accentuation</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Couleur de la barre de navigation</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Avant-plan sombre de la barre de navigation</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Bordure des touches</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Préférences de clavier</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Touches</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Rangée de numéros</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">תת הסוג הזה כבר קיים!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">ערכת נושא של המקלדת</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">לא מוגדר</string>
-    <string name="settings__theme__background" comment="General label for a background preference">צבע רקע</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">צבע הרקע כאשר מופעל</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">צבע הרקע כאשר מקש נלחץ</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">צבע רקע קדמי</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">צבע רקע קדמי (אלטרנטיבי)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">צבע קדמי (Caps lock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">בחר צבע</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">צבע רקע</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">צבע הרקע כאשר מופעל</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">צבע הרקע כאשר מקש נלחץ</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">צבע רקע קדמי</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">צבע רקע קדמי (אלטרנטיבי)</string>
     <string name="settings__theme__group_window" comment="Theme group label">חלון ומערכת</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">מקלדת</string>
     <string name="settings__theme__group_key" comment="Theme group label">מקש</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">מקש Enter</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">חלונית מקש</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">מקש Shift</string>
     <string name="settings__theme__group_media" comment="Theme group label">אזור המֶדְיָה</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">ביד אחת</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">כפתור יד אחת</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">מצב פרטיות</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">ביד אחת</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">מצב פרטיות</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">שורה חכמה</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">כפתור שורה חכמה</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">צבע ראשי</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">מיושם על לשונית המדיה העיקרית ועל סממן הבחירה</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">צבע ראשי (כהה)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">כרגע לא בשימוש, עם זאת שמור עבור מימוש עתידי</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">צבע הדגשה</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">מיושם על לשונית האימוג\'י</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">צבע סרגל הניווט</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">צבע הרקע של סרגל הניווט.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">סרגל ניווט בעל רקע קדמי כהה</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">הגדר דלוק עבור כהה או לחילופין כבוי עבור רקע קדמי בהיר.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">גבולות מקשים</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">הגדר דלוק כדי להציג גבולות מקשים או לחילופין כבוי כדי להחביא אותם</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">כפתור שורה חכמה</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">צבע ראשי</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">צבע ראשי (כהה)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">צבע הדגשה</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">צבע סרגל הניווט</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">סרגל ניווט בעל רקע קדמי כהה</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">גבולות מקשים</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">העדפות מקלדת</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">מקשים</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">שורת המספרים</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Ez az altípus már létezik!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Billentyűzet téma</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Nem meghatározott</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Háttérszín</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Aktív háttérszín</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Lenyomott háttérszín</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Előtérszín</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Előtérszín (alternatív)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Előtérszín (caps lock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Szín kiválasztása</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Háttérszín</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Aktív háttérszín</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Lenyomott háttérszín</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Előtérszín</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Előtérszín (alternatív)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Ablak és rendszer</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Billentyűzet</string>
     <string name="settings__theme__group_key" comment="Theme group label">Billentyű</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Enter billentyű</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Felugró billentyű</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Shift billentyű</string>
     <string name="settings__theme__group_media" comment="Theme group label">Média kontextus</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Egykezes</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Egykezes gomb</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Privát mód</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Egykezes</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Privát mód</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Okossáv</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Okossáv gomb</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Elsődleges szín</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Alkalmazva a fő média lapokra és a kiemelés színének</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Elsődleges szín (sötét)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Jelenleg nincs használva, fenntartva jövőbeli megvalósításra</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Kiemelés színe</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Alkalmazva az emoji lapokra</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Navigációs sáv színe</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">A navigációs sáv háttere.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Navigációs sáv sötét előtér</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Kapcsolja BE sötét, KI világos előtérszínhez.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Billentyű szegélye</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Kapcsolja BE a szegély megjelenítéséhez vagy KI az elrejtéséhez</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Okossáv gomb</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Elsődleges szín</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Elsődleges szín (sötét)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Kiemelés színe</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Navigációs sáv színe</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Navigációs sáv sötét előtér</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Billentyű szegélye</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Billentyűzet beállítások</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Billentyűk</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Számsor</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Questo stile di input esiste già !</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tema tastiera</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Sconosciuto</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Colore di sfondo</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Colore di sfondo quando attivo</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Colore di sfondo quando premuto</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Colore di primo piano</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Colore di primo piano (alternativo)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Colore di primo piano (maiuscolo)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Seleziona un colore</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Colore di sfondo</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Colore di sfondo quando attivo</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Colore di sfondo quando premuto</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Colore di primo piano</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Colore di primo piano (alternativo)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Finestra &amp; Sistema</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Tastiera</string>
     <string name="settings__theme__group_key" comment="Theme group label">Tasto</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Inserisci tasto</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Popup tasto</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Tasto Shift</string>
     <string name="settings__theme__group_media" comment="Theme group label">Contesto multimediale</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Una mano</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Pulsante una mano</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Modalità Privata</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Una mano</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Modalità Privata</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Smartbar</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Pulsante smartbar</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Colore primario</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Applicato alla tab principale e alla selezione</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Colore primario (scuro)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Attualmente non utilizzato, riservato per implementazioni future</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Colore di accento</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Applicato alla tab delle emoji</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Colore della barra di navigazione</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">Il colore di sfondo della barra di navigazione.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Colore scuro di primo piano della barra di navigazione</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Imposta a ON per un colore di primo piano scuro e OFF per uno chiaro.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Bordo dei tasti</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Imposta a ON per mostrare il bordo e ad OFF per nasconderlo</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Pulsante smartbar</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Colore primario</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Colore primario (scuro)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Colore di accento</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Colore della barra di navigazione</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Colore scuro di primo piano della barra di navigazione</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Bordo dei tasti</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Tastiera preferenze</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Tasti</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Barra numerica</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -108,37 +108,25 @@
     <string name="settings__theme_editor__error_group_name_empty" comment="Error text for an empty group name">تکایە ناوی گرووپ بنوسە</string>
     <string name="settings__theme_editor__error_attr_name" comment="Error text for an invalid attribute name">تکایە ناوی تایبەتمەندی بنووسە کە تەنها پیتەکانی a-z و/یان A-Z ی تێدا بێت.</string>
     <string name="settings__theme_editor__error_attr_name_empty" comment="Error text for an empty attribute name">تکایە ناوی تایبەتمەندی بنوسە</string>
-    <string name="settings__theme__background" comment="General label for a background preference">ڕەنگی پشتتەوە</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">ڕەنگی پشت شاشە لەکاتی چالاکبوندا</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">ڕەنگی پشت شاشە لەکاتی دەستلێدان</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">ڕەنگی پێشەوە</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">ڕەنگی پێشەوە (جێگرەوە)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">ڕەنگی پێشەوە (قوفڵی caps)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">ڕەنگێک هەڵبژێرە</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">ڕەنگی پشتتەوە</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">ڕەنگی پشت شاشە لەکاتی چالاکبوندا</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">ڕەنگی پشت شاشە لەکاتی دەستلێدان</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">ڕەنگی پێشەوە</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">ڕەنگی پێشەوە (جێگرەوە)</string>
     <string name="settings__theme__group_window" comment="Theme group label">ڕووکەش</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">تەختەکلیل</string>
     <string name="settings__theme__group_key" comment="Theme group label">دوگمە</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">دوگمەی ئینتەر</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">دوگمەی بچوککراوە</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">دوگمەی شێفت</string>
     <string name="settings__theme__group_media" comment="Theme group label">لیستی میدیا</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">بەکارهێنان بە یەک دەست</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">دوگمەی بەکارهێنانی یەک دەست</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">دۆخی تایبەت</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">بەکارهێنان بە یەک دەست</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">دۆخی تایبەت</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">ڕەنگی بەشی سەرەوە</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">ڕەنگی دوگمەکانی بەشی سەرەوە</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">ڕەنگی بنەڕەتی</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">جێبەجێ کراوە بۆ بەشی میدیای سەرەکی شەپۆل و تیشکخستنەسەر هەڵبژاردنەکان</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">ڕەنگی بنەڕەتی (تاریک)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">لە ئێستادا بەردەست نییە، دنراوە بۆ جێبەجێکردنی داهاتوو</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">ڕەنگی دووەم</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">جێبەجێ کراوە بۆ بەشی خەندەکان</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">ڕەنگی بەشی خوارەوە</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">پشت شاشەی بەشی خوارەوە</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">پشت شاشەی تاریکی بەشی خوارەوە</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">بۆ تاریک کردن یان بۆ کوژاندنەوەی بۆ ڕووناککردنی پێشگرەکە</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">لێواری دوگمەکان</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">چالاککردن واتە پیشاندانی لێوار یان نا چالاک نۆ شاردنەوە</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">ڕەنگی دوگمەکانی بەشی سەرەوە</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">ڕەنگی بنەڕەتی</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">ڕەنگی بنەڕەتی (تاریک)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">ڕەنگی دووەم</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">ڕەنگی بەشی خوارەوە</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">پشت شاشەی تاریکی بەشی خوارەوە</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">لێواری دوگمەکان</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">ڕێکخستنی تەختەکلیل</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">دوگمەکان</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">لیستی ژمارەکان</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Deze indeling bestaat al!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Toetsenbordthema</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Ongedefinieerd</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Achtergrondkleur</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Achtergrondkleur wanneer actief</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Achtergrondkleur wanneer ingedrukt</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Voorgrondkleur</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Voorgrondkleur (alternatief)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Voorgrondkleur (CapsLock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Selecteer een kleur</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Achtergrondkleur</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Achtergrondkleur wanneer actief</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Achtergrondkleur wanneer ingedrukt</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Voorgrondkleur</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Voorgrondkleur (alternatief)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Venster &amp; Systeem</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Toetsenbord</string>
     <string name="settings__theme__group_key" comment="Theme group label">Toets</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Entertoets</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Sleutel pop-up</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Shift</string>
     <string name="settings__theme__group_media" comment="Theme group label">Mediacontext</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Met één hand</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Knop met één hand</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Privémodus</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Met één hand</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Privémodus</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Slimme Balk</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Slimme Balk bewerken</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Hoofdkleur</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Toegepast op de hoofd Media tab-aanduiding en selectiemarkering</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Primaire kleur (Donker)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Momenteel niet gebruikt, gereserveerd voor toekomstige implementatie</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Accentkleur</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Toegepast op emoji tab-aanduiding</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Kleur navigatiebalk</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">De achtergrondkleur van de navigatiebalk.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Navigatiebalk donkere voorgrond</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Zet AAN voor donkere of UIT voor lichte voorgrond.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Knoprand</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Zet AAN om de knoprand te tonen of UIT om te verbergen</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Slimme Balk bewerken</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Hoofdkleur</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Primaire kleur (Donker)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Accentkleur</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Kleur navigatiebalk</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Navigatiebalk donkere voorgrond</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Knoprand</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Toetsenbordvoorkeuren</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Toetsen</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Nummerrij</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Este formato de digitação já existe!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tema do teclado</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Indefinido</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Cor do plano de fundo</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Cor do plano de fundo quando ativa</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Cor do plano fundo quando pressionada</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Cor do primeiro plano</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Cor do primeiro plano (alternativa)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Cor do primeiro plano (caps lock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Selecionar uma cor</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Cor do plano de fundo</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Cor do plano de fundo quando ativa</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Cor do plano fundo quando pressionada</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Cor do primeiro plano</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Cor do primeiro plano (alternativa)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Janela &amp; Sistema</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Teclado</string>
     <string name="settings__theme__group_key" comment="Theme group label">Tecla</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Tecla Enter</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Popup da tecla</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Tecla Shift</string>
     <string name="settings__theme__group_media" comment="Theme group label">Contexto de mídia</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Modo uma mão</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Botões do modo uma mão</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Modo privado</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Modo uma mão</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Modo privado</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Barra inteligente</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Botão da barra inteligente</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Cor primária</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Aplicado à barra de indicação da aba de mídia principal e destaque de seleção</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Cor primária (escuro)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Atualmente não utilizado, reservado para implementação futura</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Cor de destaque</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Aplicado à barra de indicação da aba emoji</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Cor da barra de navegação</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">O plano de fundo da barra de navegação.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Barra de navegação escura em primeiro plano</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Ligue para escurecer ou desligue para clarear o primeiro plano.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Borda das Teclas</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Ligue para mostrar as bordas e desligue para ocultá-las</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Botão da barra inteligente</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Cor primária</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Cor primária (escuro)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Cor de destaque</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Cor da barra de navegação</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Barra de navegação escura em primeiro plano</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Borda das Teclas</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Preferências do Teclado</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Teclas</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Linha de números</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -64,37 +64,25 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Este subtipo já existe!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tema do teclado</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Indefinido</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Cor de fundo</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Cor de fundo quando ativo</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Cor de fundo quando premida</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Cor principal</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Cor principal (alternativa)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Cor principal (CapsLock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Selecione uma cor</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Cor de fundo</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Cor de fundo quando ativo</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Cor de fundo quando premida</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Cor principal</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Cor principal (alternativa)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Janela e sistema</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Teclado</string>
     <string name="settings__theme__group_key" comment="Theme group label">Tecla</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Tecla Enter</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Ampliação de teclas</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Tecla Shift</string>
     <string name="settings__theme__group_media" comment="Theme group label">Contexto multimédia</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Uma mão</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Botão do modo uma mão</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Modo privado</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Uma mão</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Modo privado</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Barra inteligente</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Botão da barra inteligente</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Cor primária</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Aplicada ao separador multimédia e ao destaque de seleção</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Cor primária (escura)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Opção reservada para implementações futuras</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Cor de destaque</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Aplicada ao separador de emojis</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Cor da barra de navegação</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">A cor de fundo da barra de navegação</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Botões da barra de navegação escura</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Ative para usar a cor escura ou desative para cor clara.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Contorno de teclas</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Defina como Ligado para mostrar ou Desligado para ocultar</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Botão da barra inteligente</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Cor primária</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Cor primária (escura)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Cor de destaque</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Cor da barra de navegação</string>
+    <string name="settings__theme__attr_navBarLight" comment="Title of Nav bar is light theme preference">Botões da barra de navegação escura</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Contorno de teclas</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Preferências do teclado</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Teclas</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Linha de números</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -64,34 +64,24 @@
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Этот подтип уже существует!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Тема клавиатуры</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Не определено</string>
-    <string name="settings__theme__background" comment="General label for a background preference">Цвет фона</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Цвет фона когда активно</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Фоновой цвет при нажатии</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Цвет переднего плана</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Цвет переднего плана (другое)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Цвет переднего плана (caps lock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Выберите цвет</string>
+    <string name="settings__theme__attr_background" comment="General label for a background preference">Цвет фона</string>
+    <string name="settings__theme__attr_backgroundActive" comment="General label for an active background preference">Цвет фона когда активно</string>
+    <string name="settings__theme__attr_backgroundPressed" comment="General label for a pressed background preference">Фоновой цвет при нажатии</string>
+    <string name="settings__theme__attr_foreground" comment="General label for a foreground preference">Цвет переднего плана</string>
+    <string name="settings__theme__attr_foregroundAlt" comment="General label for an alternate foreground preference">Цвет переднего плана (другое)</string>
     <string name="settings__theme__group_window" comment="Theme group label">Окно &amp; Система</string>
     <string name="settings__theme__group_keyboard" comment="Theme group label">Клавиатура</string>
     <string name="settings__theme__group_key" comment="Theme group label">Кнопки</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Введите текст сюда</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Открыть поп-ап</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Клавиша регистра</string>
     <string name="settings__theme__group_media" comment="Theme group label">Медиа контекст</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">Одноручный ввод</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">Кнопка одноручного ввода</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Приватный режим</string>
+    <string name="settings__theme__group_oneHanded" comment="Theme group label">Одноручный ввод</string>
+    <string name="settings__theme__group_privateMode" comment="Theme group label">Приватный режим</string>
     <string name="settings__theme__group_smartbar" comment="Theme group label">Умная панель</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Настройки Умной панели</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Основной цвет</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Основной цвет (темный)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">В настоящее время не используется, зарезервировано для будущей реализации</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Цветовой акцент</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Цвет панели навигации</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">Фон панели навигации.</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Установите ON для темного или OFF для светлого режима.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Граница клавиш</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Чтобы показать границы установите ON или OFF чтобы скрыть их</string>
+    <string name="settings__theme__group_smartbarButton" comment="Theme group label">Настройки Умной панели</string>
+    <string name="settings__theme__attr_colorPrimary" comment="Title of Color primary theme preference">Основной цвет</string>
+    <string name="settings__theme__attr_colorPrimaryDark" comment="Title of Color primary dark theme preference">Основной цвет (темный)</string>
+    <string name="settings__theme__attr_colorAccent" comment="Title of Color accent theme preference">Цветовой акцент</string>
+    <string name="settings__theme__attr_navBarColor" comment="Title of Nav bar color theme preference">Цвет панели навигации</string>
+    <string name="settings__theme__attr_showBorder" comment="Title of Show Key Border preference">Граница клавиш</string>
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Настройки клавиатуры</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Клавиши</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Строка цифр</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,40 +119,38 @@
     <string name="settings__theme_editor__error_theme_label_empty" comment="Error text for an empty theme label">Please enter a theme name.</string>
     <string name="settings__theme_editor__error_group_name" comment="Error text for an invalid group name">Please enter a group name which only contain letters (a–z and/or A–Z), colons (:) for sub–grouping or additionally numbers (0–9), tilde (~) and underlines (_) for the key label.</string>
     <string name="settings__theme_editor__error_group_name_empty" comment="Error text for an empty group name">Please enter a group name.</string>
+    <string name="settings__theme_editor__error_group_name_already_exists" comment="Error text for a duplicate group name">This group name already exists within this theme. Please choose another one.</string>
     <string name="settings__theme_editor__error_attr_name" comment="Error text for an invalid attribute name">Please enter an attribute name which only contain the letters a-z and/or A-Z.</string>
     <string name="settings__theme_editor__error_attr_name_empty" comment="Error text for an empty attribute name">Please enter an attribute name.</string>
+    <string name="settings__theme_editor__error_attr_name_already_exists" comment="Error text for a duplicate attribute name">This attribute name already exists within this group. Please specify another one.</string>
 
-    <string name="settings__theme__background" comment="General label for a background preference">Background color</string>
-    <string name="settings__theme__background_active" comment="General label for an active background preference">Background color when active</string>
-    <string name="settings__theme__background_pressed" comment="General label for a pressed background preference">Background color when pressed</string>
-    <string name="settings__theme__foreground" comment="General label for a foreground preference">Foreground color</string>
-    <string name="settings__theme__foreground_alt" comment="General label for an alternate foreground preference">Foreground color (alternative)</string>
-    <string name="settings__theme__foreground_capslock" comment="General label for a capslock foreground preference">Foreground color (caps lock)</string>
-    <string name="settings__theme__dialog_title" comment="Title of the color selection dialog for a single theme preference">Select a color</string>
-    <string name="settings__theme__group_window" comment="Theme group label">Window &amp; System</string>
-    <string name="settings__theme__group_keyboard" comment="Theme group label">Keyboard</string>
-    <string name="settings__theme__group_key" comment="Theme group label">Key</string>
-    <string name="settings__theme__group_key_enter" comment="Theme group label">Enter key</string>
-    <string name="settings__theme__group_key_popup" comment="Theme group label">Key popup</string>
-    <string name="settings__theme__group_key_shift" comment="Theme group label">Shift key</string>
-    <string name="settings__theme__group_media" comment="Theme group label">Media context</string>
-    <string name="settings__theme__group_one_handed" comment="Theme group label">One-handed</string>
-    <string name="settings__theme__group_one_handed_button" comment="Theme group label">One-handed button</string>
-    <string name="settings__theme__group_private_mode" comment="Theme group label">Private mode</string>
-    <string name="settings__theme__group_smartbar" comment="Theme group label">Smartbar</string>
-    <string name="settings__theme__group_smartbar_button" comment="Theme group label">Smartbar button</string>
-    <string name="pref__theme__colorPrimary_title" comment="Title of Color primary theme preference">Primary color</string>
-    <string name="pref__theme__colorPrimary_summary" comment="Summary of Color primary theme preference">Applied to main media tab ripple and selection highlight</string>
-    <string name="pref__theme__colorPrimaryDark_title" comment="Title of Color primary dark theme preference">Primary color (dark)</string>
-    <string name="pref__theme__colorPrimaryDark_summary" comment="Summary of Color primary dark theme preference">Currently not used, reserved for future implementation</string>
-    <string name="pref__theme__colorAccent_title" comment="Title of Color accent theme preference">Accent color</string>
-    <string name="pref__theme__colorAccent_summary" comment="Summary of Color accent theme preference">Applied to emoji tab ripple</string>
-    <string name="pref__theme__navBarColor_title" comment="Title of Nav bar color theme preference">Navigation bar color</string>
-    <string name="pref__theme__navBarColor_summary" comment="Summary of Nav bar color theme preference">The background of the navigation bar.</string>
-    <string name="pref__theme__navBarIsLight_title" comment="Title of Nav bar is light theme preference">Navigation bar dark foreground</string>
-    <string name="pref__theme__navBarIsLight_summary" comment="Summary of Nav bar is light theme preference">Set to ON for dark or to OFF for light foreground.</string>
-    <string name="pref__theme__showKeyBorder_title" comment="Title of Show Key Border preference">Key Border</string>
-    <string name="pref__theme__showKeyBorder_summary" comment="Summary of Show Key Border preference">Set to ON to show border or to OFF to hide it</string>
+    <string name="settings__theme__group_window"                comment="Theme group label">Window &amp; System</string>
+    <string name="settings__theme__group_keyboard"              comment="Theme group label">Keyboard</string>
+    <string name="settings__theme__group_key"                   comment="Theme group label">Key</string>
+    <string name="settings__theme__group_key_specific"          comment="Theme group label (%s is specific modifier)">Key (%s)</string>
+    <string name="settings__theme__group_media"                 comment="Theme group label">Media context</string>
+    <string name="settings__theme__group_oneHanded"             comment="Theme group label">One-handed</string>
+    <string name="settings__theme__group_popup"                 comment="Theme group label">Popup</string>
+    <string name="settings__theme__group_privateMode"           comment="Theme group label">Private mode</string>
+    <string name="settings__theme__group_smartbar"              comment="Theme group label">Smartbar</string>
+    <string name="settings__theme__group_smartbarButton"        comment="Theme group label">Smartbar button</string>
+    <string name="settings__theme__group_custom"                comment="Theme group label (%s is custom group name)">Custom group (%s)</string>
+
+    <string name="settings__theme__attr_background"             comment="Theme attribute label">Background color</string>
+    <string name="settings__theme__attr_backgroundActive"       comment="Theme attribute label">Background color (active)</string>
+    <string name="settings__theme__attr_backgroundPressed"      comment="Theme attribute label">Background color (pressed)</string>
+    <string name="settings__theme__attr_foreground"             comment="Theme attribute label">Foreground color</string>
+    <string name="settings__theme__attr_foregroundAlt"          comment="Theme attribute label">Foreground color (alternative)</string>
+    <string name="settings__theme__attr_foregroundPressed"      comment="Theme attribute label">Foreground color (pressed)</string>
+    <string name="settings__theme__attr_showBorder"             comment="Theme attribute label">Show border</string>
+    <string name="settings__theme__attr_colorPrimary"           comment="Theme attribute label">Primary color</string>
+    <string name="settings__theme__attr_colorPrimaryDark"       comment="Theme attribute label">Primary color (dark)</string>
+    <string name="settings__theme__attr_colorAccent"            comment="Theme attribute label">Accent color</string>
+    <string name="settings__theme__attr_navBarColor"            comment="Theme attribute label">Navigation bar color</string>
+    <string name="settings__theme__attr_navBarLight"            comment="Theme attribute label">Navigation bar dark foreground</string>
+    <string name="settings__theme__attr_semiTransparentColor"   comment="Theme attribute label">Semi transparent color</string>
+    <string name="settings__theme__attr_textColor"              comment="Theme attribute label">Text color</string>
+    <string name="settings__theme__attr_custom"                 comment="Theme attribute label (%s is custom attribute name)">Custom attribute (%s)</string>
 
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Keyboard Preferences</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Keys</string>


### PR DESCRIPTION
This PR is an attempt at improving the theme editor UI and UX. In detail, this is what changed:

- The theme editor now has a help icon in the top right corner which leads to [this](https://github.com/florisboard/florisboard/wiki/Using-the-new-Theme-Editor) wiki entry. The referenced wiki entry is a guide to better understand some of the more complex things you can do with the theme editor, which may not be known upfront.
- Group name and attribute name inputs now also check if the given name already exists. While this didn't lead to crashes, duplicate attributes and groups overrode each other and created strange results. This is now not possible anymore and eliminates a possible error source.
- The group and attribute names now display localized strings instead of the raw English names. This is especially helpful for non-advanced users on non-English devices, where the feeling is more consistent with the rest of the app. Custom attributes are labeled "Custom" and display the raw English name besides it.
- The default color for a new attribute you create is now solid black (`#FF000000`) instead of transparent (`#00000000`). This improves the process of creating a new color attribute.
- Clean up of the theme string resources.
- Document the `ThemeEditorActivity` class

Closes #222

### Comparison old vs new (on an English device)

Old | New
----|------
![theme_editor_old](https://user-images.githubusercontent.com/19412843/105640241-3cdd6f80-5e7d-11eb-9144-ac3e66766573.jpg) | ![theme_editor_new](https://user-images.githubusercontent.com/19412843/105640246-42d35080-5e7d-11eb-8b6a-68886204f37c.jpg)

