### PR TITLE
Improve Landscape Input UI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,10 +32,12 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
+            resValue 'string', 'floris_app_name', 'FlorisBoard Debug'
         }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            resValue 'string', 'floris_app_name', '@string/app_name'
         }
     }
 

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">FlorisBoard Debug</string>
-</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,9 +23,8 @@
     <application
         android:name=".ime.core.FlorisApplication"
         android:allowBackup="false"
-        android:extractNativeLibs="false"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="@string/floris_app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/SettingsTheme">
@@ -33,7 +32,7 @@
         <!-- IME service -->
         <service
             android:name="dev.patrickgold.florisboard.ime.core.FlorisBoard"
-            android:label="@string/app_name"
+            android:label="@string/floris_app_name"
             android:permission="android.permission.BIND_INPUT_METHOD">
             <meta-data
                 android:name="android.view.im"
@@ -57,7 +56,7 @@
         <activity-alias
             android:name="dev.patrickgold.florisboard.SettingsLauncherAlias"
             android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name"
+            android:label="@string/floris_app_name"
             android:launchMode="singleTask"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:targetActivity="dev.patrickgold.florisboard.setup.SetupActivity">

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -21,6 +21,7 @@ import android.content.SharedPreferences
 import android.provider.Settings
 import androidx.preference.PreferenceManager
 import dev.patrickgold.florisboard.R
+import dev.patrickgold.florisboard.ime.landscapeinput.LandscapeInputUiMode
 import dev.patrickgold.florisboard.ime.text.gestures.DistanceThreshold
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.gestures.VelocityThreshold
@@ -316,6 +317,7 @@ class PrefHelper(
             const val HEIGHT_FACTOR_CUSTOM =            "keyboard__height_factor_custom"
             const val HINTED_NUMBER_ROW_MODE =          "keyboard__hinted_number_row_mode"
             const val HINTED_SYMBOLS_MODE =             "keyboard__hinted_symbols_mode"
+            const val LANDSCAPE_INPUT_UI_MODE =         "keyboard__landscape_input_ui_mode"
             const val LONG_PRESS_DELAY =                "keyboard__long_press_delay"
             const val NUMBER_ROW =                      "keyboard__number_row"
             const val ONE_HANDED_MODE =                 "keyboard__one_handed_mode"
@@ -352,6 +354,9 @@ class PrefHelper(
         var hintedSymbolsMode: KeyHintMode
             get() =  KeyHintMode.fromString(prefHelper.getPref(HINTED_SYMBOLS_MODE, KeyHintMode.ENABLED_ACCENT_PRIORITY.toString()))
             set(v) = prefHelper.setPref(HINTED_SYMBOLS_MODE, v)
+        var landscapeInputUiMode: LandscapeInputUiMode
+            get() =  LandscapeInputUiMode.fromString(prefHelper.getPref(LANDSCAPE_INPUT_UI_MODE, LandscapeInputUiMode.DYNAMICALLY_SHOW.toString()))
+            set(v) = prefHelper.setPref(LANDSCAPE_INPUT_UI_MODE, v)
         var longPressDelay: Int = 0
             get() = prefHelper.getPref(LONG_PRESS_DELAY, 300)
             private set

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/landscapeinput/LandscapeInputUiMode.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/landscapeinput/LandscapeInputUiMode.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.landscapeinput
+
+import java.util.*
+
+enum class LandscapeInputUiMode {
+    DYNAMICALLY_SHOW,
+    NEVER_SHOW,
+    ALWAYS_SHOW;
+
+    companion object {
+        fun fromString(string: String): LandscapeInputUiMode {
+            return valueOf(string.toUpperCase(Locale.ENGLISH))
+        }
+    }
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -21,7 +21,6 @@ import android.animation.ValueAnimator
 import android.content.Context
 import android.os.Handler
 import android.view.KeyEvent
-import android.view.View
 import android.view.inputmethod.*
 import android.widget.LinearLayout
 import android.widget.Toast
@@ -124,7 +123,6 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
 
     private suspend fun addKeyboardView(mode: KeyboardMode) {
         val keyboardView = KeyboardView(florisboard.context)
-        keyboardView.id = View.generateViewId()
         keyboardView.computedLayout = layoutManager.fetchComputedLayoutAsync(mode, florisboard.activeSubtype, florisboard.prefs).await()
         keyboardViews[mode] = keyboardView
         textViewFlipper?.addView(keyboardView)

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/SettingsMainActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/SettingsMainActivity.kt
@@ -90,7 +90,7 @@ class SettingsMainActivity : AppCompatActivity(),
             R.id.settings__navigation__home -> {
                 supportActionBar?.title = String.format(
                     resources.getString(R.string.settings__home__title),
-                    resources.getString(R.string.app_name)
+                    resources.getString(R.string.floris_app_name)
                 )
                 loadFragment(HomeFragment())
                 true

--- a/app/src/main/res/drawable/edit_text_background.xml
+++ b/app/src/main/res/drawable/edit_text_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" android:tintMode="multiply">
+    <solid android:color="@android:color/transparent"/>
+    <corners android:radius="@dimen/landscapeInputUi_editText_cornerRadius"/>
+    <stroke android:width="@dimen/landscapeInputUi_editText_borderWidth" android:color="@android:color/white"/>
+</shape>

--- a/app/src/main/res/layout/about_activity.xml
+++ b/app/src/main/res/layout/about_activity.xml
@@ -30,7 +30,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/app_name"
+                android:text="@string/floris_app_name"
                 android:textSize="24sp"
                 android:textStyle="bold"/>
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -34,6 +34,17 @@
         <item>enabled_smart_priority</item>
     </string-array>
 
+    <string-array name="pref__keyboard__landscape_input_ui_mode__entries">
+        <item>@string/pref__keyboard__landscape_input_ui_mode__never_show</item>
+        <item>@string/pref__keyboard__landscape_input_ui_mode__always_show</item>
+        <item>@string/pref__keyboard__landscape_input_ui_mode__dynamically_show</item>
+    </string-array>
+    <string-array name="pref__keyboard__landscape_input_ui_mode__values">
+        <item>never_show</item>
+        <item>always_show</item>
+        <item>dynamically_show</item>
+    </string-array>
+
     <string-array name="pref__keyboard__one_handed_mode__entries">
         <item>@string/pref__keyboard__one_handed_mode__off</item>
         <item>@string/pref__keyboard__one_handed_mode__right</item>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -26,6 +26,12 @@
     <dimen name="key_popup_textSize">21sp</dimen>
     <dimen name="emoji_key_textSize">22sp</dimen>
 
+    <dimen name="landscapeInputUi_padding">8dp</dimen>
+    <dimen name="landscapeInputUi_actionButton_cornerRadius">6dp</dimen>
+    <dimen name="landscapeInputUi_editText_borderWidth">1dp</dimen>
+    <dimen name="landscapeInputUi_editText_cornerRadius">6dp</dimen>
+    <dimen name="landscapeInputUi_editText_padding">8dp</dimen>
+
     <dimen name="media_bottom_button_width">60dp</dimen>
     <dimen name="media_bottom_button_height">@dimen/key_height</dimen>
     <dimen name="media_tab_indicator_height">4dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,10 @@
     <string name="pref__keyboard__one_handed_mode__off" comment="Preference value">Off</string>
     <string name="pref__keyboard__one_handed_mode__right" comment="Preference value">Right-handed mode</string>
     <string name="pref__keyboard__one_handed_mode__left" comment="Preference value">Left-handed mode</string>
+    <string name="pref__keyboard__landscape_input_ui_mode__label" comment="Preference value">Landscape fullscreen input</string>
+    <string name="pref__keyboard__landscape_input_ui_mode__never_show" comment="Preference value">Never show</string>
+    <string name="pref__keyboard__landscape_input_ui_mode__always_show" comment="Preference value">Always show</string>
+    <string name="pref__keyboard__landscape_input_ui_mode__dynamically_show" comment="Preference value">Dynamically show</string>
     <string name="pref__keyboard__height_factor__label" comment="Preference title">Keyboard height</string>
     <string name="pref__keyboard__height_factor__extra_short" comment="Preference value">Extra-short</string>
     <string name="pref__keyboard__height_factor__short" comment="Preference value">Short</string>

--- a/app/src/main/res/xml/prefs_keyboard.xml
+++ b/app/src/main/res/xml/prefs_keyboard.xml
@@ -85,6 +85,15 @@
             app:useSimpleSummaryProvider="true"/>
 
         <ListPreference
+            android:defaultValue="dynamically_show"
+            app:entries="@array/pref__keyboard__landscape_input_ui_mode__entries"
+            app:entryValues="@array/pref__keyboard__landscape_input_ui_mode__values"
+            app:key="keyboard__landscape_input_ui_mode"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__keyboard__landscape_input_ui_mode__label"
+            app:useSimpleSummaryProvider="true"/>
+
+        <ListPreference
             android:defaultValue="normal"
             app:entries="@array/pref__keyboard__height_factor__entries"
             app:entryValues="@array/pref__keyboard__height_factor__values"


### PR DESCRIPTION
This PR is an attempt to further improve the landscape input UI (formerly known as "Extract edit layout"). In detail, this has changed:

1. The landscape input UI has improved a tad and now looks like this:
![Screenshot_20210204-140102_F-Droid](https://user-images.githubusercontent.com/19412843/106930414-ce6a9e00-6715-11eb-8e01-859b40281238.jpg)
2. The landscape input UI should now also theme correctly on Samsung devices (tested on a physical Samsung Galaxy A20e). (Closes #307)
3. The visibility of the landscape input UI can now be configured in Settings > Landscape fullscreen input (Closes #291)