### PR TITLE
Use haptic feedback by default if available

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -210,6 +210,8 @@ class FlorisBoard : InputMethodService(), ClipboardManager.OnPrimaryClipChangedL
         baseContext.setTheme(currentThemeResId)
 
         inputWindowView = layoutInflater.inflate(R.layout.florisboard, null) as InputWindowView
+        inputWindowView?.isHapticFeedbackEnabled = true
+
         eventListeners.toList().forEach { it?.onCreateInputView() }
 
         return inputWindowView
@@ -515,7 +517,12 @@ class FlorisBoard : InputMethodService(), ClipboardManager.OnPrimaryClipChangedL
         if (prefs.keyboard.vibrationEnabled) {
             var vibrationStrength = prefs.keyboard.vibrationStrength
             if (vibrationStrength == -1 && prefs.keyboard.vibrationEnabledSystem) {
-                vibrationStrength = 36
+                val hapticsPerformed =
+                    inputWindowView?.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+
+                if (hapticsPerformed == false) {
+                    vibrationStrength = 36
+                }
             }
             if (vibrationStrength > 0) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
Resolves #255.

My original plan was to check for the device's haptics support, and use that information to determine whether or not haptic feedback should be enabled by default. A separate setting was to be provided in FlorisBoard settings, labeled "Use haptic feedback for vibration", which would be enabled if the device supported haptic feedback and disabled otherwise. This didn't pan out, as there's no function that can query whether or not a device supports haptic feedback.

As a result, I've elected to modify the default vibration behavior when a user taps a key. If the vibration strength is set to "System default", the device will first attempt to perform haptic feedback; if it succeeds, the vibration function completes. If the attempt fails, the function will fallback to the old behavior of using a default vibration strength of 36. If a manual vibration strength is set in FlorisBoard preferences, haptic feedback will be disabled. This behavior is consistent with the default AOSP keyboard.