### PR TITLE
Add option for an alternate key code when caps state is active

### DIFF
--- a/app/src/main/assets/ime/text/characters/colemak.json
+++ b/app/src/main/assets/ime/text/characters/colemak.json
@@ -18,7 +18,7 @@
         "relevant": [
           { "code":   58, "label": ":" }
         ]
-      } }
+      }, "shift": { "code":   58, "label": ":" } }
     ],
     [
       { "code":   97, "label": "a" },

--- a/app/src/main/assets/ime/text/characters/dvorak.json
+++ b/app/src/main/assets/ime/text/characters/dvorak.json
@@ -12,25 +12,25 @@
           { "code":   33, "label": "!" },
           { "code":   34, "label": "\"" }
         ]
-      } },
+      }, "shift": { "code":   34, "label": "\"" } },
       { "code":   39, "label": "'", "groupId": 101, "variation": "password", "popup": {
         "relevant": [
           { "code":   33, "label": "!" },
           { "code":   34, "label": "\"" }
         ]
-      } },
+      }, "shift": { "code":   34, "label": "\"" } },
       { "code":   47, "label": "/", "groupId": 101, "variation": "uri" },
       { "code":   44, "label": ",", "popup": {
         "relevant": [
           { "code":   60, "label": "<" },
           { "code":   63, "label": "?" }
         ]
-      } },
+      }, "shift": { "code":   60, "label": "<" } },
       { "code":   46, "label": ".", "popup": {
         "relevant": [
           { "code":   62, "label": ">" }
         ]
-      } },
+      }, "shift": { "code":   62, "label": ">" } },
       { "code":  112, "label": "p" },
       { "code":  121, "label": "y" },
       { "code":  102, "label": "f" },

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyData.kt
@@ -207,6 +207,10 @@ open class KeyData(
  *  or if the key should always be visible. Defaults to [KeyVariation.ALL].
  * @property popup List of keys which will be accessible while long pressing the key. Defaults to
  *  an empty set (no extended popup).
+ * @property shift An alternative key to use when the keyboard caps state is true. Useful for layouts
+ *  such as Colemak and Dvorak. Defaults to null (don't override base uppercase key). This override
+ *  property should only be used to provide an uppercase variant of two else not related variants, but
+ *  should not be used for providing an uppercase letter (e.g. 'a' -> 'A').
  */
 class FlorisKeyData(
     type: KeyType = KeyType.CHARACTER,
@@ -214,7 +218,8 @@ class FlorisKeyData(
     label: String = "",
     var groupId: Int = GROUP_DEFAULT,
     var variation: KeyVariation = KeyVariation.ALL,
-    var popup: PopupSet<KeyData> = PopupSet()
+    var popup: PopupSet<KeyData> = PopupSet(),
+    var shift: KeyData? = null
 ) : KeyData(type, code, label) {
     companion object {
         /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -194,17 +194,21 @@ class KeyView(
      */
     fun getComputedLetter(
         keyData: KeyData = data,
-        caps: Boolean = florisboard?.textInputManager?.caps ?: false && florisboard?.textInputManager?.getActiveKeyboardMode() == KeyboardMode.CHARACTERS,
+        caps: Boolean = florisboard?.textInputManager?.caps ?: false,
         subtype: Subtype = florisboard?.activeSubtype ?: Subtype.DEFAULT
     ): String {
-        return when (data.code) {
-            KeyCode.URI_COMPONENT_TLD -> keyData.label.toLowerCase(Locale.ENGLISH)
-            else -> {
-                val labelText = (keyData.code.toChar()).toString()
-                if (caps) {
-                    labelText.toUpperCase(subtype.locale)
-                } else {
-                    labelText
+        return if (caps && keyData is FlorisKeyData && keyData.shift != null) {
+            (keyData.shift!!.code.toChar()).toString()
+        } else {
+            when (data.code) {
+                KeyCode.URI_COMPONENT_TLD -> keyData.label.toLowerCase(Locale.ENGLISH)
+                else -> {
+                    val labelText = (keyData.code.toChar()).toString()
+                    if (caps) {
+                        labelText.toUpperCase(subtype.locale)
+                    } else {
+                        labelText
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR adds an general option for `FlorisKeyData` to have an `shift` override `KeyData` attached to it, so an alternate key code can be shown when caps is active. Colemak and Dvoark layouts have been updated to take advantage of this new feature.

### Demo (Dvorak layout)

https://user-images.githubusercontent.com/19412843/110681935-a66dcf00-81da-11eb-91f9-07bacca7cdbe.mp4

---
Closes #145 