### PR TITLE
Add exception for bat files to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+*.bat text=auto eol=crlf


### PR DESCRIPTION
This prevents `gradlew.bat` from being reset to LF line endings, which aren't guaranteed to be interpreted correctly by Windows CMD.