### PR TITLE
Rework symbols sizing when number row is enabled

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputView.kt
@@ -21,7 +21,6 @@ import android.content.res.Configuration
 import android.util.AttributeSet
 import android.util.DisplayMetrics
 import android.view.ViewGroup
-import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.ViewFlipper
 import dev.patrickgold.florisboard.R
@@ -48,6 +47,8 @@ class InputView : LinearLayout {
     var desiredMediaKeyboardViewHeight: Float = resources.getDimension(R.dimen.mediaKeyboardView_baseHeight)
         private set
     var heightFactor: Float = 1.0f
+        private set
+    var shouldGiveAdditionalSpace: Boolean = false
         private set
 
     var mainViewFlipper: ViewFlipper? = null
@@ -100,12 +101,12 @@ class InputView : LinearLayout {
         var baseSmartbarHeight = 0.16129f * baseHeight
         var baseTextInputHeight = baseHeight - baseSmartbarHeight
         val tim = florisboard.textInputManager
-        val shouldGiveAdditionalSpace = prefs.keyboard.numberRow &&
+        shouldGiveAdditionalSpace = prefs.keyboard.numberRow &&
                 !(tim.getActiveKeyboardMode() == KeyboardMode.NUMERIC ||
                 tim.getActiveKeyboardMode() == KeyboardMode.PHONE ||
                 tim.getActiveKeyboardMode() == KeyboardMode.PHONE2)
         if (shouldGiveAdditionalSpace) {
-            val additionalHeight = desiredTextKeyboardViewHeight * 0.18f
+            val additionalHeight = baseTextInputHeight * 0.25f
             baseHeight += additionalHeight
             baseTextInputHeight += additionalHeight
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -22,9 +22,10 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import android.widget.LinearLayout
 import androidx.core.view.children
+import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxLayout
+import com.google.android.flexbox.JustifyContent
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.InputKeyEvent
@@ -48,7 +49,7 @@ import kotlin.math.roundToInt
  *
  * @property florisboard Reference to instance of core class [FlorisBoard].
  */
-class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Listener,
+class KeyboardView : FlexboxLayout, FlorisBoard.EventListener, SwipeGesture.Listener,
     ThemeManager.OnThemeUpdatedListener {
     private var activeKeyViews: MutableMap<Int, KeyView> = mutableMapOf()
     private var initialKeyCodes: MutableMap<Int, Int> = mutableMapOf()
@@ -77,7 +78,8 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
             isLoadingPlaceholderKeyboard = getBoolean(R.styleable.KeyboardView_isLoadingPlaceholderKeyboard, false)
             recycle()
         }
-        orientation = VERTICAL
+        flexDirection = FlexDirection.COLUMN
+        justifyContent = JustifyContent.SPACE_BETWEEN
         layoutParams = layoutParams ?: FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             FrameLayout.LayoutParams.WRAP_CONTENT
@@ -360,9 +362,17 @@ class KeyboardView : LinearLayout, FlorisBoard.EventListener, SwipeGesture.Liste
         } else {
             (florisboard?.inputView?.desiredTextKeyboardViewHeight ?: MeasureSpec.getSize(heightMeasureSpec).toFloat())
         } * if (isPreviewMode) { 0.90f } else { 1.00f }
+        val layoutSize = computedLayout?.arrangement?.size?.toFloat() ?: 4.0f
         desiredKeyHeight = when {
-            isSmartbarKeyboardView -> desiredHeight - 1.5f * keyMarginV
-            else -> desiredHeight / (computedLayout?.arrangement?.size?.toFloat() ?: 4.0f) - 2.0f * keyMarginV
+            isSmartbarKeyboardView -> {
+                desiredHeight - 1.5f * keyMarginV
+            }
+            florisboard?.inputView?.shouldGiveAdditionalSpace == true -> {
+                desiredHeight / (layoutSize + 0.5f).coerceAtMost(5.0f) - 2.0f * keyMarginV
+            }
+            else -> {
+                desiredHeight / layoutSize - 2.0f * keyMarginV
+            }
         }.roundToInt()
 
         super.onMeasure(


### PR DESCRIPTION
This PR is an attempt to improve the symbols key and font sizing when the number row in the character layout is activated. The new key sizing calculation is now similar to Gboard's and thus the font-size bug is minimized and almost not noticeable anymore. Open to suggestions though if the new sizing method should be improved and tweaked a bit, as it now looks a bit different than before.

### Comparison Old vs New

https://user-images.githubusercontent.com/19412843/111925616-efab0200-8aa9-11eb-83f5-d6892c570521.mp4

https://user-images.githubusercontent.com/19412843/111925622-f3d71f80-8aa9-11eb-9ce3-d5e15c0119ef.mp4

Closes #203 because there's no need to set different font sizes anymore as the bug's effect has been minimized and is now almost unnoticeable.