### PR TITLE
Add ExtractEditLayout support

### DIFF
--- a/app/src/main/assets/ime/theme/floris_day.json
+++ b/app/src/main/assets/ime/theme/floris_day.json
@@ -59,6 +59,15 @@
     "smartbarButton": {
       "background": "@key/background",
       "foreground": "@key/foreground"
+    },
+    "extractEditLayout": {
+      "background": "#E8E8E8",
+      "foreground": "@window/textColor",
+      "foregroundAlt": "#8A8A8A"
+    },
+    "extractActionButton": {
+      "background": "@smartbarButton/background",
+      "foreground": "@smartbarButton/foreground"
     }
   }
 }

--- a/app/src/main/assets/ime/theme/floris_day_borderless.json
+++ b/app/src/main/assets/ime/theme/floris_day_borderless.json
@@ -63,6 +63,15 @@
     "smartbarButton": {
       "background": "#FFFFFF",
       "foreground": "@window/textColor"
+    },
+    "extractEditLayout": {
+      "background": "#E8E8E8",
+      "foreground": "@window/textColor",
+      "foregroundAlt": "#8A8A8A"
+    },
+    "extractActionButton": {
+      "background": "@smartbarButton/background",
+      "foreground": "@smartbarButton/foreground"
     }
   }
 }

--- a/app/src/main/assets/ime/theme/floris_night.json
+++ b/app/src/main/assets/ime/theme/floris_night.json
@@ -59,6 +59,15 @@
     "smartbarButton": {
       "background": "@key/background",
       "foreground": "@key/foreground"
+    },
+    "extractEditLayout": {
+      "background": "#282828",
+      "foreground": "@window/textColor",
+      "foregroundAlt": "#73FFFFFF"
+    },
+    "extractActionButton": {
+      "background": "@smartbarButton/background",
+      "foreground": "@smartbarButton/foreground"
     }
   }
 }

--- a/app/src/main/assets/ime/theme/floris_night_borderless.json
+++ b/app/src/main/assets/ime/theme/floris_night_borderless.json
@@ -63,6 +63,15 @@
     "smartbarButton": {
       "background": "#424242",
       "foreground": "@window/textColor"
+    },
+    "extractEditLayout": {
+      "background": "#282828",
+      "foreground": "@window/textColor",
+      "foregroundAlt": "#73FFFFFF"
+    },
+    "extractActionButton": {
+      "background": "@smartbarButton/background",
+      "foreground": "@smartbarButton/foreground"
     }
   }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupLayerView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupLayerView.kt
@@ -20,12 +20,14 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
+import android.view.ViewGroup
 import android.widget.FrameLayout
-import dev.patrickgold.florisboard.ime.core.PrefHelper
 
+/**
+ * Basic helper view class which acts as a non-interactive layer view, which sits above the whole
+ * input UI. Automatically rejects any touch events and passes it through to the View below.
+ */
 class PopupLayerView : FrameLayout {
-    private val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)
-
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
@@ -34,6 +36,9 @@ class PopupLayerView : FrameLayout {
         background = null
         isClickable = false
         isFocusable = false
+        layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+        )
     }
 
     override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/Theme.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/Theme.kt
@@ -80,20 +80,20 @@ open class Theme(
          */
         fun getUiAttrNameString(context: Context, attrName: String): String {
             val strId = when (attrName) {
-                "background" ->             R.string.settings__theme__attr_background
-                "backgroundActive" ->       R.string.settings__theme__attr_backgroundActive
-                "backgroundPressed" ->      R.string.settings__theme__attr_backgroundPressed
-                "foreground" ->             R.string.settings__theme__attr_foreground
-                "foregroundAlt" ->          R.string.settings__theme__attr_foregroundAlt
-                "foregroundPressed" ->      R.string.settings__theme__attr_foregroundPressed
-                "showBorder" ->             R.string.settings__theme__attr_showBorder
-                "colorPrimary" ->           R.string.settings__theme__attr_colorPrimary
-                "colorPrimaryDark" ->       R.string.settings__theme__attr_colorPrimaryDark
-                "colorAccent" ->            R.string.settings__theme__attr_colorAccent
-                "navigationBarColor" ->     R.string.settings__theme__attr_navBarColor
-                "navigationBarLight" ->     R.string.settings__theme__attr_navBarLight
-                "semiTransparentColor" ->   R.string.settings__theme__attr_semiTransparentColor
-                "textColor" ->              R.string.settings__theme__attr_textColor
+                "background" ->                     R.string.settings__theme__attr_background
+                "backgroundActive" ->               R.string.settings__theme__attr_backgroundActive
+                "backgroundPressed" ->              R.string.settings__theme__attr_backgroundPressed
+                "foreground" ->                     R.string.settings__theme__attr_foreground
+                "foregroundAlt" ->                  R.string.settings__theme__attr_foregroundAlt
+                "foregroundPressed" ->              R.string.settings__theme__attr_foregroundPressed
+                "showBorder" ->                     R.string.settings__theme__attr_showBorder
+                "colorPrimary" ->                   R.string.settings__theme__attr_colorPrimary
+                "colorPrimaryDark" ->               R.string.settings__theme__attr_colorPrimaryDark
+                "colorAccent" ->                    R.string.settings__theme__attr_colorAccent
+                "navigationBarColor" ->             R.string.settings__theme__attr_navBarColor
+                "navigationBarLight" ->             R.string.settings__theme__attr_navBarLight
+                "semiTransparentColor" ->           R.string.settings__theme__attr_semiTransparentColor
+                "textColor" ->                      R.string.settings__theme__attr_textColor
                 else -> null
             }
             return if (strId != null) {
@@ -121,15 +121,17 @@ open class Theme(
                 )
                 else -> {
                     val strId = when (groupName) {
-                        "window" ->         R.string.settings__theme__group_window
-                        "keyboard" ->       R.string.settings__theme__group_keyboard
-                        "key" ->            R.string.settings__theme__group_key
-                        "media" ->          R.string.settings__theme__group_media
-                        "oneHanded" ->      R.string.settings__theme__group_oneHanded
-                        "popup" ->          R.string.settings__theme__group_popup
-                        "privateMode" ->    R.string.settings__theme__group_privateMode
-                        "smartbar" ->       R.string.settings__theme__group_smartbar
-                        "smartbarButton" -> R.string.settings__theme__group_smartbarButton
+                        "window" ->                 R.string.settings__theme__group_window
+                        "keyboard" ->               R.string.settings__theme__group_keyboard
+                        "key" ->                    R.string.settings__theme__group_key
+                        "media" ->                  R.string.settings__theme__group_media
+                        "oneHanded" ->              R.string.settings__theme__group_oneHanded
+                        "popup" ->                  R.string.settings__theme__group_popup
+                        "privateMode" ->            R.string.settings__theme__group_privateMode
+                        "smartbar" ->               R.string.settings__theme__group_smartbar
+                        "smartbarButton" ->         R.string.settings__theme__group_smartbarButton
+                        "extractEditLayout" ->      R.string.settings__theme__group_extractEditLayout
+                        "extractActionButton" ->    R.string.settings__theme__group_extractActionButton
                         else -> null
                     }
                     if (strId != null) {
@@ -210,6 +212,15 @@ open class Theme(
                     Pair("smartbarButton", mapOf(
                         Pair("background",              ThemeValue.fromString("@key/background")),
                         Pair("foreground",              ThemeValue.fromString("@key/foreground")),
+                    )),
+                    Pair("extractEditLayout", mapOf(
+                        Pair("background",              bgColor),
+                        Pair("foreground",              ThemeValue.fromString("@window/textColor")),
+                        Pair("foregroundAlt",           ThemeValue.fromString("#73FFFFFF")),
+                    )),
+                    Pair("extractActionButton", mapOf(
+                        Pair("background",              ThemeValue.fromString("@smartbarButton/background")),
+                        Pair("foreground",              ThemeValue.fromString("@smartbarButton/foreground")),
                     ))
                 )
             )
@@ -306,7 +317,7 @@ open class Theme(
             getAttrOrNull(ref.copy(group = "${ref.group}::$s2"))?.let { return it }
         }
         getAttrOrNull(ref)?.let { return it }
-        return ThemeValue.SolidColor(0)
+        return BASE_THEME.getAttrOrNull(ref) ?: ThemeValue.SolidColor(0)
     }
 
     /**
@@ -367,6 +378,13 @@ open class Theme(
 
             val SMARTBAR_BUTTON_BACKGROUND = ThemeValue.Reference("smartbarButton", "background")
             val SMARTBAR_BUTTON_FOREGROUND = ThemeValue.Reference("smartbarButton", "foreground")
+
+            val EXTRACT_EDIT_LAYOUT_BACKGROUND = ThemeValue.Reference("extractEditLayout", "background")
+            val EXTRACT_EDIT_LAYOUT_FOREGROUND = ThemeValue.Reference("extractEditLayout", "foreground")
+            val EXTRACT_EDIT_LAYOUT_FOREGROUND_ALT = ThemeValue.Reference("extractEditLayout", "foregroundAlt")
+
+            val EXTRACT_ACTION_BUTTON_BACKGROUND = ThemeValue.Reference("extractActionButton", "background")
+            val EXTRACT_ACTION_BUTTON_FOREGROUND = ThemeValue.Reference("extractActionButton", "foreground")
         }
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
@@ -261,19 +261,24 @@ class ThemeEditorActivity : AppCompatActivity() {
         val sortedMap = baseMap.toList().sortedBy { (_, v) -> v }.toMap().toMutableMap()
         val groupIds = sortedMap.keys.toMutableList()
         val groupNames = sortedMap.values.toMutableList()
-        if (groupNames.contains("keyboard")) {
-            val windowGroupId = groupIds[groupNames.indexOf("keyboard")]
-            groupIds.remove(windowGroupId)
-            groupNames.remove("keyboard")
-            groupIds.add(0, windowGroupId)
-            groupNames.add(0, "keyboard")
-        }
-        if (groupNames.contains("window")) {
-            val windowGroupId = groupIds[groupNames.indexOf("window")]
-            groupIds.remove(windowGroupId)
-            groupNames.remove("window")
-            groupIds.add(0, windowGroupId)
-            groupNames.add(0, "window")
+        listOf(
+            Pair("keyboard", true),
+            Pair("window", true),
+            Pair("extractEditLayout", false),
+            Pair("extractActionButton", false),
+        ).forEach { (groupName, addFirst) ->
+            if (groupNames.contains(groupName)) {
+                val groupId = groupIds[groupNames.indexOf(groupName)]
+                groupIds.remove(groupId)
+                groupNames.remove(groupName)
+                if (addFirst) {
+                    groupIds.add(0, groupId)
+                    groupNames.add(0, groupName)
+                } else {
+                    groupIds.add(groupId)
+                    groupNames.add(groupName)
+                }
+            }
         }
         for ((n, groupId) in groupIds.withIndex()) {
             binding.themeAttributes.findViewById<ThemeAttrGroupView>(groupId)?.let { groupView ->

--- a/app/src/main/java/dev/patrickgold/florisboard/util/view_utils.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/util/view_utils.kt
@@ -1,6 +1,5 @@
 package dev.patrickgold.florisboard.util
 
-import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.res.ColorStateList
@@ -11,6 +10,7 @@ import android.widget.Button
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.children
+import kotlin.reflect.KClass
 
 fun getColorFromAttr(
     context: Context,
@@ -71,6 +71,18 @@ fun refreshLayoutOf(view: View?) {
         view?.invalidate()
         view?.requestLayout()
     }
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <T : View> ViewGroup.findViewWithType(type: KClass<T>): T? {
+    for (child in this.children) {
+        if (type.isInstance(child)) {
+            return child as T
+        } else if (child is ViewGroup) {
+            child.findViewWithType(type)?.let { return it }
+        }
+    }
+    return null
 }
 
 /**

--- a/app/src/main/res/layout/florisboard.xml
+++ b/app/src/main/res/layout/florisboard.xml
@@ -81,9 +81,4 @@
 
     </dev.patrickgold.florisboard.ime.core.InputView>
 
-    <dev.patrickgold.florisboard.ime.popup.PopupLayerView
-        android:id="@+id/popup_layer"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
-
 </dev.patrickgold.florisboard.ime.core.InputWindowView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,8 @@
     <string name="settings__theme__group_privateMode"           comment="Theme group label">Private mode</string>
     <string name="settings__theme__group_smartbar"              comment="Theme group label">Smartbar</string>
     <string name="settings__theme__group_smartbarButton"        comment="Theme group label">Smartbar button</string>
+    <string name="settings__theme__group_extractEditLayout"     comment="Theme group label">Extract edit layout</string>
+    <string name="settings__theme__group_extractActionButton"   comment="Theme group label">Extract action button</string>
     <string name="settings__theme__group_custom"                comment="Theme group label (%s is custom group name)">Custom group (%s)</string>
 
     <string name="settings__theme__attr_background"             comment="Theme attribute label">Background color</string>


### PR DESCRIPTION
This PR adds support for the extract edit layout, which shows in landscreen mode when the app requests it. Previously, this was default implemented, but the textures were transparent and the extracted edit layout as a whole was buggy. Now, the layout integrates with the keyboard and provides theme attributes.

This also fixes #269, where the popups were displaced due to internal height changes.

### Screenshot

![extracted-edit-layout](https://user-images.githubusercontent.com/19412843/106284239-3f581480-6243-11eb-8388-58ae50f6abd2.jpg)

### New theme attributes

```
    "extractEditLayout": {
      "background": "",
      "foreground": "",
      "foregroundAlt": ""
    },
    "extractActionButton": {
      "background": "",
      "foreground": ""
    }
```