### PR TITLE
Add theme import/export / Fix theme editor jumping to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,6 @@ to get more information on this topic.
   [Jared Rummler](https://github.com/jaredrummler)
 * [Timber](https://github.com/JakeWharton/timber) by
   [JakeWharton](https://github.com/JakeWharton)
-* [kotlin-result](https://github.com/michaelbull/kotlin-result) by
-  [Michael Bull](https://github.com/michaelbull)
 * [expandable-fab](https://github.com/nambicompany/expandable-fab) by
   [Nambi](https://github.com/nambicompany)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,8 +55,10 @@ android {
 }
 
 dependencies {
+    implementation("androidx.activity", "activity-ktx", "1.2.1")
     implementation("androidx.appcompat", "appcompat", "1.2.0")
     implementation("androidx.core", "core-ktx", "1.3.2")
+    implementation("androidx.fragment", "fragment-ktx", "1.3.0")
     implementation("androidx.preference", "preference-ktx", "1.1.1")
     implementation("androidx.constraintlayout", "constraintlayout", "2.0.4")
     implementation("androidx.lifecycle", "lifecycle-service", "2.2.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-android", "1.4.2")
     implementation("com.jaredrummler", "colorpicker", "1.1.0")
     implementation("com.jakewharton.timber", "timber", "4.7.1")
-    implementation("com.michael-bull.kotlin-result", "kotlin-result", "1.1.10")
     implementation("com.nambimobile.widgets", "expandable-fab", "1.0.2")
 
     testImplementation("junit", "junit", "4.13.1")

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisActivity.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2021 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.core
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Bundle
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.viewbinding.ViewBinding
+import com.google.android.material.snackbar.Snackbar
+import dev.patrickgold.florisboard.R
+
+abstract class FlorisActivity<V : ViewBinding> : AppCompatActivity() {
+    private var _binding: V? = null
+    protected val binding: V
+        get() = _binding!!
+
+    private var _prefs: PrefHelper? = null
+    protected val prefs: PrefHelper
+        get() = _prefs!!
+
+    private var errorDialog: AlertDialog? = null
+    private var errorSnackbar: Snackbar? = null
+    private var errorThrowable: Throwable? = null
+    private var messageSnackbar: Snackbar? = null
+
+    protected abstract fun onCreateBinding(): V
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        _prefs = PrefHelper.getDefaultInstance(applicationContext)
+        onCreateBinding().let {
+            _binding = it
+            setContentView(it.root)
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
+        _prefs = null
+        errorDialog?.dismiss()
+        errorDialog = null
+        errorSnackbar?.dismiss()
+        errorSnackbar = null
+        errorThrowable = null
+        messageSnackbar?.dismiss()
+        messageSnackbar = null
+    }
+
+    protected fun showMessage(@StringRes snackbarMessageResId: Int) {
+        val snackbarMessage = resources.getString(snackbarMessageResId)
+        showMessage(snackbarMessage)
+    }
+
+    protected fun showMessage(snackbarMessage: String) {
+        messageSnackbar?.dismiss()
+        messageSnackbar = Snackbar.make(binding.root, snackbarMessage, Snackbar.LENGTH_LONG).apply {
+            setAction(android.R.string.ok) {
+                messageSnackbar?.dismiss()
+            }
+            show() }
+    }
+
+    protected fun showError(throwable: Throwable) {
+        val snackbarMessage = resources.getString(R.string.assets__error__snackbar_message)
+        showError(snackbarMessage, throwable)
+    }
+
+    protected fun showError(@StringRes snackbarMessageResId: Int, throwable: Throwable) {
+        val snackbarMessage = resources.getString(snackbarMessageResId)
+        showError(snackbarMessage, throwable)
+    }
+
+    protected fun showError(snackbarMessage: String, throwable: Throwable) {
+        errorDialog?.dismiss()
+        errorDialog = null
+        errorSnackbar?.dismiss()
+        errorSnackbar = Snackbar.make(binding.root, snackbarMessage, Snackbar.LENGTH_LONG).apply {
+            setAction(R.string.assets__error__details) {
+                errorDialog?.dismiss()
+                errorDialog = AlertDialog.Builder(this@FlorisActivity).run {
+                    setTitle(R.string.assets__error__details)
+                    setMessage(errorThrowable.toString())
+                    setPositiveButton(android.R.string.ok, null)
+                    setNeutralButton(R.string.crash_dialog__copy_to_clipboard) { _, _ ->
+                        val clipboardManager = getSystemService(Context.CLIPBOARD_SERVICE)
+                        if (clipboardManager != null && clipboardManager is ClipboardManager) {
+                            clipboardManager.setPrimaryClip(ClipData.newPlainText(errorThrowable.toString(), errorThrowable.toString()))
+                        }
+                    }
+                    create()
+                    show()
+                }
+            }
+            show()
+        }
+        errorThrowable = throwable
+    }
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/dictionary/DictionaryManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/dictionary/DictionaryManager.kt
@@ -17,7 +17,6 @@
 package dev.patrickgold.florisboard.ime.dictionary
 
 import android.content.Context
-import com.github.michaelbull.result.*
 import dev.patrickgold.florisboard.ime.extension.AssetRef
 import timber.log.Timber
 
@@ -48,22 +47,22 @@ class DictionaryManager private constructor(private val applicationContext: Cont
         }
     }
 
-    fun loadDictionary(ref: AssetRef): Result<Dictionary<String, Int>, Throwable> {
+    fun loadDictionary(ref: AssetRef): Result<Dictionary<String, Int>> {
         dictionaryCache[ref.toString()]?.let {
-            return Ok(it)
+            return Result.success(it)
         }
         if (ref.path.endsWith(".flict")) {
             // Assume this is a Flictionary
             Flictionary.load(applicationContext, ref).onSuccess { flict ->
                 dictionaryCache[ref.toString()] = flict
-                return Ok(flict)
+                return Result.success(flict)
             }.onFailure { err ->
                 Timber.i(err)
-                return Err(err)
+                return Result.failure(err)
             }
         } else {
-            return Err(Exception("Unable to determine supported type for given AssetRef!"))
+            return Result.failure(Exception("Unable to determine supported type for given AssetRef!"))
         }
-        return Err(Exception("If this message is ever thrown, something is completely broken..."))
+        return Result.failure(Exception("If this message is ever thrown, something is completely broken..."))
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/extension/Asset.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/extension/Asset.kt
@@ -17,8 +17,6 @@
 package dev.patrickgold.florisboard.ime.extension
 
 import android.content.Context
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Result
 
 /**
  * Interface for an Asset to use within FlorisBoard. An asset is everything from a dictionary to a
@@ -61,6 +59,6 @@ interface Asset {
         /**
          * Loads an Asset of type [T] from the specified path.
          */
-        fun fromFile(context: Context, path: String): Result<T, Throwable> = Err(NotImplementedError())
+        fun fromFile(context: Context, path: String): Result<T> = Result.failure(NotImplementedError())
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/extension/AssetManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/extension/AssetManager.kt
@@ -178,12 +178,12 @@ class AssetManager private constructor(private val applicationContext: Context) 
     }
 
     fun <T : Asset> loadAsset(uri: Uri, assetClass: KClass<T>): Result<T, Throwable> {
-        val rawJsonData =
-            applicationContext.contentResolver?.openInputStream(uri)?.bufferedReader().use { it?.readText() }
-                ?: return Err(Exception("Failed to read contents of Uri!"))
+        val rawJsonData = ExternalContentUtils.readTextFromUri(applicationContext, uri).onFailure {
+            return Err(it)
+        }
         return try {
             val adapter = moshi.adapter(assetClass.java)
-            val asset = adapter.fromJson(rawJsonData)
+            val asset = adapter.fromJson(rawJsonData.getOrNull()!!)
             if (asset != null) {
                 Ok(asset)
             } else {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/extension/AssetRef.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/extension/AssetRef.kt
@@ -16,11 +16,6 @@
 
 package dev.patrickgold.florisboard.ime.extension
 
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.Result
-import com.github.michaelbull.result.getOrElse
-
 /**
  * Data class which is a reference to an asset file. It indicates in which storage medium the asset
  * is as well as the relative path to it.
@@ -36,15 +31,15 @@ data class AssetRef(
     companion object {
         private const val DELIMITER: String = ":"
 
-        fun fromString(str: String): Result<AssetRef, String> {
+        fun fromString(str: String): Result<AssetRef> {
             val items = str.split(DELIMITER)
             if (items.size != 2) {
-                return Err("Unexpected length of given asset ref. Make sure that the asset ref string contains exactly 2 items separated by '$DELIMITER'!")
+                return Result.failure(Exception("Unexpected length of given asset ref. Make sure that the asset ref string contains exactly 2 items separated by '$DELIMITER'!"))
             }
             val retSource = AssetSource.fromString(items[0]).getOrElse {
-                return Err(it)
+                return Result.failure(Exception(it))
             }
-            return Ok(AssetRef(retSource, items[1]))
+            return Result.success(AssetRef(retSource, items[1]))
         }
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/extension/AssetSource.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/extension/AssetSource.kt
@@ -16,9 +16,6 @@
 
 package dev.patrickgold.florisboard.ime.extension
 
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.Result
 import java.util.*
 
 /**
@@ -52,16 +49,16 @@ sealed class AssetSource {
     companion object {
         private val externalRegex: Regex = """^external\\(([a-z]+\\.)*[a-z]+\\)\$""".toRegex()
 
-        fun fromString(str: String): Result<AssetSource, String> {
+        fun fromString(str: String): Result<AssetSource> {
             return when (val string = str.toLowerCase(Locale.ENGLISH)) {
-                "assets" -> Ok(Assets)
-                "internal" -> Ok(Internal)
+                "assets" -> Result.success(Assets)
+                "internal" -> Result.success(Internal)
                 else -> {
                     if (string.matches(externalRegex)) {
                         val packageName = string.substring(9, string.length - 1)
-                        Ok(External(packageName))
+                        Result.success(External(packageName))
                     } else {
-                        Err("'$str' is not a valid AssetSource.")
+                        Result.failure(Exception("'$str' is not a valid AssetSource."))
                     }
                 }
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/extension/ExternalContentUtils.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/extension/ExternalContentUtils.kt
@@ -1,0 +1,26 @@
+package dev.patrickgold.florisboard.ime.extension
+
+import android.content.Context
+import android.net.Uri
+
+class ExternalContentUtils private constructor() {
+    companion object {
+        fun readTextFromUri(context: Context, uri: Uri): Result<String> {
+            val contentResolver = context.contentResolver
+                ?: return Result.failure(NullPointerException("System content resolver not available!"))
+            val inputStream = contentResolver.openInputStream(uri)
+                ?: return Result.failure(NullPointerException("Cannot open input stream!"))
+            val rawText = inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            return Result.success(rawText)
+        }
+
+        fun writeTextToUri(context: Context, uri: Uri, text: String): Result<Unit> {
+            val contentResolver = context.contentResolver
+                ?: return Result.failure(NullPointerException("System content resolver not available!"))
+            val outputStream = contentResolver.openOutputStream(uri)
+                ?: return Result.failure(NullPointerException("Cannot open output stream!"))
+            outputStream.bufferedWriter(Charsets.UTF_8).use { it.write(text) }
+            return Result.success(Unit)
+        }
+    }
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/extension/ExternalContentUtils.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/extension/ExternalContentUtils.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2021 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.patrickgold.florisboard.ime.extension
 
 import android.content.Context
@@ -7,18 +23,18 @@ class ExternalContentUtils private constructor() {
     companion object {
         fun readTextFromUri(context: Context, uri: Uri): Result<String> {
             val contentResolver = context.contentResolver
-                ?: return Result.failure(NullPointerException("System content resolver not available!"))
+                ?: return Result.failure(NullPointerException("System content resolver not available"))
             val inputStream = contentResolver.openInputStream(uri)
-                ?: return Result.failure(NullPointerException("Cannot open input stream!"))
+                ?: return Result.failure(NullPointerException("Cannot open input stream for given uri '$uri'"))
             val rawText = inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
             return Result.success(rawText)
         }
 
         fun writeTextToUri(context: Context, uri: Uri, text: String): Result<Unit> {
             val contentResolver = context.contentResolver
-                ?: return Result.failure(NullPointerException("System content resolver not available!"))
+                ?: return Result.failure(NullPointerException("System content resolver not available"))
             val outputStream = contentResolver.openOutputStream(uri)
-                ?: return Result.failure(NullPointerException("Cannot open output stream!"))
+                ?: return Result.failure(NullPointerException("Cannot open output stream for given uri '$uri'"))
             outputStream.bufferedWriter(Charsets.UTF_8).use { it.write(text) }
             return Result.success(Unit)
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/extension/ExternalContentUtils.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/extension/ExternalContentUtils.kt
@@ -33,9 +33,10 @@ class ExternalContentUtils private constructor() {
         fun writeTextToUri(context: Context, uri: Uri, text: String): Result<Unit> {
             val contentResolver = context.contentResolver
                 ?: return Result.failure(NullPointerException("System content resolver not available"))
-            val outputStream = contentResolver.openOutputStream(uri)
+            // Must use "rwt" mode to ensure destination file length is truncated after writing.
+            val outputStream = contentResolver.openOutputStream(uri, "rwt")
                 ?: return Result.failure(NullPointerException("Cannot open output stream for given uri '$uri'"))
-            outputStream.bufferedWriter(Charsets.UTF_8).use { it.write(text) }
+            outputStream.bufferedWriter(Charsets.UTF_8).use { it.flush(); it.write(text) }
             return Result.success(Unit)
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -22,7 +22,6 @@ import android.view.KeyEvent
 import android.widget.LinearLayout
 import android.widget.Toast
 import android.widget.ViewFlipper
-import com.github.michaelbull.result.getOr
 import dev.patrickgold.florisboard.BuildConfig
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.*
@@ -321,7 +320,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
             if (activeEditorInstance.isComposingEnabled) {
                 withContext(Dispatchers.IO) {
                     dictionaryManager.loadDictionary(AssetRef(AssetSource.Assets,"ime/dict/en.flict")).let {
-                        activeDictionary = it.getOr(null)
+                        activeDictionary = it.getOrDefault(null)
                     }
                 }
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
@@ -78,10 +78,10 @@ class LayoutManager(private val context: Context) : CoroutineScope by MainScope(
             source = AssetSource.Assets,
             path = PopupManager.POPUP_EXTENSION_PATH_REL + "/" + (subtype?.locale?.language ?: "\$default") + ".json"
         )
-        assetManager.loadAsset(langTagRef, PopupExtension::class.java).onSuccess {
+        assetManager.loadAsset(langTagRef, PopupExtension::class).onSuccess {
             return it
         }
-        assetManager.loadAsset(langRef, PopupExtension::class.java).onSuccess {
+        assetManager.loadAsset(langRef, PopupExtension::class).onSuccess {
             return it
         }
         return PopupExtension.empty()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
@@ -17,7 +17,6 @@
 package dev.patrickgold.florisboard.ime.text.layout
 
 import android.content.Context
-import com.github.michaelbull.result.onSuccess
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dev.patrickgold.florisboard.ime.core.PrefHelper

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
@@ -23,7 +23,6 @@ import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Color
 import android.net.Uri
-import com.github.michaelbull.result.*
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.extension.AssetManager
 import dev.patrickgold.florisboard.ime.extension.AssetRef
@@ -103,7 +102,7 @@ class ThemeManager private constructor(
         activeTheme = AdaptiveThemeOverlay(this, if (ref == null) {
             Theme.BASE_THEME
         } else {
-            loadTheme(ref).getOr(Theme.BASE_THEME)
+            loadTheme(ref).getOrDefault(Theme.BASE_THEME)
         })
         Timber.i(activeTheme.label)
         notifyCallbackReceivers()
@@ -248,33 +247,33 @@ class ThemeManager private constructor(
         }
     }
 
-    fun deleteTheme(ref: AssetRef): Result<Nothing?, Throwable> {
+    fun deleteTheme(ref: AssetRef): Result<Unit> {
         return assetManager.deleteAsset(ref)
     }
 
-    fun loadTheme(ref: AssetRef): Result<Theme, Throwable> {
+    fun loadTheme(ref: AssetRef): Result<Theme> {
         assetManager.loadAsset(ref, ThemeJson::class).onSuccess { themeJson ->
             val theme = themeJson.toTheme()
-            return Ok(theme)
+            return Result.success(theme)
         }.onFailure {
             Timber.e(it.toString())
-            return Err(it)
+            return Result.failure(it)
         }
-        return Err(Exception("Unreachable code"))
+        return Result.failure(Exception("Unreachable code"))
     }
 
-    fun loadTheme(uri: Uri): Result<Theme, Throwable> {
+    fun loadTheme(uri: Uri): Result<Theme> {
         assetManager.loadAsset(uri, ThemeJson::class).onSuccess { themeJson ->
             val theme = themeJson.toTheme()
-            return Ok(theme)
+            return Result.success(theme)
         }.onFailure {
             Timber.e(it.toString())
-            return Err(it)
+            return Result.failure(it)
         }
-        return Err(Exception("Unreachable code"))
+        return Result.failure(Exception("Unreachable code"))
     }
 
-    fun writeTheme(ref: AssetRef, theme: Theme): Result<Boolean, Throwable> {
+    fun writeTheme(ref: AssetRef, theme: Theme): Result<Unit> {
         return assetManager.writeAsset(ref, ThemeJson::class, ThemeJson.fromTheme(theme))
     }
 
@@ -312,7 +311,7 @@ class ThemeManager private constructor(
                     prefs.theme.dayThemeRef
                 }
             }
-        }).onFailure { Timber.e(it) }.getOr(null)
+        }).onFailure { Timber.e(it) }.getOrDefault(null)
     }
 
     private fun indexThemeRefs() {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Color
+import android.net.Uri
 import com.github.michaelbull.result.*
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.extension.AssetManager
@@ -252,7 +253,18 @@ class ThemeManager private constructor(
     }
 
     fun loadTheme(ref: AssetRef): Result<Theme, Throwable> {
-        assetManager.loadAsset(ref, ThemeJson::class.java).onSuccess { themeJson ->
+        assetManager.loadAsset(ref, ThemeJson::class).onSuccess { themeJson ->
+            val theme = themeJson.toTheme()
+            return Ok(theme)
+        }.onFailure {
+            Timber.e(it.toString())
+            return Err(it)
+        }
+        return Err(Exception("Unreachable code"))
+    }
+
+    fun loadTheme(uri: Uri): Result<Theme, Throwable> {
+        assetManager.loadAsset(uri, ThemeJson::class).onSuccess { themeJson ->
             val theme = themeJson.toTheme()
             return Ok(theme)
         }.onFailure {
@@ -263,7 +275,7 @@ class ThemeManager private constructor(
     }
 
     fun writeTheme(ref: AssetRef, theme: Theme): Result<Boolean, Throwable> {
-        return assetManager.writeAsset(ref, ThemeJson::class.java, ThemeJson.fromTheme(theme))
+        return assetManager.writeAsset(ref, ThemeJson::class, ThemeJson.fromTheme(theme))
     }
 
     private fun evaluateActiveThemeRef(): AssetRef? {
@@ -308,7 +320,7 @@ class ThemeManager private constructor(
         indexedNightThemeRefs.clear()
         assetManager.listAssets(
             AssetRef(AssetSource.Assets, THEME_PATH_REL),
-            ThemeMetaOnly::class.java
+            ThemeMetaOnly::class
         ).onSuccess {
             for ((ref, themeMetaOnly) in it) {
                 if (themeMetaOnly.isNightTheme) {
@@ -322,7 +334,7 @@ class ThemeManager private constructor(
         }
         assetManager.listAssets(
             AssetRef(AssetSource.Internal, THEME_PATH_REL),
-            ThemeMetaOnly::class.java
+            ThemeMetaOnly::class
         ).onSuccess {
             for ((ref, themeMetaOnly) in it) {
                 if (themeMetaOnly.isNightTheme) {

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
@@ -28,7 +28,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.children
 import androidx.core.view.forEach
-import com.github.michaelbull.result.onSuccess
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.databinding.ThemeEditorActivityBinding
 import dev.patrickgold.florisboard.databinding.ThemeEditorGroupViewBinding

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
@@ -31,6 +31,7 @@ import androidx.core.view.forEach
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.databinding.ThemeEditorActivityBinding
 import dev.patrickgold.florisboard.databinding.ThemeEditorGroupViewBinding
+import dev.patrickgold.florisboard.databinding.ThemeEditorMetaDialogBinding
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.extension.AssetRef
@@ -59,6 +60,12 @@ class ThemeEditorActivity : AppCompatActivity() {
     private var editedThemeRef: AssetRef? = null
     private var isSaved: Boolean = false
 
+    private var themeLabel: String = ""
+        set(v) {
+            field = v
+            binding.themeNameLabel.text = v
+        }
+
     companion object {
         /** Constant code for a theme saved activity result. */
         const val RESULT_CODE_THEME_EDIT_SAVED: Int = 0xFBADC1
@@ -83,6 +90,8 @@ class ThemeEditorActivity : AppCompatActivity() {
                 editedTheme = theme.copy()
             }
         }
+
+        binding.themeNameEditBtn.setOnClickListener { showMetaEditDialog() }
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
@@ -128,22 +137,13 @@ class ThemeEditorActivity : AppCompatActivity() {
             R.id.add_group_btn -> addGroup()
             R.id.theme_cancel_btn -> onBackPressed()
             R.id.theme_save_btn -> {
-                val themeName = binding.themeNameValue.text.toString().trim()
-                if (Theme.validateField(Theme.ValidationField.THEME_LABEL, themeName)) {
-                    val ref = editedThemeRef
-                    if (ref != null) {
-                        themeManager.writeTheme(
-                            ref, editedTheme.copy(
-                                label = themeName
-                            )
-                        )
-                        isSaved = true
-                        finish()
-                    }
-                } else {
-                    binding.themeNameLabel.error =
-                        resources.getString(R.string.settings__theme_editor__error_theme_label_empty)
-                    binding.themeNameLabel.isErrorEnabled = true
+                val ref = editedThemeRef
+                if (ref != null) {
+                    themeManager.writeTheme(
+                        ref, editedTheme.copy(label = themeLabel)
+                    )
+                    isSaved = true
+                    finish()
                 }
             }
         }
@@ -304,7 +304,7 @@ class ThemeEditorActivity : AppCompatActivity() {
             }
         }
         editedTheme = editedTheme.copy(
-            label = binding.themeNameValue.text.toString(),
+            label = themeLabel,
             attributes = tempMap.toMap()
         )
         binding.keyboardPreview.onThemeUpdated(editedTheme)
@@ -314,7 +314,7 @@ class ThemeEditorActivity : AppCompatActivity() {
      * Builds the Ui for the current [editedTheme]. Also sorts the groups afterwards.
      */
     private fun buildUi() {
-        binding.themeNameValue.setText(editedTheme.label)
+        themeLabel = editedTheme.label
         for ((groupName, groupAttrs) in editedTheme.attributes) {
             val groupView = addGroup(groupName).root
             for ((attrName, attrValue) in groupAttrs) {
@@ -328,5 +328,30 @@ class ThemeEditorActivity : AppCompatActivity() {
             binding.keyboardPreview.onThemeUpdated(editedTheme)
         }
         sortGroups()
+    }
+
+    private fun showMetaEditDialog() {
+        val dialogView = ThemeEditorMetaDialogBinding.inflate(layoutInflater)
+        dialogView.metaName.setText(editedTheme.label)
+        val dialog: AlertDialog
+        AlertDialog.Builder(this).apply {
+            setTitle(R.string.settings__theme_editor__edit_theme_name_dialog_title)
+            setCancelable(true)
+            setView(dialogView.root)
+            setPositiveButton(android.R.string.ok, null)
+            setNegativeButton(android.R.string.cancel, null)
+            create()
+            dialog = show()
+            dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE)?.setOnClickListener {
+                val tempThemeLabel = dialogView.metaName.text.toString().trim()
+                if (Theme.validateField(Theme.ValidationField.THEME_LABEL, tempThemeLabel)) {
+                    themeLabel = tempThemeLabel
+                    dialog.dismiss()
+                } else {
+                    dialogView.metaNameLabel.error = resources.getString(R.string.settings__theme_editor__error_theme_label_empty)
+                    dialogView.metaNameLabel.isErrorEnabled = true
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
@@ -90,7 +90,7 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
                 selectedRef = newAssetRef
                 setThemeRefInPrefs(newAssetRef)
                 buildUi()
-                showMessage("Theme imported successfully!")
+                showMessage(R.string.settings__theme_manager__theme_import_success)
             }.onFailure {
                 showError(it)
             }
@@ -106,8 +106,9 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
         val selectedRef = selectedRef
         if (selectedRef != null) {
             AssetManager.default().loadAssetRaw(selectedRef).onSuccess {
+                Timber.i(it)
                 ExternalContentUtils.writeTextToUri(this, uri, it).onSuccess {
-                    showMessage("Theme exported successfully")
+                    showMessage(R.string.settings__theme_manager__theme_export_success)
                 }.onFailure {
                     showError(it)
                 }

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
@@ -60,7 +60,7 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
     private var selectedRef: AssetRef? = null
 
     private val themeEditor = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult? ->
-        if (result?.resultCode == RESULT_OK) {
+        if (result?.resultCode == ThemeEditorActivity.RESULT_CODE_THEME_EDIT_SAVED) {
             themeManager.update()
             buildUi()
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
@@ -30,10 +30,6 @@ import androidx.annotation.IdRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.forEach
-import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.getOr
-import com.github.michaelbull.result.onFailure
-import com.github.michaelbull.result.onSuccess
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.databinding.ThemeManagerActivityBinding
 import dev.patrickgold.florisboard.ime.core.FlorisActivity
@@ -75,10 +71,10 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
         // so we don't display an error message here.
         if (uri == null) return@registerForActivityResult
         val toBeImportedTheme = themeManager.loadTheme(uri)
-        if (toBeImportedTheme is Ok) {
-            val newTheme = toBeImportedTheme.component1().copy(
-                name = toBeImportedTheme.component1().name + "_imported",
-                label = toBeImportedTheme.component1().label + " (Imported)"
+        if (toBeImportedTheme.isSuccess) {
+            val newTheme = toBeImportedTheme.getOrNull()!!.copy(
+                name = toBeImportedTheme.getOrNull()!!.name + "_imported",
+                label = toBeImportedTheme.getOrNull()!!.label + " (Imported)"
             )
             val newAssetRef = AssetRef(
                 AssetSource.Internal,
@@ -95,7 +91,7 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
                 showError(it)
             }
         } else {
-            showError(toBeImportedTheme.component2()!!)
+            showError(toBeImportedTheme.exceptionOrNull()!!)
         }
     }
 
@@ -193,7 +189,7 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
                     PrefHelper.Theme.NIGHT_THEME_REF -> prefs.theme.nightThemeRef
                     else -> ""
                 }
-            ).getOr(null)
+            ).getOrDefault(null)
         }
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
@@ -95,7 +95,7 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
         }
     }
 
-    private val exportTheme = registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+    private val exportTheme = registerForActivityResult(ActivityResultContracts.CreateDocument()) { uri: Uri? ->
         // If uri is null it indicates that the selection activity was cancelled (mostly by pressing the back button,
         // so we don't display an error message here.
         if (uri == null) return@registerForActivityResult
@@ -287,7 +287,7 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
                 }
             }
             R.id.fab_option_import -> {
-                importTheme.launch("application/json")
+                importTheme.launch("*/*")
             }
             R.id.theme_delete_btn -> {
                 val deleteRef = selectedRef?.copy()
@@ -342,7 +342,7 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
                 }
             }
             R.id.theme_export_btn -> {
-                exportTheme.launch(arrayOf("application/json"))
+                exportTheme.launch("${selectedTheme.name}.json")
             }
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/components/ThemeSelectorPreference.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/components/ThemeSelectorPreference.kt
@@ -24,7 +24,6 @@ import android.util.AttributeSet
 import androidx.preference.Preference
 import androidx.preference.Preference.OnPreferenceClickListener
 import androidx.preference.PreferenceManager
-import com.github.michaelbull.result.onSuccess
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.extension.AssetRef

--- a/app/src/main/res/drawable/ic_share.xml
+++ b/app/src/main/res/drawable/ic_share.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?android:attr/textColorPrimary" android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+</vector>

--- a/app/src/main/res/layout/theme_editor_activity.xml
+++ b/app/src/main/res/layout/theme_editor_activity.xml
@@ -42,28 +42,31 @@
                         android:layout_margin="8dp"
                         app:isPreviewKeyboard="true"/>
 
-                    <com.google.android.material.textfield.TextInputLayout
-                        android:id="@+id/theme_name_label"
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
-                        android:layout_marginHorizontal="8dp"
-                        android:hint="@string/settings__theme_editor__name_label"
-                        app:boxBackgroundMode="outline"
-                        app:boxBackgroundColor="?android:windowBackground"
-                        app:boxStrokeColor="?colorAccent"
-                        app:boxStrokeErrorColor="?colorError"
-                        app:boxStrokeWidth="1dp">
+                        android:orientation="horizontal"
+                        android:layout_margin="8dp">
 
-                        <com.google.android.material.textfield.TextInputEditText
-                            android:id="@+id/theme_name_value"
-                            android:layout_width="match_parent"
+                        <TextView
+                            android:id="@+id/theme_name_label"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:importantForAutofill="no"
-                            android:inputType="textFilter"
-                            android:imeOptions="flagForceAscii|flagNoExtractUi"/>
+                            android:layout_weight="1.0"
+                            android:textColor="?android:textColorPrimary"
+                            tools:text="GroupName"/>
 
-                    </com.google.android.material.textfield.TextInputLayout>
+                        <ImageButton
+                            android:id="@+id/theme_name_edit_btn"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="16dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:src="@drawable/ic_edit"
+                            android:tint="?android:textColorPrimary"
+                            android:contentDescription="@string/settings__theme_editor__edit_group_dialog_title"/>
+
+                    </LinearLayout>
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/theme_editor_meta_dialog.xml
+++ b/app/src/main/res/layout/theme_editor_meta_dialog.xml
@@ -1,0 +1,31 @@
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="20dp"
+    android:paddingTop="16dp"
+    android:orientation="vertical">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/meta_name_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/settings__theme_editor__name_label"
+        app:boxBackgroundMode="outline"
+        app:boxBackgroundColor="?android:windowBackground"
+        app:boxStrokeColor="?colorAccent"
+        app:boxStrokeErrorColor="?colorError"
+        app:boxStrokeWidth="1dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/meta_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:importantForAutofill="no"
+            android:inputType="textFilter"
+            android:imeOptions="flagForceAscii|flagNoExtractUi"/>
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/theme_manager_activity.xml
+++ b/app/src/main/res/layout/theme_manager_activity.xml
@@ -174,7 +174,8 @@
 
     <com.nambimobile.widgets.efab.ExpandableFabLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        app:layout_dodgeInsetEdges="bottom">
 
         <com.nambimobile.widgets.efab.Overlay
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/theme_manager_activity.xml
+++ b/app/src/main/res/layout/theme_manager_activity.xml
@@ -112,15 +112,30 @@
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="end">
+                        android:orientation="horizontal">
+
+                        <Button
+                            android:id="@+id/theme_export_btn"
+                            style="?android:attr/buttonBarButtonStyle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textAllCaps="false"
+                            android:text="@string/assets__action__export"
+                            android:textColor="?android:textColorPrimary"
+                            android:drawableStart="@drawable/ic_delete"
+                            android:drawablePadding="8dp"
+                            android:drawableTint="?colorAccent"/>
+
+                        <View
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_weight="1.0"/>
 
                         <Button
                             android:id="@+id/theme_delete_btn"
                             style="?android:attr/buttonBarButtonStyle"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="end"
                             android:textAllCaps="false"
                             android:text="@string/assets__action__delete"
                             android:textColor="?android:textColorPrimary"
@@ -133,7 +148,6 @@
                             style="?android:attr/buttonBarButtonStyle"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="end"
                             android:textAllCaps="false"
                             android:text="@string/assets__action__edit"
                             android:textColor="?android:textColorPrimary"
@@ -189,13 +203,13 @@
             app:fab_color="?colorPrimaryDark"
             app:fab_icon="@drawable/ic_file"
             app:label_text="@string/settings__theme_manager__create_from_selected"/>
-        <!--<com.nambimobile.widgets.efab.FabOption
+        <com.nambimobile.widgets.efab.FabOption
             android:id="@+id/fab_option_import"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:fab_color="?colorPrimaryDark"
             app:fab_icon="@drawable/ic_input"
-            app:label_text="@string/assets__action__import"/>-->
+            app:label_text="@string/assets__action__import"/>
 
     </com.nambimobile.widgets.efab.ExpandableFabLayout>
 

--- a/app/src/main/res/layout/theme_manager_activity.xml
+++ b/app/src/main/res/layout/theme_manager_activity.xml
@@ -122,7 +122,7 @@
                             android:textAllCaps="false"
                             android:text="@string/assets__action__export"
                             android:textColor="?android:textColorPrimary"
-                            android:drawableStart="@drawable/ic_delete"
+                            android:drawableStart="@drawable/ic_share"
                             android:drawablePadding="8dp"
                             android:drawableTint="?colorAccent"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,8 @@
     <string name="settings__theme_manager__create_from_selected" comment="Label of the Create from selected FAB action">Create from selected theme</string>
     <string name="settings__theme_manager__theme_custom_title" comment="Title template for a custom theme">Custom (based on %s)</string>
     <string name="settings__theme_manager__theme_new_title" comment="Title template for a new theme">New theme</string>
+    <string name="settings__theme_manager__theme_import_success" comment="Message for theme import success">Theme imported successfully!</string>
+    <string name="settings__theme_manager__theme_export_success" comment="Message for theme export success">Theme exported successfully!</string>
 
     <string name="settings__theme_editor__title" comment="Title of the edit theme activity">Edit theme</string>
     <string name="settings__theme_editor__name_label" comment="Label of name input">Name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -314,7 +314,9 @@
     <string name="assets__action__no">No</string>
     <string name="assets__action__save">Save</string>
     <string name="assets__action__yes">Yes</string>
+    <string name="assets__error__details">Details</string>
     <string name="assets__error__invalid">Invalid</string>
+    <string name="assets__error__snackbar_message">Something went wrong</string>
 
     <!-- Setup UI strings -->
     <string name="setup__title" comment="Title of Setup">Setup</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="settings__theme_editor__edit_group_dialog_title" comment="Title of the edit group dialog in the theme editor">Edit group</string>
     <string name="settings__theme_editor__add_attr_dialog_title" comment="Title of the add attribute dialog in the theme editor">Add attribute</string>
     <string name="settings__theme_editor__edit_attr_dialog_title" comment="Title of the edit attribute dialog in the theme editor">Edit attribute</string>
+    <string name="settings__theme_editor__edit_theme_name_dialog_title" comment="Title of the edit theme name dialog in the theme editor">Edit theme name</string>
     <string name="settings__theme_editor__value_type_reference" comment="Theme value type">Reference</string>
     <string name="settings__theme_editor__value_type_reference_group" comment="Theme value type sub-field">Group</string>
     <string name="settings__theme_editor__value_type_reference_attr" comment="Theme value type sub-field">Attribute</string>


### PR DESCRIPTION
This PR adds the ability to import/export json theme files from/to the local file system by using the Android `GET_CONTENT` and ~`OPEN_DOCUMENT`~ `CREATE_DOCUMENT` actions. Note that the file selection UI is device/system dependent and can not be influenced by FlorisBoard. If the theme import/export functionality works well on all devices I will adopt this also to other areas of FlorisBoard, especially though dictionaries and layout json files.

Closes #93 

---

The theme editor now does not jump to the top when opening an attribute dialog.

Closes #379 

---

Other non-user relevant changes:

- Switched from [michaelbull/kotlin-result](https://github.com/michaelbull/kotlin-result) to the in-built Kotlin Result type
- Add internal `FlorisActivity`, which provides several useful utilities used across different activities