### PR TITLE
Fix for #481

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/FlorisClipboardManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/FlorisClipboardManager.kt
@@ -164,7 +164,7 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
      * Wraps some plaintext in a ClipData and calls [addNewClip]
      */
     fun addNewPlaintext(newText: String) {
-        val newData = ClipboardItem(null, ItemType.TEXT, null, newText, arrayOf("text/plain"))
+        val newData = ClipboardItem(null, ItemType.TEXT, null, newText, ClipboardItem.TEXT_PLAIN)
         addNewClip(newData)
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
@@ -86,6 +86,10 @@ data class ClipboardItem(
 
     companion object {
         /**
+         * So that every item doesn't have to allocate its own array.
+         */
+        val TEXT_PLAIN = arrayOf("text/plain")
+        /**
          * Returns a new ClipboardItem based on a ClipData
          *
          * @param data The ClipData to clone.
@@ -112,10 +116,16 @@ data class ClipboardItem(
             }else { null }
 
             val text = data.getItemAt(0).text?.toString()
-            val mimeTypes = Array(data.description.mimeTypeCount) { "" }
+            val mimeTypes = when (type) {
+                ItemType.IMAGE -> {
+                    val x = Array(data.description.mimeTypeCount) { "" }
 
-            (0 until data.description.mimeTypeCount).forEach {
-                    mimeTypes[it] = data.description.getMimeType(it)
+                    (0 until data.description.mimeTypeCount).forEach {
+                        x[it] = data.description.getMimeType(it)
+                    }
+                    x
+                }
+                ItemType.TEXT -> { TEXT_PLAIN }
             }
 
             return ClipboardItem(null, type, uri, text, mimeTypes)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
@@ -118,12 +118,9 @@ data class ClipboardItem(
             val text = data.getItemAt(0).text?.toString()
             val mimeTypes = when (type) {
                 ItemType.IMAGE -> {
-                    val x = Array(data.description.mimeTypeCount) { "" }
-
-                    (0 until data.description.mimeTypeCount).forEach {
-                        x[it] = data.description.getMimeType(it)
-                    }
-                    x
+                    (0 until data.description.mimeTypeCount).map {
+                        data.description.getMimeType(it)
+                    }.toTypedArray()
                 }
                 ItemType.TEXT -> { TEXT_PLAIN }
             }


### PR DESCRIPTION
Essentially I forgot to change the mimetype to plaintext when copying html, which causes #481

Somewhat unrelated, but I also switched to using a static array for the plaintext mimetype array. This way, every time a plaintext item is added, it doesn't allocate a brand new array.

Fixes #481 