### PR TITLE
Edit bépo layout to add "êà" keys

### DIFF
--- a/app/src/main/assets/ime/text/characters/bepo.json
+++ b/app/src/main/assets/ime/text/characters/bepo.json
@@ -31,6 +31,8 @@
         { "code":  231, "label": "ç" }
       ],
       [
+        { "code":  234, "label": "ê" },
+        { "code":  224, "label": "à" },
         { "code":  121, "label": "y" },
         { "code":  120, "label": "x" },
         { "code":  107, "label": "k" },


### PR DESCRIPTION
Those keys have two uses : 
* Be present
* They move the existing keys so that they are correctly aligned. In standard bépo, H,F are right below N,M. That's currently not the case.