### PR TITLE
Add ability to customize switch key (emoji, language)

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -501,11 +501,28 @@ class FlorisBoard : InputMethodService(), ClipboardManager.OnPrimaryClipChangedL
                 switchToPreviousInputMethod()
             } else {
                 window.window?.let { window ->
+                    @Suppress("DEPRECATION")
                     imeManager?.switchToLastInputMethod(window.attributes.token)
                 }
             }
         } catch (e: Exception) {
             Timber.e(e,"Unable to switch to the previous IME")
+            imeManager?.showInputMethodPicker()
+        }
+    }
+
+    fun switchToNextKeyboard(){
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                switchToNextInputMethod(false)
+            } else {
+                window.window?.let { window ->
+                    @Suppress("DEPRECATION")
+                    imeManager?.switchToNextInputMethod(window.attributes.token, false)
+                }
+            }
+        } catch (e: Exception) {
+            Timber.e(e,"Unable to switch to the next IME")
             imeManager?.showInputMethodPicker()
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -25,6 +25,7 @@ import dev.patrickgold.florisboard.ime.text.gestures.DistanceThreshold
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.gestures.VelocityThreshold
 import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
+import dev.patrickgold.florisboard.ime.text.key.SwitchKeyMode
 import dev.patrickgold.florisboard.ime.theme.ThemeMode
 import dev.patrickgold.florisboard.util.TimeUtil
 import dev.patrickgold.florisboard.util.VersionName
@@ -320,6 +321,7 @@ class PrefHelper(
             const val POPUP_ENABLED =                   "keyboard__popup_enabled"
             const val SOUND_ENABLED =                   "keyboard__sound_enabled"
             const val SOUND_VOLUME =                    "keyboard__sound_volume"
+            const val SWITCH_KEY_MODE =                 "keyboard__switch_key_mode"
             const val VIBRATION_ENABLED =               "keyboard__vibration_enabled"
             const val VIBRATION_STRENGTH =              "keyboard__vibration_strength"
         }
@@ -364,6 +366,9 @@ class PrefHelper(
         var soundVolume: Int = 0
             get() = prefHelper.getPref(SOUND_VOLUME, -1)
             private set
+        var switchKeyMode: SwitchKeyMode
+            get() =  SwitchKeyMode.fromString(prefHelper.getPref(SWITCH_KEY_MODE, SwitchKeyMode.DYNAMIC_LANGUAGE_EMOJI.toString()))
+            set(v) = prefHelper.setPref(SWITCH_KEY_MODE, v)
         var vibrationEnabled: Boolean = false
             get() = prefHelper.getPref(VIBRATION_ENABLED, true)
             private set

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -30,10 +30,7 @@ import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.*
 import dev.patrickgold.florisboard.ime.text.editing.EditingKeyboardView
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
-import dev.patrickgold.florisboard.ime.text.key.KeyCode
-import dev.patrickgold.florisboard.ime.text.key.KeyData
-import dev.patrickgold.florisboard.ime.text.key.KeyType
-import dev.patrickgold.florisboard.ime.text.key.KeyVariation
+import dev.patrickgold.florisboard.ime.text.key.*
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardView
 import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
@@ -448,6 +445,18 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
     }
 
     /**
+     * Handles a [KeyCode.LANGUAGE_SWITCH] event. Also handles if the language switch should cycle
+     * FlorisBoard internal or system-wide.
+     */
+    private fun handleLanguageSwitch() {
+        when (florisboard.prefs.keyboard.switchKeyMode) {
+            SwitchKeyMode.DYNAMIC_LANGUAGE_EMOJI,
+            SwitchKeyMode.ALWAYS_LANGUAGE_INTERNAL -> florisboard.switchToNextSubtype()
+            else -> florisboard.switchToNextKeyboard()
+        }
+    }
+
+    /**
      * Handles a [KeyCode.SHIFT] event.
      */
     private fun handleShift() {
@@ -662,7 +671,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
                 handleEnter()
                 smartbarView?.resetClipboardSuggestion()
             }
-            KeyCode.LANGUAGE_SWITCH -> florisboard.switchToNextSubtype()
+            KeyCode.LANGUAGE_SWITCH -> handleLanguageSwitch()
             KeyCode.SETTINGS -> florisboard.launchSettings()
             KeyCode.SHIFT -> handleShift()
             KeyCode.SHOW_INPUT_METHOD_PICKER -> {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -589,17 +589,31 @@ class KeyView(
         when (data.code) {
             KeyCode.SWITCH_TO_TEXT_CONTEXT,
             KeyCode.SWITCH_TO_MEDIA_CONTEXT -> {
-                visibility = if (florisboard?.shouldShowLanguageSwitch() == true) {
-                    GONE
-                } else {
-                    VISIBLE
+                visibility = when (prefs.keyboard.switchKeyMode) {
+                    SwitchKeyMode.ALWAYS_LANGUAGE_INTERNAL,
+                    SwitchKeyMode.ALWAYS_LANGUAGE_SYSTEM,
+                    SwitchKeyMode.NEVER_SHOW -> GONE
+                    SwitchKeyMode.ALWAYS_EMOJI -> VISIBLE
+                    SwitchKeyMode.DYNAMIC_LANGUAGE_EMOJI ->
+                        if (florisboard?.shouldShowLanguageSwitch() == true) {
+                            GONE
+                        } else {
+                            VISIBLE
+                        }
                 }
             }
             KeyCode.LANGUAGE_SWITCH -> {
-                visibility = if (florisboard?.shouldShowLanguageSwitch() == true) {
-                    VISIBLE
-                } else {
-                    GONE
+                visibility = when (prefs.keyboard.switchKeyMode) {
+                    SwitchKeyMode.ALWAYS_EMOJI,
+                    SwitchKeyMode.NEVER_SHOW -> GONE
+                    SwitchKeyMode.ALWAYS_LANGUAGE_INTERNAL,
+                    SwitchKeyMode.ALWAYS_LANGUAGE_SYSTEM -> VISIBLE
+                    SwitchKeyMode.DYNAMIC_LANGUAGE_EMOJI ->
+                        if (florisboard?.shouldShowLanguageSwitch() == true) {
+                            VISIBLE
+                        } else {
+                            GONE
+                        }
                 }
             }
             else -> if (data.variation != KeyVariation.ALL) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/SwitchKeyMode.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/SwitchKeyMode.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.text.key
+
+import java.util.*
+
+/**
+ * Enum for declaring the switch key modes.
+ */
+enum class SwitchKeyMode {
+    ALWAYS_EMOJI,
+    ALWAYS_LANGUAGE_INTERNAL,
+    ALWAYS_LANGUAGE_SYSTEM,
+    DYNAMIC_LANGUAGE_EMOJI,
+    NEVER_SHOW;
+
+    companion object {
+        fun fromString(string: String): SwitchKeyMode {
+            return valueOf(string.toUpperCase(Locale.ENGLISH))
+        }
+    }
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -45,6 +45,21 @@
         <item>start</item>
     </string-array>
 
+    <string-array name="pref__keyboard__switch_key_mode__entries">
+        <item>@string/pref__keyboard__switch_key_mode__never_show</item>
+        <item>@string/pref__keyboard__switch_key_mode__always_emoji</item>
+        <item>@string/pref__keyboard__switch_key_mode__always_language_internal</item>
+        <item>@string/pref__keyboard__switch_key_mode__always_language_system</item>
+        <item>@string/pref__keyboard__switch_key_mode__dynamic_language_emoji</item>
+    </string-array>
+    <string-array name="pref__keyboard__switch_key_mode__values">
+        <item>never_show</item>
+        <item>always_emoji</item>
+        <item>always_language_internal</item>
+        <item>always_language_system</item>
+        <item>dynamic_language_emoji</item>
+    </string-array>
+
     <string-array name="pref__advanced__settings_theme__entries">
         <item>@string/settings__system_default</item>
         <item>@string/pref__advanced__settings_theme__light</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,12 @@
     <string name="pref__keyboard__hint_mode__enabled_hint_priority" comment="Preference value">Enabled (Hint is prioritized)</string>
     <string name="pref__keyboard__hint_mode__enabled_accent_priority" comment="Preference value">Enabled (Accent is prioritized)</string>
     <string name="pref__keyboard__hint_mode__enabled_smart_priority" comment="Preference value">Enabled (Smart prioritization)</string>
+    <string name="pref__keyboard__switch_key_mode__label" comment="Preference title">Switch key mode</string>
+    <string name="pref__keyboard__switch_key_mode__always_emoji" comment="Preference value">Emoji switch</string>
+    <string name="pref__keyboard__switch_key_mode__always_language_internal" comment="Preference value">Language switch (Internal)</string>
+    <string name="pref__keyboard__switch_key_mode__always_language_system" comment="Preference value">Language switch (System)</string>
+    <string name="pref__keyboard__switch_key_mode__dynamic_language_emoji" comment="Preference value">Dynamic emoji / language switch (Internal)</string>
+    <string name="pref__keyboard__switch_key_mode__never_show" comment="Preference value">Never show switch</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Font size multiplier (portrait)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Font size multiplier (landscape)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Layout</string>

--- a/app/src/main/res/xml/prefs_keyboard.xml
+++ b/app/src/main/res/xml/prefs_keyboard.xml
@@ -31,6 +31,15 @@
             app:title="@string/pref__keyboard__hinted_symbols_mode__label"
             app:useSimpleSummaryProvider="true"/>
 
+        <ListPreference
+            android:defaultValue="dynamic_language_emoji"
+            app:entries="@array/pref__keyboard__switch_key_mode__entries"
+            app:entryValues="@array/pref__keyboard__switch_key_mode__values"
+            app:key="keyboard__switch_key_mode"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__keyboard__switch_key_mode__label"
+            app:useSimpleSummaryProvider="true"/>
+
         <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
             app:allowDividerAbove="false"
             android:defaultValue="100"


### PR DESCRIPTION
This PR adds the ability to customize the switch key (emoji key / language switch key) by setting the `Switch key mode` preference in Settings > Keyboard.

The following modes are available:
- `Never show switch`: Completely disables the switch key and thus expands the space bar.
- `Emoji switch`: Always shows the emoji key.
- `Language switch (Internal)`: Cycles through the FlorisBoard internal subtypes. Note, that this key will not do anything if less or equal than 1 subtype is active in FlorisBoard.
- `Language switch (System)`: Switches to the next system subtype (is a subtype of another keyboard).
- `Dynamic emoji / language switch (Internal)`: Same as the `Language switch (Internal)`, but for the instances where the language switch would do nothing, the emoji key is shown. This is also the default value for this preference.

Closes #79

### Screenshot of the new preference

![switch_key_mode](https://user-images.githubusercontent.com/19412843/105759183-729f5880-5f50-11eb-9f5a-7816ab1ae25f.jpg)
