### PR TITLE
Fix memory management for Flictionaries & prediction algorithm

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -900,7 +900,7 @@ class CachedInput(private val editorInstance: EditorInstance) {
         private const val CACHED_TEXT_N_CHARS_BEFORE_CURSOR: Int = 192
         private const val CACHED_TEXT_N_CHARS_AFTER_CURSOR: Int = 64
 
-        private val WORD_EVAL_REGEX = """[^\p{L}]""".toRegex()
+        private val WORD_EVAL_REGEX = """[^\p{L}\']""".toRegex()
         private val WORD_SPLIT_REGEX_EN = """((?<=$WORD_EVAL_REGEX)|(?=$WORD_EVAL_REGEX))""".toRegex()
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/dictionary/Flictionary.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/dictionary/Flictionary.kt
@@ -188,14 +188,14 @@ class Flictionary private constructor(
                         if (inputStream.readNext(buffer, 1, 9) > 0) {
                             val size = (buffer[1].toInt() and 0xFF)
                             date =
-                                ((buffer[pos + 2].toInt() and 0xFF).toLong() shl 56) +
-                                ((buffer[pos + 3].toInt() and 0xFF).toLong() shl 48) +
-                                ((buffer[pos + 4].toInt() and 0xFF).toLong() shl 40) +
-                                ((buffer[pos + 5].toInt() and 0xFF).toLong() shl 32) +
-                                ((buffer[pos + 6].toInt() and 0xFF).toLong() shl 24) +
-                                ((buffer[pos + 7].toInt() and 0xFF).toLong() shl 16) +
-                                ((buffer[pos + 8].toInt() and 0xFF).toLong() shl 8) +
-                                ((buffer[pos + 9].toInt() and 0xFF).toLong() shl 0)
+                                ((buffer[2].toInt() and 0xFF).toLong() shl 56) +
+                                ((buffer[3].toInt() and 0xFF).toLong() shl 48) +
+                                ((buffer[4].toInt() and 0xFF).toLong() shl 40) +
+                                ((buffer[5].toInt() and 0xFF).toLong() shl 32) +
+                                ((buffer[6].toInt() and 0xFF).toLong() shl 24) +
+                                ((buffer[7].toInt() and 0xFF).toLong() shl 16) +
+                                ((buffer[8].toInt() and 0xFF).toLong() shl 8) +
+                                ((buffer[9].toInt() and 0xFF).toLong() shl 0)
                             if (inputStream.readNext(buffer, 10, size) > 0) {
                                 headerStr = String(buffer, 10, size, Charsets.UTF_8)
                                 ngramOrderStack.add(-1)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/dictionary/Flictionary.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/dictionary/Flictionary.kt
@@ -23,8 +23,9 @@ import com.github.michaelbull.result.Result
 import dev.patrickgold.florisboard.ime.extension.AssetRef
 import dev.patrickgold.florisboard.ime.extension.AssetSource
 import dev.patrickgold.florisboard.ime.nlp.*
+import java.io.InputStream
 import java.util.*
-import kotlin.text.StringBuilder
+import kotlin.jvm.Throws
 
 /**
  * Class Flictionary which takes care of loading the binary asset as well as providing words for
@@ -72,11 +73,10 @@ class Flictionary private constructor(
          * occurred.
          */
         fun load(context: Context, assetRef: AssetRef): Result<Flictionary, Exception> {
-            val rawData: ByteArray
+            val buffer = ByteArray(5000) { 0 }
+            val inputStream: InputStream
             if (assetRef.source == AssetSource.Assets) {
-                val inputStream = context.assets.open(assetRef.path)
-                rawData = inputStream.readBytes()
-                inputStream.close()
+                inputStream = context.assets.open(assetRef.path)
             } else {
                 return Err(Exception("Only AssetSource.Assets is currently supported!"))
             }
@@ -90,48 +90,68 @@ class Flictionary private constructor(
             val ngramOrderStack = mutableListOf<Int>()
             val ngramTreeStack = mutableListOf<NgramNode>()
 
-            while (pos < rawData.size) {
-                val cmd = rawData[pos].toInt() and 0xFF
+            while (true) {
+                if (inputStream.readNext(buffer, 0, 1) <= 0) {
+                    break
+                }
+                val cmd = buffer[0].toInt() and 0xFF
                 when {
                     (cmd and MASK_BEGIN_PTREE_NODE) == CMDB_BEGIN_PTREE_NODE -> {
                         if (pos == 0) {
-                            return Err(ParseException(
-                                errorType = ParseException.ErrorType.UNEXPECTED_CMD_BEGIN_PTREE_NODE,
-                                address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
-                            ))
+                            inputStream.close()
+                            return Err(
+                                ParseException(
+                                    errorType = ParseException.ErrorType.UNEXPECTED_CMD_BEGIN_PTREE_NODE,
+                                    address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
+                                )
+                            )
                         }
                         val order = ((cmd and ATTR_PTREE_NODE_ORDER) shr 4) + 1
                         val type = ((cmd and ATTR_PTREE_NODE_TYPE) shr 2)
                         val size = (cmd and ATTR_PTREE_NODE_SIZE) + 1
-                        if (pos + 1 + size < rawData.size) {
-                            val freq: Int
-                            val offset: Int
-                            when (type) {
-                                ATTR_PTREE_NODE_TYPE_CHAR -> {
-                                    freq = NgramNode.FREQ_CHARACTER
-                                    offset = 1
-                                }
-                                ATTR_PTREE_NODE_TYPE_WORD_FILLER -> {
-                                    freq = NgramNode.FREQ_WORD_FILLER
-                                    offset = 1
-                                }
-                                ATTR_PTREE_NODE_TYPE_WORD -> {
-                                    freq = rawData[pos + 1].toInt() and 0xFF
-                                    offset = 2
-                                }
-                                else -> return Err(Exception("TODO: shortcut not supported"))
+                        val freq: Int
+                        val freqSize: Int
+                        when (type) {
+                            ATTR_PTREE_NODE_TYPE_CHAR -> {
+                                freq = NgramNode.FREQ_CHARACTER
+                                freqSize = 0
                             }
-                            val bytes = ByteArray(size) { i -> rawData[pos + offset + i] }
-                            val char = String(bytes, Charsets.UTF_8)[0]
-                            val precomputedWord = StringBuilder()
-                            val firstNodeIndex = ngramOrderStack.indexOfFirst { it == order }
-                            if (firstNodeIndex >= 0) {
-                                for (n in firstNodeIndex until ngramOrderStack.size) {
-                                    precomputedWord.append(ngramTreeStack[n].char)
-                                }
+                            ATTR_PTREE_NODE_TYPE_WORD_FILLER -> {
+                                freq = NgramNode.FREQ_WORD_FILLER
+                                freqSize = 0
                             }
-                            precomputedWord.append(char)
-                            val node = NgramNode(order, char, precomputedWord.toString(), freq)
+                            ATTR_PTREE_NODE_TYPE_WORD -> {
+                                if (inputStream.readNext(buffer, 1, 1) > 0) {
+                                    freq = buffer[1].toInt() and 0xFF
+                                } else {
+                                    inputStream.close()
+                                    return Err(
+                                        ParseException(
+                                            errorType = ParseException.ErrorType.UNEXPECTED_EOF,
+                                            address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
+                                        )
+                                    )
+                                }
+                                freqSize = 1
+                            }
+                            else -> return Err(Exception("TODO: shortcut not supported"))
+                        }
+                        if (inputStream.readNext(buffer, freqSize + 1, size) > 0) {
+                            val char = String(buffer, freqSize + 1, size, Charsets.UTF_8)[0]
+
+                            val node = if (freq == NgramNode.FREQ_CHARACTER) {
+                                NgramNode(order, char, null, freq)
+                            } else {
+                                val precomputedWord = StringBuilder()
+                                val firstNodeIndex = ngramOrderStack.indexOfFirst { it == order }
+                                if (firstNodeIndex >= 0) {
+                                    for (n in firstNodeIndex until ngramOrderStack.size) {
+                                        precomputedWord.append(ngramTreeStack[n].char)
+                                    }
+                                }
+                                precomputedWord.append(char)
+                                NgramNode(order, char, precomputedWord.toString(), freq)
+                            }
                             val lastOrder = ngramOrderStack.lastOrNull()
                             if (lastOrder == null) {
                                 ngramTree.higherOrderChildren[char] = node
@@ -144,68 +164,85 @@ class Flictionary private constructor(
                             }
                             ngramOrderStack.add(order)
                             ngramTreeStack.add(node)
-                            pos += (offset + size)
+                            pos += (freqSize + 1 + size)
                         } else {
-                            return Err(ParseException(
-                                errorType = ParseException.ErrorType.UNEXPECTED_EOF,
-                                address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
-                            ))
+                            inputStream.close()
+                            return Err(
+                                ParseException(
+                                    errorType = ParseException.ErrorType.UNEXPECTED_EOF,
+                                    address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
+                                )
+                            )
                         }
                     }
 
                     (cmd and MASK_BEGIN_HEADER) == CMDB_BEGIN_HEADER -> {
                         if (pos != 0) {
-                            return Err(ParseException(
-                                errorType = ParseException.ErrorType.UNEXPECTED_CMD_BEGIN_HEADER,
-                                address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
-                            ))
+                            inputStream.close()
+                            return Err(
+                                ParseException(
+                                    errorType = ParseException.ErrorType.UNEXPECTED_CMD_BEGIN_HEADER,
+                                    address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
+                                )
+                            )
                         }
                         version = cmd and ATTR_HEADER_VERSION
                         if (version != VERSION_0) {
-                            return Err(ParseException(
-                                errorType = ParseException.ErrorType.UNSUPPORTED_FLICTIONARY_VERSION,
-                                address = pos,
-                                cmdByte = cmd.toByte(),
-                                absoluteDepth = ngramTreeStack.size - 1
-                            ))
+                            inputStream.close()
+                            return Err(
+                                ParseException(
+                                    errorType = ParseException.ErrorType.UNSUPPORTED_FLICTIONARY_VERSION,
+                                    address = pos,
+                                    cmdByte = cmd.toByte(),
+                                    absoluteDepth = ngramTreeStack.size
+                                )
+                            )
                         }
-                        if (pos + 9 < rawData.size) {
-                            val size = (rawData[pos + 1].toInt() and 0xFF)
+                        if (inputStream.readNext(buffer, 1, 9) > 0) {
+                            val size = (buffer[1].toInt() and 0xFF)
                             date =
-                                ((rawData[pos + 2].toInt() and 0xFF).toLong() shl 56) +
-                                ((rawData[pos + 3].toInt() and 0xFF).toLong() shl 48) +
-                                ((rawData[pos + 4].toInt() and 0xFF).toLong() shl 40) +
-                                ((rawData[pos + 5].toInt() and 0xFF).toLong() shl 32) +
-                                ((rawData[pos + 6].toInt() and 0xFF).toLong() shl 24) +
-                                ((rawData[pos + 7].toInt() and 0xFF).toLong() shl 16) +
-                                ((rawData[pos + 8].toInt() and 0xFF).toLong() shl 8) +
-                                ((rawData[pos + 9].toInt() and 0xFF).toLong() shl 0)
-                            if (pos + 9 + size < rawData.size) {
-                                val headerBytes = ByteArray(size) { i -> rawData[pos + 10 + i] }
-                                headerStr = String(headerBytes, Charsets.UTF_8)
+                                ((buffer[pos + 2].toInt() and 0xFF).toLong() shl 56) +
+                                ((buffer[pos + 3].toInt() and 0xFF).toLong() shl 48) +
+                                ((buffer[pos + 4].toInt() and 0xFF).toLong() shl 40) +
+                                ((buffer[pos + 5].toInt() and 0xFF).toLong() shl 32) +
+                                ((buffer[pos + 6].toInt() and 0xFF).toLong() shl 24) +
+                                ((buffer[pos + 7].toInt() and 0xFF).toLong() shl 16) +
+                                ((buffer[pos + 8].toInt() and 0xFF).toLong() shl 8) +
+                                ((buffer[pos + 9].toInt() and 0xFF).toLong() shl 0)
+                            if (inputStream.readNext(buffer, 10, size) > 0) {
+                                headerStr = String(buffer, 10, size, Charsets.UTF_8)
                                 ngramOrderStack.add(-1)
                                 ngramTreeStack.add(NgramTree())
                                 pos += (10 + size)
                             } else {
-                                return Err(ParseException(
-                                    errorType = ParseException.ErrorType.UNEXPECTED_EOF,
-                                    address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
-                                ))
+                                inputStream.close()
+                                return Err(
+                                    ParseException(
+                                        errorType = ParseException.ErrorType.UNEXPECTED_EOF,
+                                        address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
+                                    )
+                                )
                             }
                         } else {
-                            return Err(ParseException(
-                                errorType = ParseException.ErrorType.UNEXPECTED_EOF,
-                                address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
-                            ))
+                            inputStream.close()
+                            return Err(
+                                ParseException(
+                                    errorType = ParseException.ErrorType.UNEXPECTED_EOF,
+                                    address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
+                                )
+                            )
                         }
                     }
 
                     (cmd and MASK_END) == CMDB_END -> {
                         if (pos == 0) {
-                            return Err(ParseException(
-                                errorType = ParseException.ErrorType.UNEXPECTED_CMD_END,
-                                address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
-                            ))
+                            inputStream.close()
+                            return Err(
+                                ParseException(
+                                    errorType = ParseException.ErrorType.UNEXPECTED_CMD_END,
+                                    address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
+                                )
+                            )
                         }
                         val n = (cmd and ATTR_END_COUNT)
                         if (n > 0) {
@@ -215,31 +252,45 @@ class Flictionary private constructor(
                                     ngramTreeStack.removeLast()
                                 }
                             } else {
-                                return Err(ParseException(
-                                    errorType = ParseException.ErrorType.UNEXPECTED_ABSOLUTE_DEPTH_DECREASE_BELOW_ZERO,
-                                    address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size - n
-                                ))
+                                inputStream.close()
+                                return Err(
+                                    ParseException(
+                                        errorType = ParseException.ErrorType.UNEXPECTED_ABSOLUTE_DEPTH_DECREASE_BELOW_ZERO,
+                                        address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size - n
+                                    )
+                                )
                             }
                         } else {
-                            return Err(ParseException(
-                                errorType = ParseException.ErrorType.UNEXPECTED_CMD_END_ZERO_VALUE,
-                                address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
-                            ))
+                            inputStream.close()
+                            return Err(
+                                ParseException(
+                                    errorType = ParseException.ErrorType.UNEXPECTED_CMD_END_ZERO_VALUE,
+                                    address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
+                                )
+                            )
                         }
                         pos += 1
                     }
-                    else -> return Err(ParseException(
-                        errorType = ParseException.ErrorType.INVALID_CMD_BYTE_PROVIDED,
-                        address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
-                    ))
+                    else -> {
+                        inputStream.close()
+                        return Err(
+                            ParseException(
+                                errorType = ParseException.ErrorType.INVALID_CMD_BYTE_PROVIDED,
+                                address = pos, cmdByte = cmd.toByte(), absoluteDepth = ngramTreeStack.size
+                            )
+                        )
+                    }
                 }
             }
+            inputStream.close()
 
             if (ngramTreeStack.size != 0) {
-                return Err(ParseException(
-                    errorType = ParseException.ErrorType.UNEXPECTED_ABSOLUTE_DEPTH_NOT_ZERO_AT_EOF,
-                    address = pos, cmdByte = 0x00.toByte(), absoluteDepth = ngramTreeStack.size
-                ))
+                return Err(
+                    ParseException(
+                        errorType = ParseException.ErrorType.UNEXPECTED_ABSOLUTE_DEPTH_NOT_ZERO_AT_EOF,
+                        address = pos, cmdByte = 0x00.toByte(), absoluteDepth = ngramTreeStack.size
+                    )
+                )
             }
 
             return Ok(
@@ -312,41 +363,84 @@ class Flictionary private constructor(
             get() = toString()
         override fun toString(): String {
             return StringBuilder().run {
-                append(when (errorType) {
-                    ErrorType.UNSUPPORTED_FLICTIONARY_VERSION -> {
-                        "Unexpected Flictionary version: ${(cmdByte.toInt() and 0xFF) and ATTR_HEADER_VERSION}"
+                append(
+                    when (errorType) {
+                        ErrorType.UNSUPPORTED_FLICTIONARY_VERSION -> {
+                            "Unexpected Flictionary version: ${(cmdByte.toInt() and 0xFF) and ATTR_HEADER_VERSION}"
+                        }
+                        ErrorType.UNEXPECTED_CMD_BEGIN_HEADER -> {
+                            "Unexpected command: BEGIN_HEADER"
+                        }
+                        ErrorType.UNEXPECTED_CMD_BEGIN_PTREE_NODE -> {
+                            "Unexpected command: BEGIN_PTREE_NODE"
+                        }
+                        ErrorType.UNEXPECTED_CMD_DEFINE_SHORTCUT -> {
+                            "Unexpected command: DEFINE_SHORTCUT"
+                        }
+                        ErrorType.UNEXPECTED_CMD_END -> {
+                            "Unexpected command: END"
+                        }
+                        ErrorType.UNEXPECTED_CMD_END_ZERO_VALUE -> {
+                            "Unexpected zero value provided for command END"
+                        }
+                        ErrorType.UNEXPECTED_ABSOLUTE_DEPTH_DECREASE_BELOW_ZERO -> {
+                            "Unexpected decrease in absolute depth: cannot go below zero"
+                        }
+                        ErrorType.UNEXPECTED_ABSOLUTE_DEPTH_NOT_ZERO_AT_EOF -> {
+                            "Unexpected non-zero value in absolute depth at end of file"
+                        }
+                        ErrorType.UNEXPECTED_EOF -> {
+                            "Unexpected end of file while try to do look-ahead"
+                        }
+                        ErrorType.INVALID_CMD_BYTE_PROVIDED -> {
+                            "Invalid command byte provided"
+                        }
                     }
-                    ErrorType.UNEXPECTED_CMD_BEGIN_HEADER -> {
-                        "Unexpected command: BEGIN_HEADER"
-                    }
-                    ErrorType.UNEXPECTED_CMD_BEGIN_PTREE_NODE -> {
-                        "Unexpected command: BEGIN_PTREE_NODE"
-                    }
-                    ErrorType.UNEXPECTED_CMD_DEFINE_SHORTCUT -> {
-                        "Unexpected command: DEFINE_SHORTCUT"
-                    }
-                    ErrorType.UNEXPECTED_CMD_END -> {
-                        "Unexpected command: END"
-                    }
-                    ErrorType.UNEXPECTED_CMD_END_ZERO_VALUE -> {
-                        "Unexpected zero value provided for command END"
-                    }
-                    ErrorType.UNEXPECTED_ABSOLUTE_DEPTH_DECREASE_BELOW_ZERO -> {
-                        "Unexpected decrease in absolute depth: cannot go below zero"
-                    }
-                    ErrorType.UNEXPECTED_ABSOLUTE_DEPTH_NOT_ZERO_AT_EOF -> {
-                        "Unexpected non-zero value in absolute depth at end of file"
-                    }
-                    ErrorType.UNEXPECTED_EOF -> {
-                        "Unexpected end of file while try to do look-ahead"
-                    }
-                    ErrorType.INVALID_CMD_BYTE_PROVIDED -> {
-                        "Invalid command byte provided"
-                    }
-                })
-                append(String.format("\n at address 0x%08X where cmd_byte=0x%02X and section_depth=%d", address, cmdByte, absoluteDepth))
+                )
+                append(
+                    String.format(
+                        "\n at address 0x%08X where cmd_byte=0x%02X and section_depth=%d",
+                        address,
+                        cmdByte,
+                        absoluteDepth
+                    )
+                )
                 toString()
             }
         }
     }
+}
+
+/**
+ * Reads the next [len] bytes from the input stream into the given byte array [b]. This method guarantees to either
+ * read the full length requested or if an EOF file is encountered, -1 is returned. The first byte written is at
+ * `b[off]`, the second byte at `b[off+1]` and so on.
+ *
+ * @param b The byte array to read the next [len] bytes into.
+ * @param off The offset of the first byte written in the byte array [b]. Must be non-negative.
+ * @param len The number of bytes to read. Must be non-negative.
+ *
+ * @return The number of bytes read, always matching [len] or -1 if EOF was encountered.
+ *
+ * @throws IndexOutOfBoundsException if either [off] or [len] is negative or the byte array has insufficient space to
+ *  write the request [len] bytes into it.
+ */
+@Throws(IndexOutOfBoundsException::class)
+fun InputStream.readNext(b: ByteArray, off: Int, len: Int): Int {
+    if (off < 0 || len < 0 || len > b.size - off) {
+        throw IndexOutOfBoundsException()
+    } else if (len == 0) {
+        return 0
+    }
+
+    var lenRead = 0
+    while (lenRead < len) {
+        val c = read()
+        if (c == -1) {
+            return -1
+        } else {
+            b[off + lenRead++] = c.toByte()
+        }
+    }
+    return lenRead
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/dictionary/Flictionary.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/dictionary/Flictionary.kt
@@ -138,28 +138,15 @@ class Flictionary private constructor(
                         }
                         if (inputStream.readNext(buffer, freqSize + 1, size) > 0) {
                             val char = String(buffer, freqSize + 1, size, Charsets.UTF_8)[0]
-
-                            val node = if (freq == NgramNode.FREQ_CHARACTER) {
-                                NgramNode(order, char, null, freq)
-                            } else {
-                                val precomputedWord = StringBuilder()
-                                val firstNodeIndex = ngramOrderStack.indexOfFirst { it == order }
-                                if (firstNodeIndex >= 0) {
-                                    for (n in firstNodeIndex until ngramOrderStack.size) {
-                                        precomputedWord.append(ngramTreeStack[n].char)
-                                    }
-                                }
-                                precomputedWord.append(char)
-                                NgramNode(order, char, precomputedWord.toString(), freq)
-                            }
+                            val node = NgramNode(order, char, freq)
                             val lastOrder = ngramOrderStack.lastOrNull()
                             if (lastOrder == null) {
-                                ngramTree.higherOrderChildren[char] = node
+                                ngramTree.higherOrderChildren.add(node)
                             } else {
                                 if (lastOrder == order) {
-                                    ngramTreeStack.last().sameOrderChildren[char] = node
+                                    ngramTreeStack.last().sameOrderChildren.add(node)
                                 } else {
-                                    ngramTreeStack.last().higherOrderChildren[char] = node
+                                    ngramTreeStack.last().higherOrderChildren.add(node)
                                 }
                             }
                             ngramOrderStack.add(order)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/nlp/FlorisLanguageModel.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/nlp/FlorisLanguageModel.kt
@@ -22,7 +22,7 @@ package dev.patrickgold.florisboard.ime.nlp
 open class NgramTree(
     sameOrderChildren: MutableMap<Char, NgramNode> = mutableMapOf(),
     higherOrderChildren: MutableMap<Char, NgramNode> = mutableMapOf()
-) : NgramNode(0, '?', "", -1, sameOrderChildren, higherOrderChildren)
+) : NgramNode(0, '?', null, -1, sameOrderChildren, higherOrderChildren)
 
 /**
  * A node of a n-gram tree, which holds the character it represents, the corresponding frequency,
@@ -32,7 +32,7 @@ open class NgramTree(
 open class NgramNode(
     val order: Int,
     val char: Char,
-    val word: String,
+    val word: String?,
     val freq: Int,
     val sameOrderChildren: MutableMap<Char, NgramNode> = mutableMapOf(),
     val higherOrderChildren: MutableMap<Char, NgramNode> = mutableMapOf()
@@ -97,7 +97,9 @@ open class NgramNode(
                     || !isPossiblyOffensive)) {
             // Using shift right instead of divide by 2^(costSum) as it is mathematically the
             // same but faster.
-            list.add(word, freq shr costSum)
+            if (word != null) {
+                list.add(word, freq shr costSum)
+            }
         }
         if (pos <= -1) {
             for (childNode in higherOrderChildren.values) {
@@ -146,7 +148,9 @@ open class NgramNode(
 
     fun listAllSameOrderWords(list: StagedSuggestionList<String, Int>, allowPossiblyOffensive: Boolean) {
         if (isWord && ((isPossiblyOffensive && allowPossiblyOffensive) || !isPossiblyOffensive)) {
-            list.add(word, freq)
+            if (word != null) {
+                list.add(word, freq)
+            }
         }
         for (childNode in sameOrderChildren.values) {
             childNode.listAllSameOrderWords(list, allowPossiblyOffensive)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/nlp/FlorisLanguageModel.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/nlp/FlorisLanguageModel.kt
@@ -92,7 +92,9 @@ open class NgramNode(
         substitutionCost: Int = 0,
         pos: Int = -1
     ) {
-        word.append(char)
+        if (pos > -1) {
+            word.append(char)
+        }
         val costSum = deletionCost + insertionCost + substitutionCost
         if (pos > -1 && (pos + 1 == input.length) && isWord && ((isPossiblyOffensive && allowPossiblyOffensive)
             || !isPossiblyOffensive)) {
@@ -145,7 +147,9 @@ open class NgramNode(
                 }
             }
         }
-        word.deleteAt(word.lastIndex)
+        if (pos > -1) {
+            word.deleteAt(word.lastIndex)
+        }
     }
 
     fun listAllSameOrderWords(list: StagedSuggestionList<String, Int>, word: StringBuilder, allowPossiblyOffensive: Boolean) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/nlp/StagedSuggestionList.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/nlp/StagedSuggestionList.kt
@@ -40,6 +40,10 @@ class StagedSuggestionList<T : Any, F : Comparable<F>>(
         }
     }
 
+    fun canAdd(freq: F): Boolean {
+        return internalSize < maxSize || internalArray.last()!!.freq < freq
+    }
+
     fun clear() {
         for (n in internalArray.indices) {
             internalArray[n] = null


### PR DESCRIPTION
This PR is a response to the reported memory crashes in #403 and attempts to fix them. In detail, this is what has been improved:

- The Flictionary load function previously created a lot of unnecessary allocations which it does not need. Additionally, the input stream of the binary raw file is now read as a stream, instead of per-caching the whole file before working with it.
- The NgramNode representation has also changed, so each node is much smaller in memory size than before. Also, the child nodes are now stored in an ArrayList rather than a LinkedHashMap, which vastly reduces the allocated memory size.