### PR TITLE
Add options for key spacing

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -316,6 +316,8 @@ class PrefHelper(
             const val HEIGHT_FACTOR_CUSTOM =            "keyboard__height_factor_custom"
             const val HINTED_NUMBER_ROW_MODE =          "keyboard__hinted_number_row_mode"
             const val HINTED_SYMBOLS_MODE =             "keyboard__hinted_symbols_mode"
+            const val KEY_SPACING_HORIZONTAL =          "keyboard__key_spacing_horizontal"
+            const val KEY_SPACING_VERTICAL =            "keyboard__key_spacing_vertical"
             const val LANDSCAPE_INPUT_UI_MODE =         "keyboard__landscape_input_ui_mode"
             const val LONG_PRESS_DELAY =                "keyboard__long_press_delay"
             const val NUMBER_ROW =                      "keyboard__number_row"
@@ -353,6 +355,12 @@ class PrefHelper(
         var hintedSymbolsMode: KeyHintMode
             get() =  KeyHintMode.fromString(prefHelper.getPref(HINTED_SYMBOLS_MODE, KeyHintMode.ENABLED_ACCENT_PRIORITY.toString()))
             set(v) = prefHelper.setPref(HINTED_SYMBOLS_MODE, v)
+        var keySpacingHorizontal: Float = 2f
+            get() = prefHelper.getPref(KEY_SPACING_HORIZONTAL, 4) / 2f
+            private set
+        var keySpacingVertical: Float = 5f
+            get() = prefHelper.getPref(KEY_SPACING_VERTICAL, 10) / 2f
+            private set
         var landscapeInputUiMode: LandscapeInputUiMode
             get() =  LandscapeInputUiMode.fromString(prefHelper.getPref(LANDSCAPE_INPUT_UI_MODE, LandscapeInputUiMode.DYNAMICALLY_SHOW.toString()))
             set(v) = prefHelper.setPref(LANDSCAPE_INPUT_UI_MODE, v)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -300,9 +300,11 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
 
     override fun onSubtypeChanged(newSubtype: Subtype) {
         launch {
-            val keyboardView = keyboardViews[KeyboardMode.CHARACTERS]
-            keyboardView?.computedLayout = layoutManager.fetchComputedLayoutAsync(KeyboardMode.CHARACTERS, newSubtype, florisboard.prefs).await()
-            keyboardView?.updateVisibility()
+            // Seems like because the key spacing can change, all layouts need to be refreshed
+            for ((keyboardMode, keyboardView) in keyboardViews) {
+                keyboardView?.computedLayout = layoutManager.fetchComputedLayoutAsync(keyboardMode, newSubtype, florisboard.prefs).await()
+                keyboardView?.updateVisibility()
+            }
         }
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -300,11 +300,9 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
 
     override fun onSubtypeChanged(newSubtype: Subtype) {
         launch {
-            // Seems like because the key spacing can change, all layouts need to be refreshed
-            for ((keyboardMode, keyboardView) in keyboardViews) {
-                keyboardView?.computedLayout = layoutManager.fetchComputedLayoutAsync(keyboardMode, newSubtype, florisboard.prefs).await()
-                keyboardView?.updateVisibility()
-            }
+            val keyboardView = keyboardViews[KeyboardMode.CHARACTERS]
+            keyboardView?.computedLayout = layoutManager.fetchComputedLayoutAsync(KeyboardMode.CHARACTERS, newSubtype, florisboard.prefs).await()
+            keyboardView?.updateVisibility()
         }
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -112,11 +112,14 @@ class KeyView(
         layoutParams = FlexboxLayout.LayoutParams(
             FlexboxLayout.LayoutParams.WRAP_CONTENT, FlexboxLayout.LayoutParams.WRAP_CONTENT
         ).apply {
+
+            val keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
+            val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
             setMargins(
-                resources.getDimension((R.dimen.key_marginH)).toInt(),
-                resources.getDimension(R.dimen.key_marginV).toInt(),
-                resources.getDimension((R.dimen.key_marginH)).toInt(),
-                resources.getDimension(R.dimen.key_marginV).toInt()
+                keyMarginH,
+                keyMarginV,
+                keyMarginH,
+                keyMarginV
             )
             flexShrink = when (keyboardView.computedLayout?.mode) {
                 KeyboardMode.NUMERIC,
@@ -609,8 +612,9 @@ class KeyView(
             touchHitBox.set(-1, -1, -1, -1)
         } else {
             val parent = parent as ViewGroup
-            val keyMarginH = resources.getDimension((R.dimen.key_marginH)).toInt()
-            val keyMarginV = resources.getDimension((R.dimen.key_marginV)).toInt()
+
+            val keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
+            val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
 
             touchHitBox.apply {
                 left = when (this@KeyView) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -112,9 +112,17 @@ class KeyView(
         layoutParams = FlexboxLayout.LayoutParams(
             FlexboxLayout.LayoutParams.WRAP_CONTENT, FlexboxLayout.LayoutParams.WRAP_CONTENT
         ).apply {
+            val keyMarginH: Int
+            val keyMarginV: Int
 
-            val keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
-            val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+            if (keyboardView.isSmartbarKeyboardView){
+                keyMarginH = resources.getDimension(R.dimen.key_marginH).toInt()
+                keyMarginV = resources.getDimension(R.dimen.key_marginV).toInt()
+            }else {
+                keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
+                keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+            }
+
             setMargins(
                 keyMarginH,
                 keyMarginV,
@@ -439,8 +447,16 @@ class KeyView(
      */
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
 
-        val keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
-        val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+        val keyMarginH: Int
+        val keyMarginV: Int
+
+        if (keyboardView.isSmartbarKeyboardView){
+            keyMarginH = resources.getDimension(R.dimen.key_marginH).toInt()
+            keyMarginV = resources.getDimension(R.dimen.key_marginV).toInt()
+        }else {
+            keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
+            keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+        }
 
         (layoutParams as ViewGroup.MarginLayoutParams).setMargins(
             keyMarginH,
@@ -624,8 +640,16 @@ class KeyView(
         } else {
             val parent = parent as ViewGroup
 
-            val keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
-            val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+            val keyMarginH: Int
+            val keyMarginV: Int
+
+            if (keyboardView.isSmartbarKeyboardView){
+                keyMarginH = resources.getDimension(R.dimen.key_marginH).toInt()
+                keyMarginV = resources.getDimension(R.dimen.key_marginV).toInt()
+            }else {
+                keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
+                keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+            }
 
             touchHitBox.apply {
                 left = when (this@KeyView) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -887,8 +887,8 @@ class KeyView(
                             data.code != KeyCode.SPACE -> {
                         val cachedTextSize = setTextSizeFor(
                             labelPaint,
-                            desiredWidth - (2.6f * drawablePaddingH),
-                            desiredHeight - (3.4f * drawablePaddingV),
+                            measuredWidth - (2.6f * drawablePaddingH),
+                            measuredHeight - (3.4f * drawablePaddingV),
                             // Note: taking a "X" here because it is one of the biggest letters and
                             //  the keys must have the same base character for calculation, else
                             //  they will all look different and weird...

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -438,6 +438,17 @@ class KeyView(
      *  by Devunwired
      */
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+
+        val keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
+        val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+
+        (layoutParams as ViewGroup.MarginLayoutParams).setMargins(
+            keyMarginH,
+            keyMarginV,
+            keyMarginH,
+            keyMarginV
+        )
+
         desiredWidth = (keyboardView.desiredKeyWidth * when (keyboardView.computedLayout?.mode) {
             KeyboardMode.NUMERIC,
             KeyboardMode.PHONE,

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardRowView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardRowView.kt
@@ -52,4 +52,16 @@ class KeyboardRowView(context: Context) : FlexboxLayout(context) {
     override fun onTouchEvent(event: MotionEvent?): Boolean {
         return false
     }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)
+        val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+
+        (layoutParams as MarginLayoutParams).setMargins(
+            keyMarginH, 0,
+            keyMarginH, 0
+        )
+
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardRowView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardRowView.kt
@@ -22,7 +22,8 @@ import android.view.MotionEvent
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxLayout
 import com.google.android.flexbox.JustifyContent
-import dev.patrickgold.florisboard.R
+import dev.patrickgold.florisboard.ime.core.PrefHelper
+import dev.patrickgold.florisboard.util.ViewLayoutUtils
 
 /**
  * This class' sole purpose is to manage the layout within a row of [KeyboardView]. No logic is
@@ -30,10 +31,12 @@ import dev.patrickgold.florisboard.R
  */
 class KeyboardRowView(context: Context) : FlexboxLayout(context) {
     init {
+        val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)
+        val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
         layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT).apply {
             setMargins(
-                resources.getDimension(R.dimen.keyboard_row_marginH).toInt(), 0,
-                resources.getDimension(R.dimen.keyboard_row_marginH).toInt(), 0
+                keyMarginH, 0,
+                keyMarginH, 0
             )
         }
         flexDirection = FlexDirection.ROW

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardRowView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardRowView.kt
@@ -22,6 +22,7 @@ import android.view.MotionEvent
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxLayout
 import com.google.android.flexbox.JustifyContent
+import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.util.ViewLayoutUtils
 
@@ -29,10 +30,14 @@ import dev.patrickgold.florisboard.util.ViewLayoutUtils
  * This class' sole purpose is to manage the layout within a row of [KeyboardView]. No logic is
  * handled in this class.
  */
-class KeyboardRowView(context: Context) : FlexboxLayout(context) {
+class KeyboardRowView(context: Context, val keyboardView: KeyboardView) : FlexboxLayout(context) {
     init {
         val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)
-        val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+        val keyMarginH = if (keyboardView.isSmartbarKeyboardView){
+            resources.getDimension(R.dimen.key_marginH).toInt()
+        }else{
+            ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+        }
         layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT).apply {
             setMargins(
                 keyMarginH, 0,
@@ -55,8 +60,11 @@ class KeyboardRowView(context: Context) : FlexboxLayout(context) {
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)
-        val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
-
+        val keyMarginH = if (keyboardView.isSmartbarKeyboardView){
+            resources.getDimension(R.dimen.key_marginH).toInt()
+        }else{
+            ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+        }
         (layoutParams as MarginLayoutParams).setMargins(
             keyMarginH, 0,
             keyMarginH, 0

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -36,6 +36,7 @@ import dev.patrickgold.florisboard.ime.text.key.KeyView
 import dev.patrickgold.florisboard.ime.text.layout.ComputedLayoutData
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
+import dev.patrickgold.florisboard.util.ViewLayoutUtils
 import kotlin.math.roundToInt
 
 /**
@@ -331,8 +332,8 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
      * The desired key heights/widths are being calculated here.
      */
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val keyMarginH = resources.getDimension((R.dimen.key_marginH)).toInt()
-        val keyMarginV = resources.getDimension((R.dimen.key_marginV)).toInt()
+        val keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
+        val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
 
         val desiredWidth = MeasureSpec.getSize(widthMeasureSpec).toFloat()
         desiredKeyWidth = if (isSmartbarKeyboardView) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -98,7 +98,7 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
         destroyLayout()
         val computedLayout = computedLayout ?: return
         for (row in computedLayout.arrangement) {
-            val rowView = KeyboardRowView(context)
+            val rowView = KeyboardRowView(context, this)
             for (key in row) {
                 val keyView = KeyView(this, key, florisboard)
                 rowView.addView(keyView)
@@ -332,8 +332,16 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
      * The desired key heights/widths are being calculated here.
      */
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
-        val keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+        val keyMarginH: Int
+        val keyMarginV: Int
+
+        if (isSmartbarKeyboardView){
+            keyMarginH = resources.getDimension(R.dimen.key_marginH).toInt()
+            keyMarginV = resources.getDimension(R.dimen.key_marginV).toInt()
+        }else {
+            keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
+            keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
+        }
 
         val desiredWidth = MeasureSpec.getSize(widthMeasureSpec).toFloat()
         desiredKeyWidth = if (isSmartbarKeyboardView) {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -13,6 +13,10 @@
     <dimen name="emoji_key_width">@dimen/key_height</dimen>
     <dimen name="emoji_key_height">@dimen/key_height</dimen>
 
+    <dimen name="key_marginH">2dp</dimen>
+    <dimen name="key_marginV">5dp</dimen>
+    <dimen name="keyboard_row_marginH">@dimen/key_marginH</dimen>
+
     <dimen name="keyboard_preview_margin">16dp</dimen>
 
     <dimen name="key_borderRadius">6dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -13,9 +13,6 @@
     <dimen name="emoji_key_width">@dimen/key_height</dimen>
     <dimen name="emoji_key_height">@dimen/key_height</dimen>
 
-    <dimen name="key_marginH">2dp</dimen>
-    <dimen name="key_marginV">5dp</dimen>
-    <dimen name="keyboard_row_marginH">@dimen/key_marginH</dimen>
     <dimen name="keyboard_preview_margin">16dp</dimen>
 
     <dimen name="key_borderRadius">6dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,6 +196,8 @@
     <string name="pref__keyboard__height_factor_custom__label" comment="Preference title">Custom keyboard height value</string>
     <string name="pref__keyboard__bottom_offset_portrait__label" comment="Preference title">Bottom offset (portrait)</string>
     <string name="pref__keyboard__bottom_offset_landscape__label" comment="Preference title">Bottom offset (landscape)</string>
+    <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Key spacing (vertical)</string>
+    <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Key spacing (horizontal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Key press</string>
     <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Sound on key press</string>
     <string name="pref__keyboard__sound_volume__label" comment="Preference title">Sound volume on key press</string>

--- a/app/src/main/res/xml/prefs_keyboard.xml
+++ b/app/src/main/res/xml/prefs_keyboard.xml
@@ -135,6 +135,28 @@
             app:seekBarIncrement="1"
             app:unit=" dp"/>
 
+        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
+            app:allowDividerAbove="false"
+            android:defaultValue="10"
+            app:key="keyboard__key_spacing_vertical"
+            app:min="0"
+            app:max="20"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__keyboard__key_spacing_vertical__label"
+            app:seekBarIncrement="1"
+            app:unit=" half dp"/>
+
+        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
+            app:allowDividerAbove="false"
+            android:defaultValue="4"
+            app:key="keyboard__key_spacing_horizontal"
+            app:min="0"
+            app:max="20"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__keyboard__key_spacing_horizontal__label"
+            app:seekBarIncrement="1"
+            app:unit=" half dp"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Hello :) 

I wanted to implement proposal #67 because I kinda wanted the feature as well. So, I've added options to to adjust the key spacing like this:

<img width="300"  src="https://user-images.githubusercontent.com/28653555/107780991-d2736d00-6d60-11eb-93fb-3b2da8de570d.jpg">

I chose 0.5 dp as the unit because unfortunately a full dp is a bit big.

As an example,

Before (spacing 2dp, 5dp):  

<img width="300"  src="https://user-images.githubusercontent.com/28653555/107777332-1b74f280-6d5c-11eb-9448-00f819b7cc6f.jpg">

After (spacing 4dp, 4dp):

<img width="300"  src="https://user-images.githubusercontent.com/28653555/107777309-13b54e00-6d5c-11eb-9d7d-5e8fdb2d875a.jpg">

(There's a bit more space between the columns, it looks a bit more even)

This is my first contribution here so let me know if I need to change something :)

---
Closes #67 
Closes #354