### PR TITLE
Improve adaptive theme / Fix color dialog cache bug in theme editor

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -829,7 +829,11 @@ class KeyView(
                     }
                 }
             }
-            labelPaint.color = themeValueCache.keyForeground.toSolidColor().color
+            labelPaint.color = if (isKeyPressed && isEnabled) {
+                themeValueCache.keyForegroundPressed.toSolidColor().color
+            } else {
+                themeValueCache.keyForeground.toSolidColor().color
+            }
             labelPaint.alpha = if (keyboardView.computedLayout?.mode == KeyboardMode.CHARACTERS &&
                 data.code == KeyCode.SPACE) { 120 } else { 255 }
             val centerX = measuredWidth / 2.0f

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/AdaptiveThemeOverlay.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/AdaptiveThemeOverlay.kt
@@ -16,6 +16,8 @@
 
 package dev.patrickgold.florisboard.ime.theme
 
+import android.graphics.Color
+
 /**
  * Theme overlay class which, if enabled, changes some requested attributes in a Theme and returns
  * the corresponding adaptive color. The adaptive colors itself are determined by the ThemeManager
@@ -29,12 +31,17 @@ class AdaptiveThemeOverlay(
         return when {
             themeManager.isAdaptiveThemeEnabled -> when (ref) {
                 Attr.KEYBOARD_BACKGROUND,
+                Attr.KEY_BACKGROUND_PRESSED,
                 Attr.SMARTBAR_BACKGROUND,
                 Attr.WINDOW_NAVIGATION_BAR_COLOR -> {
                     themeManager.remoteColorPrimaryVariant ?: super.getAttr(ref, s1, s2)
                 }
+                Attr.KEY_FOREGROUND_PRESSED,
                 Attr.SMARTBAR_FOREGROUND -> {
                     themeManager.remoteColorPrimaryVariant?.complimentaryTextColor() ?: super.getAttr(ref, s1, s2)
+                }
+                Attr.SMARTBAR_FOREGROUND_ALT -> {
+                    themeManager.remoteColorPrimaryVariant?.complimentaryTextColor(true) ?: super.getAttr(ref, s1, s2)
                 }
                 Attr.KEY_BACKGROUND,
                 Attr.SMARTBAR_BUTTON_BACKGROUND -> {
@@ -50,6 +57,22 @@ class AdaptiveThemeOverlay(
                     } else {
                         super.getAttr(ref, s1, s2)
                     }
+                }
+                Attr.WINDOW_NAVIGATION_BAR_LIGHT -> {
+                    if (themeManager.remoteColorPrimaryVariant != null) {
+                        ThemeValue.OnOff(themeManager.remoteColorPrimaryVariant?.complimentaryTextColor()?.color == Color.BLACK)
+                    } else {
+                        super.getAttr(ref, s1, s2)
+                    }
+                }
+                Attr.POPUP_BACKGROUND -> {
+                    themeManager.remoteColorSecondary ?: super.getAttr(ref, s1, s2)
+                }
+                Attr.POPUP_BACKGROUND_ACTIVE -> {
+                    themeManager.remoteColorSecondary?.complimentaryTextColor(true) ?: super.getAttr(ref, s1, s2)
+                }
+                Attr.POPUP_FOREGROUND -> {
+                    themeManager.remoteColorSecondary?.complimentaryTextColor() ?: super.getAttr(ref, s1, s2)
                 }
                 else -> super.getAttr(ref, s1, s2)
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeValue.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeValue.kt
@@ -44,13 +44,25 @@ sealed class ThemeValue {
             return super.toString()
         }
 
-        fun complimentaryTextColor(): SolidColor {
-            return if (Color.red(color) * 0.299 + Color.green(color) * 0.587 +
+        fun complimentaryTextColor(isAlt: Boolean = false): SolidColor {
+            val ret = if (Color.red(color) * 0.299 + Color.green(color) * 0.587 +
                 Color.blue(color) * 0.114 > 186) {
-                SolidColor(Color.BLACK)
+                Color.BLACK
             } else {
-                SolidColor(Color.WHITE)
+                Color.WHITE
             }
+            return SolidColor(
+                if (isAlt) {
+                    Color.argb(
+                        0x60,
+                        Color.red(ret),
+                        Color.green(ret),
+                        Color.blue(ret)
+                    )
+                } else {
+                    ret
+                }
+            )
         }
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/components/ThemeAttrView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/components/ThemeAttrView.kt
@@ -160,7 +160,7 @@ class ThemeAttrView : LinearLayout {
                             ThemeValue.Reference("", "")
                         }
                         ThemeValue.SolidColor::class.simpleName -> {
-                            ThemeValue.SolidColor(0)
+                            ThemeValue.SolidColor(Color.BLACK)
                         }
                         ThemeValue.LinearGradient::class.simpleName -> {
                             ThemeValue.LinearGradient(0)
@@ -242,6 +242,8 @@ class ThemeAttrView : LinearLayout {
             is ThemeValue.SolidColor -> {
                 dialogView.attrValueSolidColor.isVisible = true
                 dialogView.attrValueSolidColorInt.text = value.toString()
+                dialogView.attrValueSolidColorEditBtn.background.setTint(value.color)
+                dialogView.attrValueSolidColorEditBtn.drawable.setTint(value.complimentaryTextColor().color)
                 dialogView.attrValueSolidColorEditBtn.setOnClickListener {
                     // Method on how to create a dialog which does not have a listener in the
                     // Activity taken from the original source code for the PreferenceCompat class.
@@ -252,7 +254,9 @@ class ThemeAttrView : LinearLayout {
                     }.create()
                     colorPickerDialog.setColorPickerDialogListener(object : ColorPickerDialogListener {
                         override fun onColorSelected(dialogId: Int, color: Int) {
-                            dialogView.attrValueSolidColorInt.text = ThemeValue.SolidColor(color).toString()
+                            val tempSolidColor = ThemeValue.SolidColor(color)
+                            dialogView.attrValueSolidColorInt.text = tempSolidColor.toString()
+                            configureDialogUi(dialogView, tempSolidColor)
                         }
 
                         override fun onDialogDismissed(dialogId: Int) {

--- a/app/src/main/res/layout/theme_editor_attr_dialog.xml
+++ b/app/src/main/res/layout/theme_editor_attr_dialog.xml
@@ -118,8 +118,9 @@
 
         <ImageButton
             android:id="@+id/attr_value_solid_color_edit_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:background="@drawable/shape_rect_rounded"
             android:src="@drawable/ic_edit"
             android:contentDescription="@string/assets__action__edit"/>
 


### PR DESCRIPTION
This PR improves adaptive themeing and additionally fixes small bugs in the theme engine and editor. In detail, this is what changed:

- The adaptive theme process now is more consistent and checks for the `targetActivity` attribute. Also, if the launch activity has no theme set, the application is checked if a theme is set there. This makes the colors more consistent and for most apps colors are found.
- All parsed colors are forced to be non-transparent to fix issues with see-through keyboards.
- The key `foregroundPressed` attribute is now applied when the key is pressed (was previously ignored in some circumstances).
- The Smartbar `foregroundAlt` attribute now also adapts to the target app theme.
- The navigation bar foreground now also adapts the the background color parsed from the target app.
- Popups now take the `colorAccent` (or for MaterialComponents themes `colorSecondary`) color. This styles the popups (instead of being always grey) and creates more unique styles on a per-app basis.

In general, the adaptive theme process gives good results since this overhaul. Still, there are some apps where the colors are all white/black, etc. and the adaptive theme may not look that good.

Closes #226

Fix that the selection color in the theme editor did not override the cache if the color dialog was reopened before hitting "OK". Additionally, the color edit button's background color now matches the currently cached color. 

Closes #237
