### PR TITLE
Fix utility key naming

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -25,7 +25,7 @@ import dev.patrickgold.florisboard.ime.text.gestures.DistanceThreshold
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.gestures.VelocityThreshold
 import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
-import dev.patrickgold.florisboard.ime.text.key.SwitchKeyMode
+import dev.patrickgold.florisboard.ime.text.key.UtilityKeyAction
 import dev.patrickgold.florisboard.ime.theme.ThemeMode
 import dev.patrickgold.florisboard.util.TimeUtil
 import dev.patrickgold.florisboard.util.VersionName
@@ -321,7 +321,8 @@ class PrefHelper(
             const val POPUP_ENABLED =                   "keyboard__popup_enabled"
             const val SOUND_ENABLED =                   "keyboard__sound_enabled"
             const val SOUND_VOLUME =                    "keyboard__sound_volume"
-            const val SWITCH_KEY_MODE =                 "keyboard__switch_key_mode"
+            const val UTILITY_KEY_ACTION =              "keyboard__utility_key_action"
+            const val UTILITY_KEY_ENABLED =             "keyboard__utility_key_enabled"
             const val VIBRATION_ENABLED =               "keyboard__vibration_enabled"
             const val VIBRATION_STRENGTH =              "keyboard__vibration_strength"
         }
@@ -366,9 +367,12 @@ class PrefHelper(
         var soundVolume: Int = 0
             get() = prefHelper.getPref(SOUND_VOLUME, -1)
             private set
-        var switchKeyMode: SwitchKeyMode
-            get() =  SwitchKeyMode.fromString(prefHelper.getPref(SWITCH_KEY_MODE, SwitchKeyMode.DYNAMIC_LANGUAGE_EMOJI.toString()))
-            set(v) = prefHelper.setPref(SWITCH_KEY_MODE, v)
+        var utilityKeyAction: UtilityKeyAction
+            get() =  UtilityKeyAction.fromString(prefHelper.getPref(UTILITY_KEY_ACTION, UtilityKeyAction.DYNAMIC_SWITCH_LANGUAGE_EMOJIS.toString()))
+            set(v) = prefHelper.setPref(UTILITY_KEY_ACTION, v)
+        var utilityKeyEnabled: Boolean
+            get() =  prefHelper.getPref(UTILITY_KEY_ENABLED, true)
+            set(v) = prefHelper.setPref(UTILITY_KEY_ENABLED, v)
         var vibrationEnabled: Boolean = false
             get() = prefHelper.getPref(VIBRATION_ENABLED, true)
             private set

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -449,9 +449,9 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
      * FlorisBoard internal or system-wide.
      */
     private fun handleLanguageSwitch() {
-        when (florisboard.prefs.keyboard.switchKeyMode) {
-            SwitchKeyMode.DYNAMIC_LANGUAGE_EMOJI,
-            SwitchKeyMode.ALWAYS_LANGUAGE_INTERNAL -> florisboard.switchToNextSubtype()
+        when (florisboard.prefs.keyboard.utilityKeyAction) {
+            UtilityKeyAction.DYNAMIC_SWITCH_LANGUAGE_EMOJIS,
+            UtilityKeyAction.SWITCH_LANGUAGE -> florisboard.switchToNextSubtype()
             else -> florisboard.switchToNextKeyboard()
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -589,12 +589,16 @@ class KeyView(
         when (data.code) {
             KeyCode.SWITCH_TO_TEXT_CONTEXT,
             KeyCode.SWITCH_TO_MEDIA_CONTEXT -> {
-                visibility = when (prefs.keyboard.switchKeyMode) {
-                    SwitchKeyMode.ALWAYS_LANGUAGE_INTERNAL,
-                    SwitchKeyMode.ALWAYS_LANGUAGE_SYSTEM,
-                    SwitchKeyMode.NEVER_SHOW -> GONE
-                    SwitchKeyMode.ALWAYS_EMOJI -> VISIBLE
-                    SwitchKeyMode.DYNAMIC_LANGUAGE_EMOJI ->
+                val tempUtilityKeyAction = when {
+                    prefs.keyboard.utilityKeyEnabled -> prefs.keyboard.utilityKeyAction
+                    else -> UtilityKeyAction.DISABLED
+                }
+                visibility = when (tempUtilityKeyAction) {
+                    UtilityKeyAction.DISABLED,
+                    UtilityKeyAction.SWITCH_LANGUAGE,
+                    UtilityKeyAction.SWITCH_KEYBOARD_APP -> GONE
+                    UtilityKeyAction.SWITCH_TO_EMOJIS -> VISIBLE
+                    UtilityKeyAction.DYNAMIC_SWITCH_LANGUAGE_EMOJIS ->
                         if (florisboard?.shouldShowLanguageSwitch() == true) {
                             GONE
                         } else {
@@ -603,12 +607,16 @@ class KeyView(
                 }
             }
             KeyCode.LANGUAGE_SWITCH -> {
-                visibility = when (prefs.keyboard.switchKeyMode) {
-                    SwitchKeyMode.ALWAYS_EMOJI,
-                    SwitchKeyMode.NEVER_SHOW -> GONE
-                    SwitchKeyMode.ALWAYS_LANGUAGE_INTERNAL,
-                    SwitchKeyMode.ALWAYS_LANGUAGE_SYSTEM -> VISIBLE
-                    SwitchKeyMode.DYNAMIC_LANGUAGE_EMOJI ->
+                val tempUtilityKeyAction = when {
+                    prefs.keyboard.utilityKeyEnabled -> prefs.keyboard.utilityKeyAction
+                    else -> UtilityKeyAction.DISABLED
+                }
+                visibility = when (tempUtilityKeyAction) {
+                    UtilityKeyAction.DISABLED,
+                    UtilityKeyAction.SWITCH_TO_EMOJIS -> GONE
+                    UtilityKeyAction.SWITCH_LANGUAGE,
+                    UtilityKeyAction.SWITCH_KEYBOARD_APP -> VISIBLE
+                    UtilityKeyAction.DYNAMIC_SWITCH_LANGUAGE_EMOJIS ->
                         if (florisboard?.shouldShowLanguageSwitch() == true) {
                             VISIBLE
                         } else {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/UtilityKeyAction.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/UtilityKeyAction.kt
@@ -19,17 +19,17 @@ package dev.patrickgold.florisboard.ime.text.key
 import java.util.*
 
 /**
- * Enum for declaring the switch key modes.
+ * Enum for declaring the utility key actions.
  */
-enum class SwitchKeyMode {
-    ALWAYS_EMOJI,
-    ALWAYS_LANGUAGE_INTERNAL,
-    ALWAYS_LANGUAGE_SYSTEM,
-    DYNAMIC_LANGUAGE_EMOJI,
-    NEVER_SHOW;
+enum class UtilityKeyAction {
+    SWITCH_TO_EMOJIS,
+    SWITCH_LANGUAGE,
+    SWITCH_KEYBOARD_APP,
+    DYNAMIC_SWITCH_LANGUAGE_EMOJIS,
+    DISABLED;
 
     companion object {
-        fun fromString(string: String): SwitchKeyMode {
+        fun fromString(string: String): UtilityKeyAction {
             return valueOf(string.toUpperCase(Locale.ENGLISH))
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/fragments/KeyboardFragment.kt
@@ -18,6 +18,7 @@ package dev.patrickgold.florisboard.settings.fragments
 
 import android.content.SharedPreferences
 import android.os.Bundle
+import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import dev.patrickgold.florisboard.R
@@ -27,6 +28,7 @@ import dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
 class KeyboardFragment : PreferenceFragmentCompat(),
     SharedPreferences.OnSharedPreferenceChangeListener {
     private var heightFactorCustom: DialogSeekBarPreference? = null
+    private var utilityKeyAction: ListPreference? = null
     private var sharedPrefs: SharedPreferences? = null
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -34,7 +36,9 @@ class KeyboardFragment : PreferenceFragmentCompat(),
         sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
 
         heightFactorCustom = findPreference(PrefHelper.Keyboard.HEIGHT_FACTOR_CUSTOM)
+        utilityKeyAction = findPreference(PrefHelper.Keyboard.UTILITY_KEY_ACTION)
         onSharedPreferenceChanged(null, PrefHelper.Keyboard.HEIGHT_FACTOR)
+        onSharedPreferenceChanged(null, PrefHelper.Keyboard.UTILITY_KEY_ENABLED)
     }
 
     override fun onResume() {
@@ -50,6 +54,8 @@ class KeyboardFragment : PreferenceFragmentCompat(),
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
         if (key == PrefHelper.Keyboard.HEIGHT_FACTOR) {
             heightFactorCustom?.isVisible = sharedPrefs?.getString(key, "") == "custom"
+        } else if (key == PrefHelper.Keyboard.UTILITY_KEY_ENABLED) {
+            utilityKeyAction?.isVisible = sharedPrefs?.getBoolean(key, false) == true
         }
     }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -45,19 +45,17 @@
         <item>start</item>
     </string-array>
 
-    <string-array name="pref__keyboard__switch_key_mode__entries">
-        <item>@string/pref__keyboard__switch_key_mode__never_show</item>
-        <item>@string/pref__keyboard__switch_key_mode__always_emoji</item>
-        <item>@string/pref__keyboard__switch_key_mode__always_language_internal</item>
-        <item>@string/pref__keyboard__switch_key_mode__always_language_system</item>
-        <item>@string/pref__keyboard__switch_key_mode__dynamic_language_emoji</item>
+    <string-array name="pref__keyboard__utility_key_action__entries">
+        <item>@string/pref__keyboard__utility_key_action__switch_to_emojis</item>
+        <item>@string/pref__keyboard__utility_key_action__switch_language</item>
+        <item>@string/pref__keyboard__utility_key_action__switch_keyboard_app</item>
+        <item>@string/pref__keyboard__utility_key_action__dynamic_switch_language_emojis</item>
     </string-array>
-    <string-array name="pref__keyboard__switch_key_mode__values">
-        <item>never_show</item>
-        <item>always_emoji</item>
-        <item>always_language_internal</item>
-        <item>always_language_system</item>
-        <item>dynamic_language_emoji</item>
+    <string-array name="pref__keyboard__utility_key_action__values">
+        <item>switch_to_emojis</item>
+        <item>switch_language</item>
+        <item>switch_keyboard_app</item>
+        <item>dynamic_switch_language_emojis</item>
     </string-array>
 
     <string-array name="pref__advanced__settings_theme__entries">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,12 +162,13 @@
     <string name="pref__keyboard__hint_mode__enabled_hint_priority" comment="Preference value">Enabled (Hint is prioritized)</string>
     <string name="pref__keyboard__hint_mode__enabled_accent_priority" comment="Preference value">Enabled (Accent is prioritized)</string>
     <string name="pref__keyboard__hint_mode__enabled_smart_priority" comment="Preference value">Enabled (Smart prioritization)</string>
-    <string name="pref__keyboard__switch_key_mode__label" comment="Preference title ('switch key' is a key, not the action to switch sth. here)">Switch key mode</string>
-    <string name="pref__keyboard__switch_key_mode__always_emoji" comment="Preference value">Emoji switch</string>
-    <string name="pref__keyboard__switch_key_mode__always_language_internal" comment="Preference value">Language switch (Internal)</string>
-    <string name="pref__keyboard__switch_key_mode__always_language_system" comment="Preference value">Language switch (System)</string>
-    <string name="pref__keyboard__switch_key_mode__dynamic_language_emoji" comment="Preference value">Dynamic emoji / language switch (Internal)</string>
-    <string name="pref__keyboard__switch_key_mode__never_show" comment="Preference value">Never show switch</string>
+    <string name="pref__keyboard__utility_key_enabled__label" comment="Preference title">Show utility key</string>
+    <string name="pref__keyboard__utility_key_enabled__summary" comment="Preference summary">Shows a configurable utility key next to space bar</string>
+    <string name="pref__keyboard__utility_key_action__label" comment="Preference title">Utility key action</string>
+    <string name="pref__keyboard__utility_key_action__switch_to_emojis" comment="Preference value">Switch to emojis</string>
+    <string name="pref__keyboard__utility_key_action__switch_language" comment="Preference value">Switch language</string>
+    <string name="pref__keyboard__utility_key_action__switch_keyboard_app" comment="Preference value">Switch keyboard app</string>
+    <string name="pref__keyboard__utility_key_action__dynamic_switch_language_emojis" comment="Preference value">Dynamic: Switch to emojis / Switch language</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Font size multiplier (portrait)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Font size multiplier (landscape)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Layout</string>

--- a/app/src/main/res/xml/prefs_keyboard.xml
+++ b/app/src/main/res/xml/prefs_keyboard.xml
@@ -31,13 +31,20 @@
             app:title="@string/pref__keyboard__hinted_symbols_mode__label"
             app:useSimpleSummaryProvider="true"/>
 
-        <ListPreference
-            android:defaultValue="dynamic_language_emoji"
-            app:entries="@array/pref__keyboard__switch_key_mode__entries"
-            app:entryValues="@array/pref__keyboard__switch_key_mode__values"
-            app:key="keyboard__switch_key_mode"
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="keyboard__utility_key_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__keyboard__switch_key_mode__label"
+            app:title="@string/pref__keyboard__utility_key_enabled__label"
+            android:summary="@string/pref__keyboard__utility_key_enabled__summary"/>
+
+        <ListPreference
+            android:defaultValue="dynamic_switch_language_emojis"
+            app:entries="@array/pref__keyboard__utility_key_action__entries"
+            app:entryValues="@array/pref__keyboard__utility_key_action__values"
+            app:key="keyboard__utility_key_action"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__keyboard__utility_key_action__label"
             app:useSimpleSummaryProvider="true"/>
 
         <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference


### PR DESCRIPTION
This PR is an attempt to fix the utility key naming scheme (previously called "Switch key mode"). See attached screenshots below for what has changed. As the preference keys for this feature have changed, this causes the "Switch key mode" to completely reset. Sorry for the inconvenience.

Closes #246 

### Screenshots

Old | New (Disabled) | New (Enabled) | New (Utility key actions)
---|---|---|---
![switch_key_mode](https://user-images.githubusercontent.com/19412843/106046857-19b3f980-60e3-11eb-93ff-b079ee2efa0c.jpg) | ![Screenshot_20210127-205746](https://user-images.githubusercontent.com/19412843/106046874-20427100-60e3-11eb-88b8-de6cc2b5cf7c.jpg) | ![Screenshot_20210127-205751](https://user-images.githubusercontent.com/19412843/106046892-246e8e80-60e3-11eb-879c-659836253cd4.jpg) | ![Screenshot_20210127-205758](https://user-images.githubusercontent.com/19412843/106046903-289aac00-60e3-11eb-832a-922f8b7933bb.jpg)

_((( no idea what GitHub does with the column widths... )))_