### PR TITLE
Input logic rework

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ trim_trailing_whitespace = true
 
 [{*.har,*.json}]
 indent_size = 2
+
+[*.kt]
+ij_kotlin_name_count_to_use_star_import = 99
+ij_kotlin_name_count_to_use_star_import_for_members = 99

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation("androidx.core", "core-ktx", "1.3.2")
     implementation("androidx.preference", "preference-ktx", "1.1.1")
     implementation("androidx.constraintlayout", "constraintlayout", "2.0.4")
+    implementation("androidx.lifecycle", "lifecycle-service", "2.2.0")
     implementation("com.google.android", "flexbox", "2.0.1") // requires jcenter as of version 2.0.1
     implementation("com.squareup.moshi", "moshi-kotlin", "1.11.0")
     implementation("com.squareup.moshi", "moshi-adapters", "1.11.0")

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -551,10 +551,13 @@ class EditorInstance private constructor(
      *
      * @param keyEventCode The key code to send, use a key code defined in Android's [KeyEvent].
      * @param metaState Flags indicating which meta keys are currently pressed.
+     * @param count How often the key is pressed while the meta keys passed are down. Must be greater than or equal to
+     *  `1`, else this method will immediately return false.
+     *
      * @return True on success, false if an error occurred or the input connection is invalid.
      */
-    fun sendDownUpKeyEvent(keyEventCode: Int, metaState: Int = meta(), repeatCount: Int = 1): Boolean {
-        if (repeatCount < 1) return false
+    fun sendDownUpKeyEvent(keyEventCode: Int, metaState: Int = meta(), count: Int = 1): Boolean {
+        if (count < 1) return false
         val eventTime = SystemClock.uptimeMillis()
         if (metaState and KeyEvent.META_CTRL_ON > 0) {
             sendDownKeyEvent(eventTime, KeyEvent.KEYCODE_CTRL_LEFT, 0)
@@ -565,7 +568,7 @@ class EditorInstance private constructor(
         if (metaState and KeyEvent.META_SHIFT_ON > 0) {
             sendDownKeyEvent(eventTime, KeyEvent.KEYCODE_SHIFT_LEFT, 0)
         }
-        for (n in 0 until repeatCount) {
+        for (n in 0 until count) {
             sendDownKeyEvent(eventTime, keyEventCode, metaState)
             sendUpKeyEvent(eventTime, keyEventCode, metaState)
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -553,7 +553,8 @@ class EditorInstance private constructor(
      * @param metaState Flags indicating which meta keys are currently pressed.
      * @return True on success, false if an error occurred or the input connection is invalid.
      */
-    fun sendDownUpKeyEvent(keyEventCode: Int, metaState: Int = meta()): Boolean {
+    fun sendDownUpKeyEvent(keyEventCode: Int, metaState: Int = meta(), repeatCount: Int = 1): Boolean {
+        if (repeatCount < 1) return false
         val eventTime = SystemClock.uptimeMillis()
         if (metaState and KeyEvent.META_CTRL_ON > 0) {
             sendDownKeyEvent(eventTime, KeyEvent.KEYCODE_CTRL_LEFT, 0)
@@ -564,8 +565,10 @@ class EditorInstance private constructor(
         if (metaState and KeyEvent.META_SHIFT_ON > 0) {
             sendDownKeyEvent(eventTime, KeyEvent.KEYCODE_SHIFT_LEFT, 0)
         }
-        sendDownKeyEvent(eventTime, keyEventCode, metaState)
-        sendUpKeyEvent(eventTime, keyEventCode, metaState)
+        for (n in 0 until repeatCount) {
+            sendDownKeyEvent(eventTime, keyEventCode, metaState)
+            sendUpKeyEvent(eventTime, keyEventCode, metaState)
+        }
         if (metaState and KeyEvent.META_SHIFT_ON > 0) {
             sendUpKeyEvent(eventTime, KeyEvent.KEYCODE_SHIFT_LEFT, 0)
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -101,6 +101,7 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, ClipboardManager.OnPri
     private var currentThemeIsNight: Boolean = false
     private var currentThemeResId: Int = 0
     private var isNumberRowVisible: Boolean = false
+    private var isWindowShown: Boolean = false
 
     val textInputManager: TextInputManager
     val mediaInputManager: MediaInputManager
@@ -358,7 +359,13 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, ClipboardManager.OnPri
     }
 
     override fun onWindowShown() {
-        Timber.i("onWindowShown()")
+        if (isWindowShown) {
+            Timber.i("Ignoring onWindowShown()")
+            return
+        } else {
+            Timber.i("onWindowShown()")
+        }
+        isWindowShown = true
 
         prefs.sync()
         val newIsNumberRowVisible = prefs.keyboard.numberRow
@@ -377,7 +384,13 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, ClipboardManager.OnPri
     }
 
     override fun onWindowHidden() {
-        Timber.i("onWindowHidden()")
+        if (!isWindowShown) {
+            Timber.i("Ignoring onWindowHidden()")
+            return
+        } else {
+            Timber.i("onWindowHidden()")
+        }
+        isWindowShown = false
 
         super.onWindowHidden()
         eventListeners.toList().forEach { it?.onWindowHidden() }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -32,6 +32,7 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import android.provider.Settings
 import android.view.*
+import android.view.inputmethod.CursorAnchorInfo
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputMethodManager
@@ -325,7 +326,7 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, ClipboardManager.OnPri
         Timber.i("onStartInput($attribute, $restarting)")
 
         super.onStartInput(attribute, restarting)
-        currentInputConnection?.requestCursorUpdates(InputConnection.CURSOR_UPDATE_IMMEDIATE)
+        currentInputConnection?.requestCursorUpdates(InputConnection.CURSOR_UPDATE_MONITOR or InputConnection.CURSOR_UPDATE_IMMEDIATE)
     }
 
     override fun onStartInputView(info: EditorInfo?, restarting: Boolean) {
@@ -405,23 +406,11 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, ClipboardManager.OnPri
         super.onConfigurationChanged(newConfig)
     }
 
-    override fun onUpdateSelection(
-        oldSelStart: Int, oldSelEnd: Int,
-        newSelStart: Int, newSelEnd: Int,
-        candidatesStart: Int, candidatesEnd: Int
-    ) {
-        Timber.i("onUpdateSelection($oldSelStart, $oldSelEnd, $newSelStart, $newSelEnd, $candidatesStart, $candidatesEnd)")
+    override fun onUpdateCursorAnchorInfo(cursorAnchorInfo: CursorAnchorInfo?) {
+        Timber.i("onUpdateCursorAnchorInfo()")
+        super.onUpdateCursorAnchorInfo(cursorAnchorInfo)
 
-        super.onUpdateSelection(
-            oldSelStart, oldSelEnd,
-            newSelStart, newSelEnd,
-            candidatesStart, candidatesEnd
-        )
-        activeEditorInstance.onUpdateSelection(
-            oldSelStart, oldSelEnd,
-            newSelStart, newSelEnd,
-            candidatesStart, candidatesEnd
-        )
+        activeEditorInstance.onUpdateSelection(cursorAnchorInfo)
         eventListeners.toList().forEach { it?.onUpdateSelection() }
     }
 
@@ -611,7 +600,7 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, ClipboardManager.OnPri
         i.flags = Intent.FLAG_ACTIVITY_NEW_TASK or
                   Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED or
                   Intent.FLAG_ACTIVITY_CLEAR_TOP
-        startActivity(i)
+        applicationContext.startActivity(i)
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputEventDispatcher.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputEventDispatcher.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2021 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.core
+
+import android.os.SystemClock
+import dev.patrickgold.florisboard.BuildConfig
+import dev.patrickgold.florisboard.ime.text.key.KeyCode
+import dev.patrickgold.florisboard.ime.text.key.KeyData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+class InputEventDispatcher private constructor(
+    parentScope: CoroutineScope,
+    channelCapacity: Int,
+    private val mainDispatcher: CoroutineDispatcher,
+    private val defaultDispatcher: CoroutineDispatcher,
+    private val requiredDownUpKeyCodes: List<Int>
+) : InputKeyEventSender {
+    private val channel: Channel<InputKeyEvent> = Channel(channelCapacity)
+    private val scope: CoroutineScope = CoroutineScope(parentScope.coroutineContext)
+    private val jobs: MutableMap<Int, Job> = mutableMapOf()
+    private var lastKeyEvent: InputKeyEvent? = null
+
+    var keyEventReceiver: InputKeyEventReceiver? = null
+
+    companion object {
+        private const val DEFAULT_CHANNEL_CAPACITY: Int = 32
+
+        fun new(
+            parentScope: CoroutineScope,
+            channelCapacity: Int = DEFAULT_CHANNEL_CAPACITY,
+            mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
+            defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
+            requiredDownUpKeyCodes: List<Int>
+        ): InputEventDispatcher {
+            return InputEventDispatcher(
+                parentScope,
+                channelCapacity,
+                mainDispatcher,
+                defaultDispatcher,
+                requiredDownUpKeyCodes.toList()
+            )
+        }
+    }
+
+    init {
+        scope.launch(defaultDispatcher) {
+            for (ev in channel) {
+                if (!isActive) break
+                val startTime = System.nanoTime()
+                if (BuildConfig.DEBUG) {
+                    Timber.d(ev.toString())
+                }
+                when (ev.action) {
+                    InputKeyEvent.Action.DOWN -> {
+                        if (jobs.containsKey(ev.data.code)) continue
+                        jobs[ev.data.code] = scope.launch(defaultDispatcher) {
+                            delay(600)
+                            while (isActive) {
+                                if (ev.data.code != KeyCode.SHIFT) {
+                                    channel.send(InputKeyEvent.repeat(ev.data))
+                                }
+                                delay(25)
+                            }
+                        }
+                        withContext(mainDispatcher) {
+                            keyEventReceiver?.onInputKeyDown(ev)
+                        }
+                    }
+                    InputKeyEvent.Action.DOWN_UP -> {
+                        jobs.remove(ev.data.code)?.cancel()
+                        withContext(mainDispatcher) {
+                            keyEventReceiver?.onInputKeyDown(ev)
+                            keyEventReceiver?.onInputKeyUp(ev)
+                        }
+                        lastKeyEvent = ev
+                    }
+                    InputKeyEvent.Action.UP -> {
+                        if (jobs.containsKey(ev.data.code)) {
+                            jobs.remove(ev.data.code)?.cancel()
+                            withContext(mainDispatcher) {
+                                keyEventReceiver?.onInputKeyUp(ev)
+                            }
+                            lastKeyEvent = ev
+                        }
+                    }
+                    InputKeyEvent.Action.REPEAT -> {
+                        if (jobs.containsKey(ev.data.code)) {
+                            withContext(mainDispatcher) {
+                                keyEventReceiver?.onInputKeyRepeat(ev)
+                            }
+                        }
+                    }
+                    InputKeyEvent.Action.CANCEL -> {
+                        if (jobs.containsKey(ev.data.code)) {
+                            withContext(mainDispatcher) {
+                                keyEventReceiver?.onInputKeyCancel(ev)
+                            }
+                        }
+                    }
+                }
+                if (BuildConfig.DEBUG) {
+                    Timber.d("Time elapsed: ${(System.nanoTime() - startTime) / 1_000_000}")
+                }
+            }
+            val jobIterator = jobs.iterator()
+            while (jobIterator.hasNext()) {
+                jobIterator.next().value.cancel()
+                jobIterator.remove()
+            }
+        }
+    }
+
+    override fun send(ev: InputKeyEvent) {
+        scope.launch(defaultDispatcher) {
+            channel.send(ev)
+        }
+    }
+
+    fun isPressed(code: Int): Boolean {
+        return jobs.containsKey(code)
+    }
+
+    fun isConsecutiveOfLastEvent(ev: InputKeyEvent, maxEventTimeDiff: Long): Boolean {
+        return ev.isConsecutiveEventOf(lastKeyEvent, maxEventTimeDiff)
+    }
+
+    fun requireSeparateDownUp(code: Int): Boolean {
+        return requiredDownUpKeyCodes.contains(code)
+    }
+
+    fun close() {
+        keyEventReceiver = null
+        scope.cancel()
+    }
+}
+
+data class InputKeyEvent(
+    val eventTime: Long,
+    val action: Action,
+    val data: KeyData,
+    val count: Int
+) {
+    companion object {
+        fun down(keyData: KeyData): InputKeyEvent {
+            return InputKeyEvent(
+                eventTime = SystemClock.uptimeMillis(),
+                action = Action.DOWN,
+                data = keyData,
+                count = 1
+            )
+        }
+
+        fun downUp(keyData: KeyData, count: Int = 1): InputKeyEvent {
+            return InputKeyEvent(
+                eventTime = SystemClock.uptimeMillis(),
+                action = Action.DOWN_UP,
+                data = keyData,
+                count = count
+            )
+        }
+
+        fun up(keyData: KeyData): InputKeyEvent {
+            return InputKeyEvent(
+                eventTime = SystemClock.uptimeMillis(),
+                action = Action.UP,
+                data = keyData,
+                count = 1
+            )
+        }
+
+        fun repeat(keyData: KeyData): InputKeyEvent {
+            return InputKeyEvent(
+                eventTime = SystemClock.uptimeMillis(),
+                action = Action.REPEAT,
+                data = keyData,
+                count = 1
+            )
+        }
+
+        fun cancel(keyData: KeyData): InputKeyEvent {
+            return InputKeyEvent(
+                eventTime = SystemClock.uptimeMillis(),
+                action = Action.CANCEL,
+                data = keyData,
+                count = 1
+            )
+        }
+    }
+
+    fun isConsecutiveEventOf(other: InputKeyEvent?, maxEventTimeDiff: Long): Boolean {
+        return other != null && data.code == other.data.code && eventTime - other.eventTime <= maxEventTimeDiff
+    }
+
+    override fun toString(): String {
+        return "FlorisKeyEvent { eventTime=${eventTime}ms, action=$action, data=$data, repeatCount=$count }"
+    }
+
+    enum class Action {
+        DOWN,
+        DOWN_UP,
+        UP,
+        REPEAT,
+        CANCEL,
+    }
+}
+
+interface InputKeyEventSender {
+    fun send(ev: InputKeyEvent)
+}
+
+interface InputKeyEventReceiver {
+    fun onInputKeyDown(ev: InputKeyEvent)
+
+    fun onInputKeyUp(ev: InputKeyEvent)
+
+    fun onInputKeyRepeat(ev: InputKeyEvent)
+
+    fun onInputKeyCancel(ev: InputKeyEvent)
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputEventDispatcher.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputEventDispatcher.kt
@@ -32,38 +32,59 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
+/**
+ * The main logic point of processing input events and delegating them to the registered event receivers. Currently,
+ * only [InputKeyEvent]s are supported, but in the future this class is thought to be the single point where input
+ * events can be dispatched.
+ */
 class InputEventDispatcher private constructor(
     parentScope: CoroutineScope,
     channelCapacity: Int,
     private val mainDispatcher: CoroutineDispatcher,
     private val defaultDispatcher: CoroutineDispatcher,
-    private val requiredDownUpKeyCodes: List<Int>
+    private val requiredDownUpKeyCodes: IntArray
 ) : InputKeyEventSender {
     private val channel: Channel<InputKeyEvent> = Channel(channelCapacity)
     private val scope: CoroutineScope = CoroutineScope(parentScope.coroutineContext)
     private val jobs: MutableMap<Int, Job> = mutableMapOf()
     private var lastKeyEvent: InputKeyEvent? = null
 
+    /**
+     * The input key event register. If null, the dispatcher will still process input, but won't dispatch them to an
+     * event receiver.
+     */
     var keyEventReceiver: InputKeyEventReceiver? = null
 
     companion object {
+        /**
+         * The default input event channel capacity to be used in [new].
+         */
         private const val DEFAULT_CHANNEL_CAPACITY: Int = 32
 
+        /**
+         * Creates a new [InputEventDispatcher] instance from given arguments and returns it.
+         *
+         * @param parentScope The parent coroutine scope which this dispatcher will attach its own scope to.
+         * @param channelCapacity The capacity of this input channel, defaults to [DEFAULT_CHANNEL_CAPACITY].
+         * @param mainDispatcher The main dispatcher used to switch the context to call the receiver callbacks.
+         *  Defaults to [Dispatchers.Main].
+         * @param defaultDispatcher The default dispatcher used to switch the context to call the receiver callbacks.
+         *  Defaults to [Dispatchers.Default].
+         * @param requiredDownUpKeyCodes An int array of all key codes which require separate down/up events. This does
+         *  nothing in this dispatcher, but is used by [requireSeparateDownUp] to return a boolean result. Defaults to
+         *  an empty array.
+         *
+         * @return A new [InputEventDispatcher] instance initialized with given arguments.
+         */
         fun new(
             parentScope: CoroutineScope,
             channelCapacity: Int = DEFAULT_CHANNEL_CAPACITY,
             mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
             defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
-            requiredDownUpKeyCodes: List<Int>
-        ): InputEventDispatcher {
-            return InputEventDispatcher(
-                parentScope,
-                channelCapacity,
-                mainDispatcher,
-                defaultDispatcher,
-                requiredDownUpKeyCodes.toList()
-            )
-        }
+            requiredDownUpKeyCodes: IntArray = intArrayOf()
+        ): InputEventDispatcher = InputEventDispatcher(
+            parentScope, channelCapacity, mainDispatcher, defaultDispatcher, requiredDownUpKeyCodes.clone()
+        )
     }
 
     init {
@@ -140,24 +161,58 @@ class InputEventDispatcher private constructor(
         }
     }
 
+    /**
+     * Checks if there's currently a key down with given [code].
+     *
+     * @param code The key code to check for.
+     *
+     * @return True if the given [code] is currently down, false otherwise.
+     */
     fun isPressed(code: Int): Boolean {
         return jobs.containsKey(code)
     }
 
+    /**
+     * Checks if a given event [ev] is a consecutive event of the last event.
+     *
+     * @param ev The event to check for.
+     * @param maxEventTimeDiff The maximum event time diff between [ev] and the last event, in milliseconds.
+     */
     fun isConsecutiveOfLastEvent(ev: InputKeyEvent, maxEventTimeDiff: Long): Boolean {
         return ev.isConsecutiveEventOf(lastKeyEvent, maxEventTimeDiff)
     }
 
+    /**
+     * Checks if given [code] requires a separate down/up.
+     *
+     * @param code The key code to check for.
+     *
+     * @return True if the given [code] requires a separate down/up, false otherwise.
+     */
     fun requireSeparateDownUp(code: Int): Boolean {
         return requiredDownUpKeyCodes.contains(code)
     }
 
+    /**
+     * Closes this dispatcher and cancels the local coroutine scope.
+     */
     fun close() {
         keyEventReceiver = null
         scope.cancel()
     }
 }
 
+/**
+ * Data class representing a single input key event.
+ *
+ * @property eventTime The exact event time when this event occurred, measured in milliseconds since a static point in
+ *  the past. The exact point is irrelevant, but while this input dispatcher is active, the point must not change in
+ *  order for difference time calculation to succeed.
+ * @property action The action of this event.
+ * @property data The data of this event.
+ * @property count The count how often this event occurred. Is only respected by other methods if the [action] of this
+ *  event is [Action.DOWN_UP], else always 1 is assumed.
+ */
 data class InputKeyEvent(
     val eventTime: Long,
     val action: Action,
@@ -165,6 +220,13 @@ data class InputKeyEvent(
     val count: Int
 ) {
     companion object {
+        /**
+         * Creates a new input key event with given [keyData] and sets the action to [Action.DOWN].
+         *
+         * @param keyData The key data of the input key event event to create.
+         *
+         * @return The created input key event.
+         */
         fun down(keyData: KeyData): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
@@ -174,6 +236,14 @@ data class InputKeyEvent(
             )
         }
 
+        /**
+         * Creates a new input key event with given [keyData] and sets the action to [Action.DOWN_UP].
+         *
+         * @param keyData The key data of the input key event event to create.
+         * @param count How often this event occurred. Must be grater or equal to 1, defaults to 1.
+         *
+         * @return The created input key event.
+         */
         fun downUp(keyData: KeyData, count: Int = 1): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
@@ -183,6 +253,13 @@ data class InputKeyEvent(
             )
         }
 
+        /**
+         * Creates a new input key event with given [keyData] and sets the action to [Action.UP].
+         *
+         * @param keyData The key data of the input key event event to create.
+         *
+         * @return The created input key event.
+         */
         fun up(keyData: KeyData): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
@@ -192,6 +269,13 @@ data class InputKeyEvent(
             )
         }
 
+        /**
+         * Creates a new input key event with given [keyData] and sets the action to [Action.REPEAT].
+         *
+         * @param keyData The key data of the input key event event to create.
+         *
+         * @return The created input key event.
+         */
         fun repeat(keyData: KeyData): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
@@ -201,6 +285,13 @@ data class InputKeyEvent(
             )
         }
 
+        /**
+         * Creates a new input key event with given [keyData] and sets the action to [Action.CANCEL].
+         *
+         * @param keyData The key data of the input key event event to create.
+         *
+         * @return The created input key event.
+         */
         fun cancel(keyData: KeyData): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
@@ -211,14 +302,28 @@ data class InputKeyEvent(
         }
     }
 
+    /**
+     * Checks if the [other] input key event is a consecutive event while respecting [maxEventTimeDiff].
+     *
+     * @param other The other input key event to compare with this one.
+     * @param maxEventTimeDiff The maximum event time diff between this event and [other], in milliseconds.
+     *
+     * @return True if this event is a consecutive event of [other], false otherwise.
+     */
     fun isConsecutiveEventOf(other: InputKeyEvent?, maxEventTimeDiff: Long): Boolean {
         return other != null && data.code == other.data.code && eventTime - other.eventTime <= maxEventTimeDiff
     }
 
+    /**
+     * Returns a string representation of this input key event.
+     */
     override fun toString(): String {
-        return "FlorisKeyEvent { eventTime=${eventTime}ms, action=$action, data=$data, repeatCount=$count }"
+        return "FlorisKeyEvent { eventTime=${eventTime}ms, action=$action, data=$data, count=$count }"
     }
 
+    /**
+     * The action of an input key event.
+     */
     enum class Action {
         DOWN,
         DOWN_UP,
@@ -228,16 +333,47 @@ data class InputKeyEvent(
     }
 }
 
+/**
+ * Interface which represents an input key event sender.
+ */
 interface InputKeyEventSender {
+    /**
+     * Sends given input key event [ev] to the underlying input channel, awaiting to be processed.
+     *
+     * @param ev The input key event to send.
+     */
     fun send(ev: InputKeyEvent)
 }
 
+/**
+ * Interface which represents an input key event receiver.
+ */
 interface InputKeyEventReceiver {
+    /**
+     * Event method which gets called when a key went down.
+     *
+     * @param ev The associated input key event.
+     */
     fun onInputKeyDown(ev: InputKeyEvent)
 
+    /**
+     * Event method which gets called when a key went up.
+     *
+     * @param ev The associated input key event.
+     */
     fun onInputKeyUp(ev: InputKeyEvent)
 
+    /**
+     * Event method which gets called when a key is called repeatedly while being pressed down.
+     *
+     * @param ev The associated input key event.
+     */
     fun onInputKeyRepeat(ev: InputKeyEvent)
 
+    /**
+     * Event method which gets called when a key press is cancelled.
+     *
+     * @param ev The associated input key event.
+     */
     fun onInputKeyCancel(ev: InputKeyEvent)
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputEventDispatcher.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputEventDispatcher.kt
@@ -159,9 +159,6 @@ class InputEventDispatcher private constructor(
 
     override fun send(ev: InputKeyEvent) {
         scope.launch(mainDispatcher) {
-            if (ev.action == InputKeyEvent.Action.UP) {
-                pressedKeys.remove(ev.data.code)?.repeatKeyPressJob?.cancel()
-            }
             channel.send(ev)
         }
     }
@@ -175,16 +172,6 @@ class InputEventDispatcher private constructor(
      */
     fun isPressed(code: Int): Boolean {
         return pressedKeys.containsKey(code)
-    }
-
-    /**
-     * Checks if a given event [ev] is a consecutive event of the last event.
-     *
-     * @param ev The event to check for.
-     * @param maxEventTimeDiff The maximum event time diff between [ev] and the last event, in milliseconds.
-     */
-    fun isConsecutiveOfLastEvent(ev: InputKeyEvent, maxEventTimeDiff: Long): Boolean {
-        return ev.isConsecutiveEventOf(lastKeyEventUp, maxEventTimeDiff)
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
@@ -24,12 +24,12 @@ import com.google.android.material.tabs.TabLayout
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.EditorInstance
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
+import dev.patrickgold.florisboard.ime.core.InputKeyEvent
 import dev.patrickgold.florisboard.ime.core.InputView
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiKeyData
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiKeyboardView
 import dev.patrickgold.florisboard.ime.media.emoticon.EmoticonKeyData
 import dev.patrickgold.florisboard.ime.media.emoticon.EmoticonKeyboardView
-import dev.patrickgold.florisboard.ime.text.FlorisKeyEvent
 import dev.patrickgold.florisboard.ime.text.key.KeyData
 import kotlinx.coroutines.*
 import timber.log.Timber
@@ -143,20 +143,20 @@ class MediaInputManager private constructor() : CoroutineScope by MainScope(),
             MotionEvent.ACTION_DOWN -> {
                 florisboard.keyPressVibrate()
                 florisboard.keyPressSound(data)
-                if (FlorisKeyEvent.requireSeparateDownUp(data.code)) {
-                    florisboard.textInputManager.sendKeyEvent(FlorisKeyEvent.down(data))
+                if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code)) {
+                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.down(data))
                 }
             }
             MotionEvent.ACTION_UP -> {
-                if (FlorisKeyEvent.requireSeparateDownUp(data.code)) {
-                    florisboard.textInputManager.sendKeyEvent(FlorisKeyEvent.up(data))
+                if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code)) {
+                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.up(data))
                 } else {
-                    florisboard.textInputManager.sendKeyEvent(FlorisKeyEvent.downUp(data))
+                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(data))
                 }
             }
             MotionEvent.ACTION_CANCEL -> {
-                if (FlorisKeyEvent.requireSeparateDownUp(data.code)) {
-                    florisboard.textInputManager.sendKeyEvent(FlorisKeyEvent.cancel(data))
+                if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code)) {
+                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(data))
                 }
             }
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
@@ -143,21 +143,13 @@ class MediaInputManager private constructor() : CoroutineScope by MainScope(),
             MotionEvent.ACTION_DOWN -> {
                 florisboard.keyPressVibrate()
                 florisboard.keyPressSound(data)
-                if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code)) {
-                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.down(data))
-                }
+                florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.down(data))
             }
             MotionEvent.ACTION_UP -> {
-                if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code)) {
-                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.up(data))
-                } else {
-                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(data))
-                }
+                florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.up(data))
             }
             MotionEvent.ACTION_CANCEL -> {
-                if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code)) {
-                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(data))
-                }
+                florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(data))
             }
         }
         // MUST return false here so the background selector for showing a transparent bg works

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
@@ -33,6 +33,8 @@ import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
 
 /**
  * View class for managing the rendering and the events of a single emoji keyboard key.
@@ -46,7 +48,7 @@ import dev.patrickgold.florisboard.ime.theme.ThemeManager
 class EmojiKeyView(
     private val emojiKeyboardView: EmojiKeyboardView,
     val data: EmojiKeyData
-) : androidx.appcompat.widget.AppCompatTextView(emojiKeyboardView.context),
+) : androidx.appcompat.widget.AppCompatTextView(emojiKeyboardView.context), CoroutineScope by MainScope(),
     FlorisBoard.EventListener, ThemeManager.OnThemeUpdatedListener {
     private val florisboard: FlorisBoard? = FlorisBoard.getInstanceOrNull()
     private val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -73,7 +73,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
     private var activeDictionary: Dictionary<String, Int>? = null
     val inputEventDispatcher: InputEventDispatcher = InputEventDispatcher.new(
         parentScope = this,
-        requiredDownUpKeyCodes = listOf(
+        requiredDownUpKeyCodes = intArrayOf(
             KeyCode.ARROW_DOWN,
             KeyCode.ARROW_LEFT,
             KeyCode.ARROW_RIGHT,
@@ -543,7 +543,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
     /**
      * Handles [KeyCode] arrow and move events, behaves differently depending on text selection.
      */
-    private fun handleArrow(code: Int, repeatCount: Int) = activeEditorInstance.apply {
+    private fun handleArrow(code: Int, count: Int) = activeEditorInstance.apply {
         val isShiftPressed = isManualSelectionMode || inputEventDispatcher.isPressed(KeyCode.SHIFT)
         when (code) {
             KeyCode.ARROW_DOWN -> {
@@ -551,56 +551,56 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
                     isManualSelectionModeStart = false
                     isManualSelectionModeEnd = true
                 }
-                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_DOWN, meta(shift = isShiftPressed), repeatCount)
+                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_DOWN, meta(shift = isShiftPressed), count)
             }
             KeyCode.ARROW_LEFT -> {
                 if (!selection.isSelectionMode && isManualSelectionMode) {
                     isManualSelectionModeStart = true
                     isManualSelectionModeEnd = false
                 }
-                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_LEFT, meta(shift = isShiftPressed), repeatCount)
+                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_LEFT, meta(shift = isShiftPressed), count)
             }
             KeyCode.ARROW_RIGHT -> {
                 if (!selection.isSelectionMode && isManualSelectionMode) {
                     isManualSelectionModeStart = false
                     isManualSelectionModeEnd = true
                 }
-                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_RIGHT, meta(shift = isShiftPressed), repeatCount)
+                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_RIGHT, meta(shift = isShiftPressed), count)
             }
             KeyCode.ARROW_UP -> {
                 if (!selection.isSelectionMode && isManualSelectionMode) {
                     isManualSelectionModeStart = true
                     isManualSelectionModeEnd = false
                 }
-                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_UP, meta(shift = isShiftPressed), repeatCount)
+                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_UP, meta(shift = isShiftPressed), count)
             }
             KeyCode.MOVE_START_OF_PAGE -> {
                 if (!selection.isSelectionMode && isManualSelectionMode) {
                     isManualSelectionModeStart = true
                     isManualSelectionModeEnd = false
                 }
-                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_UP, meta(alt = true, shift = isShiftPressed), repeatCount)
+                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_UP, meta(alt = true, shift = isShiftPressed), count)
             }
             KeyCode.MOVE_END_OF_PAGE -> {
                 if (!selection.isSelectionMode && isManualSelectionMode) {
                     isManualSelectionModeStart = false
                     isManualSelectionModeEnd = true
                 }
-                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_DOWN, meta(alt = true, shift = isShiftPressed), repeatCount)
+                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_DOWN, meta(alt = true, shift = isShiftPressed), count)
             }
             KeyCode.MOVE_START_OF_LINE -> {
                 if (!selection.isSelectionMode && isManualSelectionMode) {
                     isManualSelectionModeStart = true
                     isManualSelectionModeEnd = false
                 }
-                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_LEFT, meta(alt = true, shift = isShiftPressed), repeatCount)
+                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_LEFT, meta(alt = true, shift = isShiftPressed), count)
             }
             KeyCode.MOVE_END_OF_LINE -> {
                 if (!selection.isSelectionMode && isManualSelectionMode) {
                     isManualSelectionModeStart = false
                     isManualSelectionModeEnd = true
                 }
-                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_RIGHT, meta(alt = true, shift = isShiftPressed), repeatCount)
+                sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_RIGHT, meta(alt = true, shift = isShiftPressed), count)
             }
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -366,7 +366,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
         if (BuildConfig.DEBUG) {
             Timber.i("current word: ${activeEditorInstance.cachedInput.currentWord.text}")
         }
-        if (activeEditorInstance.isComposingEnabled) {
+        if (activeEditorInstance.isComposingEnabled && !keyEventJobs.containsKey(KeyCode.DELETE)) {
             if (activeEditorInstance.shouldReevaluateComposingSuggestions) {
                 activeEditorInstance.shouldReevaluateComposingSuggestions = false
                 activeDictionary?.let {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -548,6 +548,21 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
     }
 
     /**
+     * Handles a [KeyCode.SHIFT] up event.
+     */
+    private fun handleShiftLock() {
+        val lastKeyEvent = inputEventDispatcher.lastKeyEventDown ?: return
+        Timber.d(lastKeyEvent.toString())
+        if (lastKeyEvent.data.code == KeyCode.SHIFT && lastKeyEvent.action == InputKeyEvent.Action.DOWN) {
+            newCapsState = true
+            caps = true
+            capsLock = true
+            keyboardViews[activeKeyboardMode]?.invalidateAllKeys()
+            smartbarView?.updateCandidateSuggestionCapsState()
+        }
+    }
+
+    /**
      * Handles a [KeyCode.SPACE] event. Also handles the auto-correction of two space taps if
      * enabled by the user.
      */
@@ -696,6 +711,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
             KeyCode.LANGUAGE_SWITCH -> handleLanguageSwitch()
             KeyCode.SETTINGS -> florisboard.launchSettings()
             KeyCode.SHIFT -> handleShiftUp()
+            KeyCode.SHIFT_LOCK -> handleShiftLock()
             KeyCode.SHOW_INPUT_METHOD_PICKER -> florisboard.imeManager?.showInputMethodPicker()
             KeyCode.SWITCH_TO_MEDIA_CONTEXT -> florisboard.setActiveInput(R.id.media_input)
             KeyCode.SWITCH_TO_TEXT_CONTEXT -> florisboard.setActiveInput(R.id.text_input)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -437,24 +437,16 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
             R.id.quick_action_open_settings -> florisboard.launchSettings()
             R.id.quick_action_one_handed_toggle -> florisboard.toggleOneHandedMode(isRight = true)
             R.id.quick_action_undo -> {
-                handleUndo()
+                activeEditorInstance.performUndo()
                 return
             }
             R.id.quick_action_redo -> {
-                handleRedo()
+                activeEditorInstance.performRedo()
                 return
             }
         }
         smartbarView?.isQuickActionsVisible = false
         smartbarView?.updateSmartbarState()
-    }
-
-    private fun handleUndo(){
-        activeEditorInstance.performUndo()
-    }
-
-    private fun handleRedo(){
-        activeEditorInstance.performRedo()
     }
 
     /**
@@ -514,7 +506,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
      * Handles a [KeyCode.SHIFT] down event.
      */
     private fun handleShiftDown(ev: InputKeyEvent) {
-        if (inputEventDispatcher.isConsecutiveOfLastEvent(ev, florisboard.prefs.keyboard.longPressDelay.toLong())) {
+        if (ev.isConsecutiveEventOf(inputEventDispatcher.lastKeyEventDown, florisboard.prefs.keyboard.longPressDelay.toLong())) {
             newCapsState = true
             caps = true
             capsLock = true
@@ -551,7 +543,6 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
      */
     private fun handleShiftLock() {
         val lastKeyEvent = inputEventDispatcher.lastKeyEventDown ?: return
-        Timber.d(lastKeyEvent.toString())
         if (lastKeyEvent.data.code == KeyCode.SHIFT && lastKeyEvent.action == InputKeyEvent.Action.DOWN) {
             newCapsState = true
             caps = true
@@ -567,7 +558,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
      */
     private fun handleSpace(ev: InputKeyEvent) {
         if (florisboard.prefs.correction.doubleSpacePeriod) {
-            if (inputEventDispatcher.isConsecutiveOfLastEvent(ev, florisboard.prefs.keyboard.longPressDelay.toLong())) {
+            if (ev.isConsecutiveEventOf(inputEventDispatcher.lastKeyEventUp, florisboard.prefs.keyboard.longPressDelay.toLong())) {
                 val text = activeEditorInstance.getTextBeforeCursor(2)
                 if (text.length == 2 && !text.matches("""[.!?‽\s][\s]""".toRegex())) {
                     activeEditorInstance.deleteBackwards()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -73,14 +73,13 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
     private var activeDictionary: Dictionary<String, Int>? = null
     val inputEventDispatcher: InputEventDispatcher = InputEventDispatcher.new(
         parentScope = this,
-        requiredDownUpKeyCodes = intArrayOf(
+        repeatableKeyCodes = intArrayOf(
             KeyCode.ARROW_DOWN,
             KeyCode.ARROW_LEFT,
             KeyCode.ARROW_RIGHT,
             KeyCode.ARROW_UP,
             KeyCode.DELETE,
-            KeyCode.FORWARD_DELETE,
-            KeyCode.SHIFT
+            KeyCode.FORWARD_DELETE
         )
     )
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -124,7 +124,10 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(),
                             }
                         }
                     }
-                    FlorisKeyEvent.Action.DOWN_UP,
+                    FlorisKeyEvent.Action.DOWN_UP -> {
+                        handleKeyEvent(ev)
+                        lastKeyEvent = ev
+                    }
                     FlorisKeyEvent.Action.UP -> {
                         keyEventJobs.remove(ev.data.code)?.cancel()
                         handleKeyEvent(ev)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -654,6 +654,10 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
 
     override fun onInputKeyDown(ev: InputKeyEvent) {
         when (ev.data.code) {
+            KeyCode.INTERNAL_BATCH_EDIT -> {
+                florisboard.beginInternalBatchEdit()
+                return
+            }
             KeyCode.SHIFT -> {
                 handleShiftDown(ev)
             }
@@ -669,7 +673,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
             KeyCode.MOVE_START_OF_PAGE,
             KeyCode.MOVE_END_OF_PAGE,
             KeyCode.MOVE_START_OF_LINE,
-            KeyCode.MOVE_END_OF_LINE -> if (ev.action == InputKeyEvent.Action.DOWN_UP) {
+            KeyCode.MOVE_END_OF_LINE -> if (ev.action == InputKeyEvent.Action.DOWN_UP || ev.action == InputKeyEvent.Action.REPEAT) {
                 handleArrow(ev.data.code, ev.count)
             } else {
                 handleArrow(ev.data.code, 1)
@@ -697,6 +701,10 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
             KeyCode.ENTER -> {
                 handleEnter()
                 smartbarView?.resetClipboardSuggestion()
+            }
+            KeyCode.INTERNAL_BATCH_EDIT -> {
+                florisboard.endInternalBatchEdit()
+                return
             }
             KeyCode.LANGUAGE_SWITCH -> handleLanguageSwitch()
             KeyCode.SETTINGS -> florisboard.launchSettings()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
@@ -65,6 +65,7 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
     private var isKeyPressed: Boolean = false
     private val repeatedKeyPressHandler: Handler = Handler(context.mainLooper)
 
+    private val defaultTextSize: Float = Button(context).textSize
     private var label: String? = null
     private var labelPaint: Paint = Paint().apply {
         alpha = 255
@@ -72,7 +73,7 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
         isAntiAlias = true
         isFakeBoldText = false
         textAlign = Paint.Align.CENTER
-        textSize = Button(context).textSize
+        textSize = defaultTextSize
         typeface = Typeface.DEFAULT
     }
 
@@ -172,8 +173,10 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
             }
             val isPortrait =
                 resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
-            if (!isPortrait) {
-                labelPaint.textSize *= 0.9f
+            labelPaint.textSize = if (isPortrait) {
+                defaultTextSize
+            } else {
+                defaultTextSize * 0.9f
             }
             val centerX = measuredWidth / 2.0f
             val centerY = measuredHeight / 2.0f + (labelPaint.textSize - labelPaint.descent()) / 2

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
@@ -31,6 +31,7 @@ import androidx.appcompat.widget.AppCompatImageButton
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.PrefHelper
+import dev.patrickgold.florisboard.ime.text.FlorisKeyEvent
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyData
 import dev.patrickgold.florisboard.ime.theme.Theme
@@ -123,7 +124,7 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
                         val delayMillis = prefs.keyboard.longPressDelay.toLong()
                         repeatedKeyPressHandler.postAtScheduledRate(delayMillis, 25) {
                             if (isKeyPressed) {
-                                florisboard?.textInputManager?.sendKeyPress(data)
+                                florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.downUp(data))
                             } else {
                                 repeatedKeyPressHandler.cancelAll()
                             }
@@ -135,7 +136,7 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
                 isKeyPressed = false
                 repeatedKeyPressHandler.cancelAll()
                 if (event.actionMasked != MotionEvent.ACTION_CANCEL) {
-                    florisboard?.textInputManager?.sendKeyPress(data)
+                    florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.downUp(data))
                 }
             }
             else -> return false

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
@@ -30,8 +30,8 @@ import android.widget.Button
 import androidx.appcompat.widget.AppCompatImageButton
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
+import dev.patrickgold.florisboard.ime.core.InputKeyEvent
 import dev.patrickgold.florisboard.ime.core.PrefHelper
-import dev.patrickgold.florisboard.ime.text.FlorisKeyEvent
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyData
 import dev.patrickgold.florisboard.ime.theme.Theme
@@ -47,7 +47,21 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
     private val florisboard: FlorisBoard? = FlorisBoard.getInstanceOrNull()
     private val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)
     private val themeManager: ThemeManager = ThemeManager.default()
-    private val data: KeyData
+    private val data: KeyData = when (id) {
+        R.id.arrow_down -> KeyData.ARROW_DOWN
+        R.id.arrow_left -> KeyData.ARROW_LEFT
+        R.id.arrow_right -> KeyData.ARROW_RIGHT
+        R.id.arrow_up -> KeyData.ARROW_UP
+        R.id.backspace -> KeyData.DELETE
+        R.id.clipboard_copy -> KeyData.CLIPBOARD_COPY
+        R.id.clipboard_cut -> KeyData.CLIPBOARD_CUT
+        R.id.clipboard_paste -> KeyData.CLIPBOARD_PASTE
+        R.id.move_start_of_line -> KeyData.MOVE_START_OF_LINE
+        R.id.move_end_of_line -> KeyData.MOVE_END_OF_LINE
+        R.id.select -> KeyData.CLIPBOARD_SELECT
+        R.id.select_all -> KeyData.CLIPBOARD_SELECT_ALL
+        else -> KeyData.UNSPECIFIED
+    }
     private var isKeyPressed: Boolean = false
     private val repeatedKeyPressHandler: Handler = Handler(context.mainLooper)
 
@@ -72,21 +86,6 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, R.style.TextEditingButton)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        data = when (id) {
-            R.id.arrow_down -> KeyData.ARROW_DOWN
-            R.id.arrow_left -> KeyData.ARROW_LEFT
-            R.id.arrow_right -> KeyData.ARROW_RIGHT
-            R.id.arrow_up -> KeyData.ARROW_UP
-            R.id.backspace -> KeyData.DELETE
-            R.id.clipboard_copy -> KeyData.CLIPBOARD_COPY
-            R.id.clipboard_cut -> KeyData.CLIPBOARD_CUT
-            R.id.clipboard_paste -> KeyData.CLIPBOARD_PASTE
-            R.id.move_start_of_line -> KeyData.MOVE_START_OF_LINE
-            R.id.move_end_of_line -> KeyData.MOVE_END_OF_LINE
-            R.id.select -> KeyData.CLIPBOARD_SELECT
-            R.id.select_all -> KeyData.CLIPBOARD_SELECT_ALL
-            else -> KeyData.UNSPECIFIED
-        }
         context.obtainStyledAttributes(attrs, R.styleable.EditingKeyView).apply {
             label = getString(R.styleable.EditingKeyView_android_text)
             recycle()
@@ -123,7 +122,7 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
                         val delayMillis = prefs.keyboard.longPressDelay.toLong()
                         repeatedKeyPressHandler.postAtScheduledRate(delayMillis, 25) {
                             if (isKeyPressed) {
-                                florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.downUp(data))
+                                florisboard?.textInputManager?.inputEventDispatcher?.send(InputKeyEvent.downUp(data))
                             } else {
                                 repeatedKeyPressHandler.cancelAll()
                             }
@@ -135,7 +134,7 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
                 isKeyPressed = false
                 repeatedKeyPressHandler.cancelAll()
                 if (event.actionMasked != MotionEvent.ACTION_CANCEL) {
-                    florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.downUp(data))
+                    florisboard?.textInputManager?.inputEventDispatcher?.send(InputKeyEvent.downUp(data))
                 }
             }
             else -> return false

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
@@ -72,22 +72,21 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, R.style.TextEditingButton)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        val code = when (id) {
-            R.id.arrow_down -> KeyCode.ARROW_DOWN
-            R.id.arrow_left -> KeyCode.ARROW_LEFT
-            R.id.arrow_right -> KeyCode.ARROW_RIGHT
-            R.id.arrow_up -> KeyCode.ARROW_UP
-            R.id.backspace -> KeyCode.DELETE
-            R.id.clipboard_copy -> KeyCode.CLIPBOARD_COPY
-            R.id.clipboard_cut -> KeyCode.CLIPBOARD_CUT
-            R.id.clipboard_paste -> KeyCode.CLIPBOARD_PASTE
-            R.id.move_start_of_line -> KeyCode.MOVE_START_OF_LINE
-            R.id.move_end_of_line -> KeyCode.MOVE_END_OF_LINE
-            R.id.select -> KeyCode.CLIPBOARD_SELECT
-            R.id.select_all -> KeyCode.CLIPBOARD_SELECT_ALL
-            else -> 0
+        data = when (id) {
+            R.id.arrow_down -> KeyData.ARROW_DOWN
+            R.id.arrow_left -> KeyData.ARROW_LEFT
+            R.id.arrow_right -> KeyData.ARROW_RIGHT
+            R.id.arrow_up -> KeyData.ARROW_UP
+            R.id.backspace -> KeyData.DELETE
+            R.id.clipboard_copy -> KeyData.CLIPBOARD_COPY
+            R.id.clipboard_cut -> KeyData.CLIPBOARD_CUT
+            R.id.clipboard_paste -> KeyData.CLIPBOARD_PASTE
+            R.id.move_start_of_line -> KeyData.MOVE_START_OF_LINE
+            R.id.move_end_of_line -> KeyData.MOVE_END_OF_LINE
+            R.id.select -> KeyData.CLIPBOARD_SELECT
+            R.id.select_all -> KeyData.CLIPBOARD_SELECT_ALL
+            else -> KeyData.UNSPECIFIED
         }
-        data = KeyData(code = code)
         context.obtainStyledAttributes(attrs, R.styleable.EditingKeyView).apply {
             label = getString(R.styleable.EditingKeyView_android_text)
             recycle()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyboardView.kt
@@ -35,8 +35,6 @@ class EditingKeyboardView : ConstraintLayout, FlorisBoard.EventListener,
     private val florisboard: FlorisBoard? = FlorisBoard.getInstanceOrNull()
     private val themeManager: ThemeManager = ThemeManager.default()
 
-    private var arrowUpKey: EditingKeyView? = null
-    private var arrowDownKey: EditingKeyView? = null
     private var selectKey: EditingKeyView? = null
     private var selectAllKey: EditingKeyView? = null
     private var cutKey: EditingKeyView? = null
@@ -52,8 +50,6 @@ class EditingKeyboardView : ConstraintLayout, FlorisBoard.EventListener,
         florisboard?.addEventListener(this)
         themeManager.registerOnThemeUpdatedListener(this)
 
-        arrowUpKey = findViewById(R.id.arrow_up)
-        arrowDownKey = findViewById(R.id.arrow_down)
         selectKey = findViewById(R.id.select)
         selectAllKey = findViewById(R.id.select_all)
         cutKey = findViewById(R.id.clipboard_cut)
@@ -74,8 +70,6 @@ class EditingKeyboardView : ConstraintLayout, FlorisBoard.EventListener,
     override fun onUpdateSelection() {
         val isSelectionActive = florisboard?.activeEditorInstance?.selection?.isSelectionMode ?: false
         val isSelectionMode = florisboard?.textInputManager?.isManualSelectionMode ?: false
-        arrowUpKey?.isEnabled = !(isSelectionActive || isSelectionMode)
-        arrowDownKey?.isEnabled = !(isSelectionActive || isSelectionMode)
         selectKey?.isHighlighted = isSelectionActive || isSelectionMode
         selectAllKey?.visibility = when {
             isSelectionActive -> View.GONE

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
@@ -50,7 +50,7 @@ object KeyCode {
     const val CLEAR_INPUT =                  -13
     const val VOICE_INPUT =                   -4
 
-    const val DISABLED =                       0
+    const val UNSPECIFIED =                    0
 
     const val SPLIT_LAYOUT =                -110
     const val MERGE_LAYOUT =                -111

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
@@ -89,6 +89,8 @@ object KeyCode {
     const val TOGGLE_ONE_HANDED_MODE_RIGHT =-216
     const val URI_COMPONENT_TLD =           -255
 
+    const val INTERNAL_BATCH_EDIT =         -901
+
     const val KESHIDA =                     1600
     const val HALF_SPACE =                  8204
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
@@ -113,6 +113,13 @@ open class KeyData(
             label = "delete_word"
         )
 
+        /** Predefined key data for [KeyCode.INTERNAL_BATCH_EDIT] */
+        val INTERNAL_BATCH_EDIT = KeyData(
+            type = KeyType.FUNCTION,
+            code = KeyCode.INTERNAL_BATCH_EDIT,
+            label = "internal_batch_edit"
+        )
+
         /** Predefined key data for [KeyCode.MOVE_START_OF_LINE] */
         val MOVE_START_OF_LINE = KeyData(
             type = KeyType.NAVIGATION,

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
@@ -162,6 +162,13 @@ open class KeyData(
             label = "shift"
         )
 
+        /** Predefined key data for [KeyCode.SHIFT_LOCK] */
+        val SHIFT_LOCK = KeyData(
+            type = KeyType.MODIFIER,
+            code = KeyCode.SHIFT_LOCK,
+            label = "shift_lock"
+        )
+
         /** Predefined key data for [KeyCode.SPACE] */
         val SPACE = KeyData(
             type = KeyType.CHARACTER,

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
@@ -34,7 +34,55 @@ open class KeyData(
     var type: KeyType = KeyType.CHARACTER,
     var code: Int = 0,
     var label: String = ""
-)
+) {
+    companion object {
+        /** Predefined key data for [KeyCode.ARROW_DOWN] */
+        val ARROW_DOWN = KeyData(code = KeyCode.ARROW_DOWN, type = KeyType.NAVIGATION)
+
+        /** Predefined key data for [KeyCode.ARROW_LEFT] */
+        val ARROW_LEFT = KeyData(code = KeyCode.ARROW_LEFT, type = KeyType.NAVIGATION)
+
+        /** Predefined key data for [KeyCode.ARROW_RIGHT] */
+        val ARROW_RIGHT = KeyData(code = KeyCode.ARROW_RIGHT, type = KeyType.NAVIGATION)
+
+        /** Predefined key data for [KeyCode.ARROW_UP] */
+        val ARROW_UP = KeyData(code = KeyCode.ARROW_UP, type = KeyType.NAVIGATION)
+
+        /** Predefined key data for [KeyCode.DELETE] */
+        val DELETE = KeyData(code = KeyCode.DELETE, type = KeyType.ENTER_EDITING)
+
+        /** Predefined key data for [KeyCode.DELETE_WORD] */
+        val DELETE_WORD = KeyData(code = KeyCode.DELETE_WORD, type = KeyType.ENTER_EDITING)
+
+        /** Predefined key data for [KeyCode.MOVE_START_OF_LINE] */
+        val MOVE_START_OF_LINE = KeyData(code = KeyCode.MOVE_START_OF_LINE, type = KeyType.NAVIGATION)
+
+        /** Predefined key data for [KeyCode.MOVE_END_OF_LINE] */
+        val MOVE_END_OF_LINE = KeyData(code = KeyCode.MOVE_END_OF_LINE, type = KeyType.NAVIGATION)
+
+        /** Predefined key data for [KeyCode.MOVE_START_OF_PAGE] */
+        val MOVE_START_OF_PAGE = KeyData(code = KeyCode.MOVE_START_OF_PAGE, type = KeyType.NAVIGATION)
+
+        /** Predefined key data for [KeyCode.MOVE_END_OF_PAGE] */
+        val MOVE_END_OF_PAGE = KeyData(code = KeyCode.MOVE_END_OF_PAGE, type = KeyType.NAVIGATION)
+
+        /** Predefined key data for [KeyCode.SHOW_INPUT_METHOD_PICKER] */
+        val SHOW_INPUT_METHOD_PICKER = KeyData(code = KeyCode.SHOW_INPUT_METHOD_PICKER, type = KeyType.FUNCTION)
+
+        /** Predefined key data for [KeyCode.SWITCH_TO_TEXT_CONTEXT] */
+        val SWITCH_TO_TEXT_CONTEXT = KeyData(code = KeyCode.SWITCH_TO_TEXT_CONTEXT, type = KeyType.SYSTEM_GUI)
+
+        /** Predefined key data for [KeyCode.SHIFT] */
+        val SHIFT = KeyData(code = KeyCode.SHIFT, type = KeyType.MODIFIER)
+
+        /** Predefined key data for [KeyCode.SPACE] */
+        val SPACE = KeyData(code = KeyCode.SPACE, type = KeyType.CHARACTER)
+    }
+
+    override fun toString(): String {
+        return "KeyData { type=$type code=$code label=\"$label\" }"
+    }
+}
 
 /**
  * Data class which describes a single key and its attributes, while also providing additional

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
@@ -37,46 +37,144 @@ open class KeyData(
 ) {
     companion object {
         /** Predefined key data for [KeyCode.ARROW_DOWN] */
-        val ARROW_DOWN = KeyData(code = KeyCode.ARROW_DOWN, type = KeyType.NAVIGATION)
+        val ARROW_DOWN = KeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.ARROW_DOWN,
+            label = "arrow_down"
+        )
 
         /** Predefined key data for [KeyCode.ARROW_LEFT] */
-        val ARROW_LEFT = KeyData(code = KeyCode.ARROW_LEFT, type = KeyType.NAVIGATION)
+        val ARROW_LEFT = KeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.ARROW_LEFT,
+            label = "arrow_left"
+        )
 
         /** Predefined key data for [KeyCode.ARROW_RIGHT] */
-        val ARROW_RIGHT = KeyData(code = KeyCode.ARROW_RIGHT, type = KeyType.NAVIGATION)
+        val ARROW_RIGHT = KeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.ARROW_RIGHT,
+            label = "arrow_right"
+        )
 
         /** Predefined key data for [KeyCode.ARROW_UP] */
-        val ARROW_UP = KeyData(code = KeyCode.ARROW_UP, type = KeyType.NAVIGATION)
+        val ARROW_UP = KeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.ARROW_UP,
+            label = "arrow_up"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_COPY] */
+        val CLIPBOARD_COPY = KeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_COPY,
+            label = "clipboard_copy"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_CUT] */
+        val CLIPBOARD_CUT = KeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_CUT,
+            label = "clipboard_cut"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_PASTE] */
+        val CLIPBOARD_PASTE = KeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_PASTE,
+            label = "clipboard_paste"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_SELECT] */
+        val CLIPBOARD_SELECT = KeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_SELECT,
+            label = "clipboard_select"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_SELECT_ALL] */
+        val CLIPBOARD_SELECT_ALL = KeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_SELECT_ALL,
+            label = "clipboard_select_all"
+        )
 
         /** Predefined key data for [KeyCode.DELETE] */
-        val DELETE = KeyData(code = KeyCode.DELETE, type = KeyType.ENTER_EDITING)
+        val DELETE = KeyData(
+            type = KeyType.ENTER_EDITING,
+            code = KeyCode.DELETE,
+            label = "delete"
+        )
 
         /** Predefined key data for [KeyCode.DELETE_WORD] */
-        val DELETE_WORD = KeyData(code = KeyCode.DELETE_WORD, type = KeyType.ENTER_EDITING)
+        val DELETE_WORD = KeyData(
+            type = KeyType.ENTER_EDITING,
+            code = KeyCode.DELETE_WORD,
+            label = "delete_word"
+        )
 
         /** Predefined key data for [KeyCode.MOVE_START_OF_LINE] */
-        val MOVE_START_OF_LINE = KeyData(code = KeyCode.MOVE_START_OF_LINE, type = KeyType.NAVIGATION)
+        val MOVE_START_OF_LINE = KeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.MOVE_START_OF_LINE,
+            label = "move_start_of_line"
+        )
 
         /** Predefined key data for [KeyCode.MOVE_END_OF_LINE] */
-        val MOVE_END_OF_LINE = KeyData(code = KeyCode.MOVE_END_OF_LINE, type = KeyType.NAVIGATION)
+        val MOVE_END_OF_LINE = KeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.MOVE_END_OF_LINE,
+            label = "move_end_of_line"
+        )
 
         /** Predefined key data for [KeyCode.MOVE_START_OF_PAGE] */
-        val MOVE_START_OF_PAGE = KeyData(code = KeyCode.MOVE_START_OF_PAGE, type = KeyType.NAVIGATION)
+        val MOVE_START_OF_PAGE = KeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.MOVE_START_OF_PAGE,
+            label = "move_start_of_page"
+        )
 
         /** Predefined key data for [KeyCode.MOVE_END_OF_PAGE] */
-        val MOVE_END_OF_PAGE = KeyData(code = KeyCode.MOVE_END_OF_PAGE, type = KeyType.NAVIGATION)
+        val MOVE_END_OF_PAGE = KeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.MOVE_END_OF_PAGE,
+            label = "move_end_of_page"
+        )
 
         /** Predefined key data for [KeyCode.SHOW_INPUT_METHOD_PICKER] */
-        val SHOW_INPUT_METHOD_PICKER = KeyData(code = KeyCode.SHOW_INPUT_METHOD_PICKER, type = KeyType.FUNCTION)
+        val SHOW_INPUT_METHOD_PICKER = KeyData(
+            type = KeyType.FUNCTION,
+            code = KeyCode.SHOW_INPUT_METHOD_PICKER,
+            label = "show_input_method_picker"
+        )
 
         /** Predefined key data for [KeyCode.SWITCH_TO_TEXT_CONTEXT] */
-        val SWITCH_TO_TEXT_CONTEXT = KeyData(code = KeyCode.SWITCH_TO_TEXT_CONTEXT, type = KeyType.SYSTEM_GUI)
+        val SWITCH_TO_TEXT_CONTEXT = KeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.SWITCH_TO_TEXT_CONTEXT,
+            label = "switch_to_text_context"
+        )
 
         /** Predefined key data for [KeyCode.SHIFT] */
-        val SHIFT = KeyData(code = KeyCode.SHIFT, type = KeyType.MODIFIER)
+        val SHIFT = KeyData(
+            type = KeyType.MODIFIER,
+            code = KeyCode.SHIFT,
+            label = "shift"
+        )
 
         /** Predefined key data for [KeyCode.SPACE] */
-        val SPACE = KeyData(code = KeyCode.SPACE, type = KeyType.CHARACTER)
+        val SPACE = KeyData(
+            type = KeyType.CHARACTER,
+            code = KeyCode.SPACE,
+            label = "space"
+        )
+
+        /** Predefined key data for [KeyCode.UNSPECIFIED] */
+        val UNSPECIFIED = KeyData(
+            type = KeyType.UNSPECIFIED,
+            code = KeyCode.UNSPECIFIED,
+            label = "unspecified"
+        )
     }
 
     override fun toString(): String {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -349,9 +349,6 @@ class KeyView(
                             florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(data))
                         }
                     }
-                    if (florisboard.textInputManager.inputEventDispatcher.isPressed(KeyCode.SHIFT) && data.code != KeyCode.SHIFT) {
-                        florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(KeyData.SHIFT))
-                    }
                     popupManager.hide()
                 }
                 shouldBlockNextKeyCode = false

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -18,7 +18,11 @@ package dev.patrickgold.florisboard.ime.text.key
 
 import android.annotation.SuppressLint
 import android.content.res.Configuration
-import android.graphics.*
+import android.graphics.Canvas
+import android.graphics.Outline
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.PaintDrawable
 import android.os.Handler
@@ -34,6 +38,8 @@ import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.ImeOptions
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.core.Subtype
+import dev.patrickgold.florisboard.ime.popup.PopupManager
+import dev.patrickgold.florisboard.ime.text.FlorisKeyEvent
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeGesture
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
@@ -41,7 +47,10 @@ import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardView
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import dev.patrickgold.florisboard.ime.theme.ThemeValue
-import dev.patrickgold.florisboard.util.*
+import dev.patrickgold.florisboard.util.ViewLayoutUtils
+import dev.patrickgold.florisboard.util.cancelAll
+import dev.patrickgold.florisboard.util.postDelayed
+import timber.log.Timber
 import java.util.*
 import kotlin.math.abs
 
@@ -69,7 +78,7 @@ class KeyView(
     private var hasTriggeredGestureMove: Boolean = false
     private var keyHintMode: KeyHintMode = KeyHintMode.DISABLED
     private val longKeyPressHandler: Handler = Handler(context.mainLooper)
-    private val repeatedKeyPressHandler: Handler = Handler(context.mainLooper)
+    private val popupManager = PopupManager<KeyboardView, KeyView>(keyboardView, florisboard?.popupLayerView)
     private val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)
     private var shouldBlockNextKeyCode: Boolean = false
 
@@ -115,10 +124,10 @@ class KeyView(
             val keyMarginH: Int
             val keyMarginV: Int
 
-            if (keyboardView.isSmartbarKeyboardView){
+            if (keyboardView.isSmartbarKeyboardView) {
                 keyMarginH = resources.getDimension(R.dimen.key_marginH).toInt()
                 keyMarginV = resources.getDimension(R.dimen.key_marginV).toInt()
-            }else {
+            } else {
                 keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
                 keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
             }
@@ -161,7 +170,7 @@ class KeyView(
         setPadding(0, 0, 0, 0)
 
         background = backgroundDrawable
-        elevation = if(themeValueCache.shouldShowBorder) 4.0f else 0.0f
+        elevation = if (themeValueCache.shouldShowBorder) 4.0f else 0.0f
 
         if (prefs.keyboard.hintedNumberRowMode != KeyHintMode.DISABLED && data.popup.hint?.type == KeyType.NUMERIC) {
             keyHintMode = prefs.keyboard.hintedNumberRowMode
@@ -228,78 +237,67 @@ class KeyView(
      */
     fun onFlorisTouchEvent(event: MotionEvent?): Boolean {
         if (event == null || !isEnabled) return false
+
+        val pointerIndex = event.actionIndex
+        val pointerId = event.getPointerId(pointerIndex)
+
         val alwaysTriggerOnMove = (hasTriggeredGestureMove
-                && (data.code == KeyCode.DELETE && prefs.gestures.deleteKeySwipeLeft == SwipeAction.DELETE_CHARACTERS_PRECISELY
-                || data.code == KeyCode.SPACE))
+            && (data.code == KeyCode.DELETE && prefs.gestures.deleteKeySwipeLeft == SwipeAction.DELETE_CHARACTERS_PRECISELY
+            || data.code == KeyCode.SPACE))
         if (swipeGestureDetector.onTouchEvent(event, alwaysTriggerOnMove)) {
+            florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.cancel(data))
             isKeyPressed = false
             longKeyPressHandler.cancelAll()
-            repeatedKeyPressHandler.cancelAll()
-            keyboardView.popupManager.hide()
+            popupManager.hide()
             return true
         }
+
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
-                if (data.code == KeyCode.SHIFT) {
-                    isKeyPressed = true
-                    florisboard?.keyPressVibrate()
-                    florisboard?.keyPressSound(data)
-                    florisboard?.textInputManager?.sendKeyPress(data)
+                if (FlorisKeyEvent.requireSeparateDownUp(data.code)) {
+                    florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.down(data))
+                }
+                isKeyPressed = true
+                val delayMillis = prefs.keyboard.longPressDelay.toLong()
+                hasTriggeredGestureMove = false
+                shouldBlockNextKeyCode = false
+                florisboard?.prefs?.keyboard?.let {
+                    if (it.popupEnabled) {
+                        popupManager.show(this, keyHintMode)
+                    }
+                }
+                isKeyPressed = true
+                florisboard?.keyPressVibrate()
+                florisboard?.keyPressSound(data)
+
+                if (data.code == KeyCode.SPACE) {
+                    initSelectionStart = florisboard?.activeEditorInstance?.selection?.start ?: 0
+                    initSelectionEnd = florisboard?.activeEditorInstance?.selection?.end ?: 0
+                    longKeyPressHandler.postDelayed((delayMillis * 2.5f).toLong()) {
+                        when (prefs.gestures.spaceBarLongPress) {
+                            SwipeAction.NO_ACTION,
+                            SwipeAction.INSERT_SPACE -> {
+                            }
+                            else -> {
+                                florisboard?.executeSwipeAction(prefs.gestures.spaceBarLongPress)
+                                shouldBlockNextKeyCode = true
+                            }
+                        }
+                    }
                 } else {
-                    val delayMillis = prefs.keyboard.longPressDelay.toLong()
-                    hasTriggeredGestureMove = false
-                    shouldBlockNextKeyCode = false
-                    florisboard?.prefs?.keyboard?.let {
-                        if (it.popupEnabled){
-                            keyboardView.popupManager.show(this, keyHintMode)
-                        }
-                    }
-                    isKeyPressed = true
-                    florisboard?.keyPressVibrate()
-                    florisboard?.keyPressSound(data)
-                    when (data.code) {
-                        KeyCode.ARROW_DOWN,
-                        KeyCode.ARROW_LEFT,
-                        KeyCode.ARROW_RIGHT,
-                        KeyCode.ARROW_UP,
-                        KeyCode.DELETE -> {
-                            repeatedKeyPressHandler.postAtScheduledRate((delayMillis * 2.0f).toLong(), 25) {
-                                if (isKeyPressed) {
-                                    florisboard?.textInputManager?.sendKeyPress(data)
-                                } else {
-                                    repeatedKeyPressHandler.cancelAll()
-                                }
-                            }
-                        }
-                    }
-                    if (data.code == KeyCode.SPACE) {
-                        initSelectionStart = florisboard?.activeEditorInstance?.selection?.start ?: 0
-                        initSelectionEnd = florisboard?.activeEditorInstance?.selection?.end ?: 0
-                        longKeyPressHandler.postDelayed((delayMillis * 2.5f).toLong()) {
-                            when (prefs.gestures.spaceBarLongPress) {
-                                SwipeAction.NO_ACTION,
-                                SwipeAction.INSERT_SPACE -> {}
-                                else -> {
-                                    florisboard?.executeSwipeAction(prefs.gestures.spaceBarLongPress)
-                                    shouldBlockNextKeyCode = true
-                                }
-                            }
-                        }
-                    } else {
-                        longKeyPressHandler.postDelayed(delayMillis) {
-                            if (data.popup.isNotEmpty()) {
-                                keyboardView.popupManager.extend(this, keyHintMode)
-                            }
+                    longKeyPressHandler.postDelayed(delayMillis) {
+                        if (data.popup.isNotEmpty()) {
+                            popupManager.extend(this@KeyView, keyHintMode)
                         }
                     }
                 }
             }
             MotionEvent.ACTION_MOVE -> {
-                if (keyboardView.popupManager.isShowingExtendedPopup) {
+                if (popupManager.isShowingExtendedPopup) {
                     val isPointerWithinBounds =
-                        keyboardView.popupManager.propagateMotionEvent(this, event)
+                        popupManager.propagateMotionEvent(this, event)
                     if (!isPointerWithinBounds && !shouldBlockNextKeyCode) {
-                        keyboardView.dismissActiveKeyViewReference()
+                        keyboardView.dismissActiveKeyViewReference(pointerId)
                     }
                 } else {
                     val parent = parent as ViewGroup
@@ -309,30 +307,36 @@ class KeyView(
                         || event.y > 1.35f * measuredHeight
                     ) {
                         if (!shouldBlockNextKeyCode) {
-                            keyboardView.dismissActiveKeyViewReference()
+                            keyboardView.dismissActiveKeyViewReference(pointerId)
                         }
                     }
                 }
             }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 longKeyPressHandler.cancelAll()
-                repeatedKeyPressHandler.cancelAll()
-                if (data.code != KeyCode.SHIFT) {
-                    if (hasTriggeredGestureMove && data.code == KeyCode.DELETE) {
-                        florisboard?.activeEditorInstance?.apply {
-                            if (selection.isSelectionMode) {
-                                deleteBackwards()
-                            }
+                if (hasTriggeredGestureMove && data.code == KeyCode.DELETE) {
+                    florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.cancel(data))
+                    florisboard?.activeEditorInstance?.apply {
+                        if (selection.isSelectionMode) {
+                            deleteBackwards()
+                        }
+                    }
+                } else {
+                    val retData = popupManager.getActiveKeyData(this)
+                    Timber.i(retData.toString())
+                    if (event.actionMasked != MotionEvent.ACTION_CANCEL && !shouldBlockNextKeyCode && retData != null) {
+                        if (FlorisKeyEvent.requireSeparateDownUp(retData.code)) {
+                            florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.up(retData))
+                        } else {
+                            florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.downUp(retData))
                         }
                     } else {
-                        val retData = keyboardView.popupManager.getActiveKeyData(this)
-                        if (event.actionMasked != MotionEvent.ACTION_CANCEL && !shouldBlockNextKeyCode && retData != null) {
-                            florisboard?.textInputManager?.sendKeyPress(retData)
-                        } else {
-                            shouldBlockNextKeyCode = false
+                        if (FlorisKeyEvent.requireSeparateDownUp(data.code)) {
+                            florisboard?.textInputManager?.sendKeyEvent(FlorisKeyEvent.cancel(data))
                         }
-                        keyboardView.popupManager.hide()
+                        shouldBlockNextKeyCode = false
                     }
+                    popupManager.hide()
                 }
                 hasTriggeredGestureMove = false
                 isKeyPressed = false
@@ -398,13 +402,8 @@ class KeyView(
                     }
                     SwipeGesture.Direction.LEFT -> {
                         if (prefs.gestures.spaceBarSwipeLeft == SwipeAction.MOVE_CURSOR_LEFT) {
-                            if (!florisboard.activeEditorInstance.isRawInputEditor) {
-                                val s = (initSelectionEnd + event.absUnitCountX).coerceIn(0, florisboard.activeEditorInstance.cachedInput.expectedMaxLength)
-                                florisboard.activeEditorInstance.selection.updateAndNotify(s, s)
-                            } else {
-                                for (n in 0 until abs(event.relUnitCountX)) {
-                                    florisboard.executeSwipeAction(prefs.gestures.spaceBarSwipeLeft)
-                                }
+                            for (n in 0 until abs(event.relUnitCountX)) {
+                                florisboard.executeSwipeAction(prefs.gestures.spaceBarSwipeLeft)
                             }
                         } else {
                             florisboard.executeSwipeAction(prefs.gestures.spaceBarSwipeLeft)
@@ -415,13 +414,8 @@ class KeyView(
                     }
                     SwipeGesture.Direction.RIGHT -> {
                         if (prefs.gestures.spaceBarSwipeRight == SwipeAction.MOVE_CURSOR_RIGHT) {
-                            if (!florisboard.activeEditorInstance.isRawInputEditor) {
-                                val s = (initSelectionEnd + event.absUnitCountX).coerceIn(0, florisboard.activeEditorInstance.cachedInput.expectedMaxLength)
-                                florisboard.activeEditorInstance.selection.updateAndNotify(s, s)
-                            } else {
-                                for (n in 0 until abs(event.relUnitCountX)) {
-                                    florisboard.executeSwipeAction(prefs.gestures.spaceBarSwipeRight)
-                                }
+                            for (n in 0 until abs(event.relUnitCountX)) {
+                                florisboard.executeSwipeAction(prefs.gestures.spaceBarSwipeRight)
                             }
                         } else {
                             florisboard.executeSwipeAction(prefs.gestures.spaceBarSwipeRight)
@@ -449,10 +443,10 @@ class KeyView(
         val keyMarginH: Int
         val keyMarginV: Int
 
-        if (keyboardView.isSmartbarKeyboardView){
+        if (keyboardView.isSmartbarKeyboardView) {
             keyMarginH = resources.getDimension(R.dimen.key_marginH).toInt()
             keyMarginV = resources.getDimension(R.dimen.key_marginV).toInt()
-        }else {
+        } else {
             keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
             keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
         }
@@ -476,11 +470,11 @@ class KeyView(
             else -> when (data.code) {
                 KeyCode.SHIFT,
                 KeyCode.DELETE ->
-                        if ((keyboardView.computedLayout?.arrangement?.get(2)?.size ?: 0) > 10) {
-                            1.12f
-                        } else {
-                            1.56f
-                        }
+                    if ((keyboardView.computedLayout?.arrangement?.get(2)?.size ?: 0) > 10) {
+                        1.12f
+                    } else {
+                        1.56f
+                    }
                 KeyCode.VIEW_CHARACTERS,
                 KeyCode.VIEW_SYMBOLS,
                 KeyCode.VIEW_SYMBOLS2,
@@ -551,8 +545,8 @@ class KeyView(
         isEnabled = when (data.code) {
             KeyCode.CLIPBOARD_COPY,
             KeyCode.CLIPBOARD_CUT -> (florisboard != null
-                    && florisboard.activeEditorInstance.selection.isSelectionMode
-                    && !florisboard.activeEditorInstance.isRawInputEditor)
+                && florisboard.activeEditorInstance.selection.isSelectionMode
+                && !florisboard.activeEditorInstance.isRawInputEditor)
             KeyCode.CLIPBOARD_PASTE -> florisboard?.clipboardManager?.hasPrimaryClip() == true
             KeyCode.CLIPBOARD_SELECT_ALL -> {
                 florisboard?.activeEditorInstance?.isRawInputEditor == false
@@ -642,10 +636,10 @@ class KeyView(
             val keyMarginH: Int
             val keyMarginV: Int
 
-            if (keyboardView.isSmartbarKeyboardView){
+            if (keyboardView.isSmartbarKeyboardView) {
                 keyMarginH = resources.getDimension(R.dimen.key_marginH).toInt()
                 keyMarginV = resources.getDimension(R.dimen.key_marginV).toInt()
-            }else {
+            } else {
                 keyMarginV = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingVertical, context).toInt()
                 keyMarginH = ViewLayoutUtils.convertDpToPixel(prefs.keyboard.keySpacingHorizontal, context).toInt()
             }
@@ -711,7 +705,11 @@ class KeyView(
             }
             else -> if (data.variation != KeyVariation.ALL) {
                 val keyVariation = florisboard?.textInputManager?.keyVariation ?: KeyVariation.NORMAL
-                visibility = if (data.variation == keyVariation) { VISIBLE } else { GONE }
+                visibility = if (data.variation == keyVariation) {
+                    VISIBLE
+                } else {
+                    GONE
+                }
                 updateTouchHitBox()
             }
         }
@@ -827,7 +825,8 @@ class KeyView(
                         KeyboardMode.CHARACTERS -> {
                             label = florisboard?.activeSubtype?.locale?.displayName
                         }
-                        else -> {}
+                        else -> {
+                        }
                     }
                 }
                 KeyCode.SWITCH_TO_MEDIA_CONTEXT -> {
@@ -907,7 +906,7 @@ class KeyView(
                 }
                 else -> when {
                     (data.type == KeyType.CHARACTER || data.type == KeyType.NUMERIC) &&
-                            data.code != KeyCode.SPACE -> {
+                        data.code != KeyCode.SPACE -> {
                         val cachedTextSize = setTextSizeFor(
                             labelPaint,
                             measuredWidth - (2.6f * drawablePaddingH),
@@ -926,7 +925,7 @@ class KeyView(
                                 else -> 1.0f
                             }
                         )
-                        keyboardView.popupManager.keyPopupTextSize = cachedTextSize
+                        popupManager.keyPopupTextSize = cachedTextSize
                     }
                     else -> {
                         setTextSizeFor(
@@ -949,7 +948,11 @@ class KeyView(
                 themeValueCache.keyForeground.toSolidColor().color
             }
             labelPaint.alpha = if (keyboardView.computedLayout?.mode == KeyboardMode.CHARACTERS &&
-                data.code == KeyCode.SPACE) { 120 } else { 255 }
+                data.code == KeyCode.SPACE) {
+                120
+            } else {
+                255
+            }
             val centerX = measuredWidth / 2.0f
             val centerY = measuredHeight / 2.0f + (labelPaint.textSize - labelPaint.descent()) / 2
             if (label.contains("\n")) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -270,24 +270,38 @@ class KeyView(
                 florisboard.keyPressVibrate()
                 florisboard.keyPressSound(data)
 
-                if (data.code == KeyCode.SPACE) {
-                    initSelectionStart = florisboard.activeEditorInstance.selection.start
-                    initSelectionEnd = florisboard.activeEditorInstance.selection.end
-                    longKeyPressHandler.postDelayed((delayMillis * 2.5f).toLong()) {
-                        when (prefs.gestures.spaceBarLongPress) {
-                            SwipeAction.NO_ACTION,
-                            SwipeAction.INSERT_SPACE -> {
-                            }
-                            else -> {
-                                this@KeyView.florisboard.executeSwipeAction(prefs.gestures.spaceBarLongPress)
-                                shouldBlockNextKeyCode = true
+                when (data.code) {
+                    KeyCode.SPACE -> {
+                        initSelectionStart = florisboard.activeEditorInstance.selection.start
+                        initSelectionEnd = florisboard.activeEditorInstance.selection.end
+                        longKeyPressHandler.postDelayed((delayMillis * 2.5f).toLong()) {
+                            when (prefs.gestures.spaceBarLongPress) {
+                                SwipeAction.NO_ACTION,
+                                SwipeAction.INSERT_SPACE -> {
+                                }
+                                else -> {
+                                    this.florisboard.executeSwipeAction(prefs.gestures.spaceBarLongPress)
+                                    shouldBlockNextKeyCode = true
+                                }
                             }
                         }
                     }
-                } else {
-                    longKeyPressHandler.postDelayed(delayMillis) {
-                        if (data.popup.isNotEmpty()) {
-                            popupManager.extend(this@KeyView, keyHintMode)
+                    KeyCode.SHIFT -> {
+                        longKeyPressHandler.postDelayed((delayMillis * 2.5).toLong()) {
+                            this.florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(KeyData.SHIFT_LOCK))
+                        }
+                    }
+                    KeyCode.LANGUAGE_SWITCH -> {
+                        longKeyPressHandler.postDelayed((delayMillis * 2.0).toLong()) {
+                            shouldBlockNextKeyCode = true
+                            this.florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(KeyData.SHOW_INPUT_METHOD_PICKER))
+                        }
+                    }
+                    else -> {
+                        longKeyPressHandler.postDelayed(delayMillis) {
+                            if (data.popup.isNotEmpty()) {
+                                popupManager.extend(this@KeyView, keyHintMode)
+                            }
                         }
                     }
                 }
@@ -328,9 +342,9 @@ class KeyView(
                             florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.up(retData))
                         } else {
                             florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(retData))
-                        }
-                        if (event.actionMasked == MotionEvent.ACTION_UP && florisboard.textInputManager.inputEventDispatcher.isPressed(KeyCode.SHIFT) && data.code != KeyCode.SHIFT) {
-                            florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(KeyData.SHIFT))
+                            if (event.actionMasked == MotionEvent.ACTION_UP && florisboard.textInputManager.inputEventDispatcher.isPressed(KeyCode.SHIFT) && data.code != KeyCode.SHIFT) {
+                                florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(KeyData.SHIFT))
+                            }
                         }
                     } else {
                         if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code) && data.code != KeyCode.SHIFT) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -427,8 +427,9 @@ class KeyView(
                     SwipeGesture.Direction.LEFT -> {
                         if (prefs.gestures.spaceBarSwipeLeft == SwipeAction.MOVE_CURSOR_LEFT) {
                             abs(event.relUnitCountX).let {
-                                if (it > 0) {
-                                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(KeyData.ARROW_LEFT, it))
+                                val count = if (!hasTriggeredGestureMove) { it - 1 } else { it }
+                                if (count > 0) {
+                                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(KeyData.ARROW_LEFT, count))
                                 }
                             }
                         } else {
@@ -441,8 +442,9 @@ class KeyView(
                     SwipeGesture.Direction.RIGHT -> {
                         if (prefs.gestures.spaceBarSwipeRight == SwipeAction.MOVE_CURSOR_RIGHT) {
                             abs(event.relUnitCountX).let {
-                                if (it > 0) {
-                                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(KeyData.ARROW_RIGHT, it))
+                                val count = if (!hasTriggeredGestureMove) { it - 1 } else { it }
+                                if (count > 0) {
+                                    florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(KeyData.ARROW_RIGHT, count))
                                 }
                             }
                         } else {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -50,7 +50,6 @@ import dev.patrickgold.florisboard.ime.theme.ThemeValue
 import dev.patrickgold.florisboard.util.ViewLayoutUtils
 import dev.patrickgold.florisboard.util.cancelAll
 import dev.patrickgold.florisboard.util.postDelayed
-import timber.log.Timber
 import java.util.*
 import kotlin.math.abs
 
@@ -246,10 +245,9 @@ class KeyView(
             && (data.code == KeyCode.DELETE && prefs.gestures.deleteKeySwipeLeft == SwipeAction.DELETE_CHARACTERS_PRECISELY
             || data.code == KeyCode.SPACE))
         if (swipeGestureDetector.onTouchEvent(event, alwaysTriggerOnMove)) {
-            if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code) && !shouldBlockNextKeyCode) {
+            if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code) && florisboard.textInputManager.inputEventDispatcher.isPressed(data.code)) {
                 florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(data))
             }
-            shouldBlockNextKeyCode = true
             isKeyPressed = false
             longKeyPressHandler.cancelAll()
             popupManager.hide()
@@ -325,15 +323,17 @@ class KeyView(
                     }
                 } else {
                     val retData = popupManager.getActiveKeyData(this)
-                    Timber.i(retData.toString())
                     if (event.actionMasked != MotionEvent.ACTION_CANCEL && !shouldBlockNextKeyCode && retData != null) {
                         if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(retData.code)) {
                             florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.up(retData))
                         } else {
                             florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(retData))
                         }
+                        if (event.actionMasked == MotionEvent.ACTION_UP && florisboard.textInputManager.inputEventDispatcher.isPressed(KeyCode.SHIFT) && data.code != KeyCode.SHIFT) {
+                            florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(KeyData.SHIFT))
+                        }
                     } else {
-                        if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code)) {
+                        if (florisboard.textInputManager.inputEventDispatcher.requireSeparateDownUp(data.code) && data.code != KeyCode.SHIFT) {
                             florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(data))
                         }
                         shouldBlockNextKeyCode = false

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -382,7 +382,7 @@ class KeyView(
                     SwipeAction.DELETE_CHARACTERS_PRECISELY -> {
                         florisboard.activeEditorInstance.apply {
                             selection.updateAndNotify(
-                                (selection.end + event.absUnitCountX).coerceIn(0, selection.end),
+                                (selection.end + event.absUnitCountX + 1).coerceIn(0, selection.end),
                                 selection.end
                             )
                         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -175,11 +175,15 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
                 sendFlorisTouchEvent(event, pointerIndex, pointerId, MotionEvent.ACTION_CANCEL)
                 activeKeyViews.remove(pointerId)
             }
+            if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
+                florisboard?.textInputManager?.inputEventDispatcher?.send(InputKeyEvent.up(KeyData.INTERNAL_BATCH_EDIT))
+            }
             return true
         }
 
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
+                florisboard?.textInputManager?.inputEventDispatcher?.send(InputKeyEvent.down(KeyData.INTERNAL_BATCH_EDIT))
                 val pointerIndex = event.actionIndex
                 val pointerId = event.getPointerId(pointerIndex)
                 searchForActiveKeyView(event, pointerIndex, pointerId)
@@ -216,6 +220,7 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
                 val pointerId = event.getPointerId(pointerIndex)
                 sendFlorisTouchEvent(event, pointerIndex, pointerId, event.actionMasked)
                 activeKeyViews.remove(pointerId)
+                florisboard?.textInputManager?.inputEventDispatcher?.send(InputKeyEvent.up(KeyData.INTERNAL_BATCH_EDIT))
             }
             else -> return false
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -28,7 +28,6 @@ import com.google.android.flexbox.FlexboxLayout
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.PrefHelper
-import dev.patrickgold.florisboard.ime.popup.PopupManager
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeGesture
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
@@ -203,7 +202,7 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
             MotionEvent.ACTION_POINTER_UP -> {
                 val pointerIndex = event.actionIndex
                 val pointerId = event.getPointerId(pointerIndex)
-                sendFlorisTouchEvent(eventFloris, pointerIndex, pointerId, MotionEvent.ACTION_UP)
+                sendFlorisTouchEvent(eventFloris, pointerIndex, pointerId, event.actionMasked)
                 activeKeyViews.remove(pointerId)
             }
             else -> return false

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -266,7 +266,8 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
                     false
                 }
             }
-            initialKeyCodes[event.pointerId] ?: 0 > KeyCode.SPACE -> when {
+            initialKeyCodes[event.pointerId] ?: 0 > KeyCode.SPACE &&
+                activeKeyViews[event.pointerId]?.popupManager?.isShowingExtendedPopup == false -> when {
                 !prefs.glide.enabled -> when (event.type) {
                     SwipeGesture.Type.TOUCH_UP -> {
                         val swipeAction = when (event.direction) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -276,7 +276,8 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
                             KeyboardMode.PHONE2 -> null
                             else -> when {
                                 florisboard.activeEditorInstance.isComposingEnabled &&
-                                        shouldSuggestClipboardContents
+                                    shouldSuggestClipboardContents &&
+                                    florisboard.activeEditorInstance.selection.isCursorMode
                                 -> R.id.clipboard_suggestion_row
                                 florisboard.activeEditorInstance.isComposingEnabled &&
                                         florisboard.activeEditorInstance.selection.isCursorMode


### PR DESCRIPTION
This PR is a rather big one, as it reworks a ton of the backend input logic, adds support for multiple input touch pointers at once and adds some cool new frontend features. In detail, this is what changed:

### Backend

- Input events of pressed keys are now guaranteed to execute in the order pressed and cannot overlap each other, thus preventing some weird state bugs. State bugs such as #227 can still occur because the `onUpdateSelection` callback is called asynchronously a few milliseconds later.
- The touch logic supports multiple input pointers now (preparation for glide typing) and in general the touch detection code has been cleaned up. Further refactoring needs to be done to completely clean up the touch logic code and improve its performance.
- The core class FlorisBoard now implements a LifecycleOwner (preparation for future use with stateful data).
- The input event logic is now in a separate class, as it is planned to unite all input events (keys, media, etc.) in this class. For now, most of the key events are managed by the `InputEventDispatcher` class.
- The suggestion marker bug has been resolved as well as the crazy jumping at the end of a textfield. (Resolves #411)

### Frontend

- You can now select text by pressing-and-holding the shift key and then either using the space bar cursor movement or Smartbar arrow keys to select text. (Closes #370, Closes #230)
- Press-and-hold the shift key without arrow keys turns on caps lock. (Closes #351)
- Press and then drag the touch pointer to a key to write only that key in uppercase. Automatically switches back to lowercase after releasing the touch pointer.
- When press-and-holding the delete key, the suggestions now don't recreate for every delete event, only for the last, thus allowing for a smoother deletion experience.
- The Smartbar clipboard/cursor tools now automatically display when there's a selection, thus allowing for easier copy/cut action performing. (Fixes #431)
- Cursor movement now works flawlessly in Acode and other web-based text editors. (Closes #395)
- Fix space bar initial movement amount. (Closes #448)
- The responsiveness of the UI has once improved and any lags should now be gone even on older devices. (Closes #280)
- Long press on the language switch button to bring up the input method picker dialog. (Closes #265)
- - Phantom space is now inserted only if a letter is inserted, else the phantom space is ignored. Currently works only for English (US) grammar. (Closes #415)

### Known bugs

- Input now almost completely fails for the "GitJournal" app, but the issue is more with the app than with FlorisBoard, as it does not really support hardware emulated keys, which are needed for the current input logic. Don't really know how to fix this one yet.
- Shift immediately after a key still causes a state issue, needs investigation.

---

This PR is now pretty complete feature-wise. Tomorrow I will try out the new logic on many different apps and some devices to chase away potential bugs, then merge it into master.