### PR TITLE
Suggestions frontend rework

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/FlorisClipboardManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/FlorisClipboardManager.kt
@@ -71,6 +71,10 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
             }
             return instance!!
         }
+
+        @Synchronized
+        fun getInstanceOrNull(): FlorisClipboardManager? = instance
+
         /**
          * Taken from ClipboardDescription.java from the AOSP
          *

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
@@ -84,11 +84,20 @@ data class ClipboardItem(
         return result
     }
 
+    fun stringRepresentation(): String {
+        return when {
+            uri != null -> "(Image) $uri"
+            text != null -> text
+            else -> "#ERROR"
+        }
+    }
+
     companion object {
         /**
          * So that every item doesn't have to allocate its own array.
          */
         val TEXT_PLAIN = arrayOf("text/plain")
+
         /**
          * Returns a new ClipboardItem based on a ClipData
          *
@@ -113,7 +122,7 @@ data class ClipboardItem(
                         }
                         FlorisBoard.getInstance().context.contentResolver.insert(FlorisContentProvider.CLIPS_URI, values)
                     }
-            }else { null }
+            } else { null }
 
             val text = data.getItemAt(0).text?.toString()
             val mimeTypes = when (type) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -28,6 +28,7 @@ import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.gestures.VelocityThreshold
 import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
 import dev.patrickgold.florisboard.ime.text.key.UtilityKeyAction
+import dev.patrickgold.florisboard.ime.text.smartbar.CandidateView
 import dev.patrickgold.florisboard.ime.theme.ThemeMode
 import dev.patrickgold.florisboard.util.TimeUtil
 import dev.patrickgold.florisboard.util.VersionName
@@ -444,20 +445,28 @@ class PrefHelper(
     class Suggestion(private val prefHelper: PrefHelper) {
         companion object {
             const val BLOCK_POSSIBLY_OFFENSIVE =    "suggestion__block_possibly_offensive"
+            const val CLIPBOARD_CONTENT_ENABLED =   "suggestion__clipboard_content_enabled"
+            const val CLIPBOARD_CONTENT_TIMEOUT =   "suggestion__clipboard_content_timeout"
+            const val DISPLAY_MODE =                "suggestion__display_mode"
             const val ENABLED =                     "suggestion__enabled"
-            const val SUGGEST_CLIPBOARD_CONTENT =   "suggestion__suggest_clipboard_content"
             const val USE_PREV_WORDS =              "suggestion__use_prev_words"
         }
 
         var blockPossiblyOffensive: Boolean
             get() =  prefHelper.getPref(BLOCK_POSSIBLY_OFFENSIVE, true)
             set(v) = prefHelper.setPref(BLOCK_POSSIBLY_OFFENSIVE, v)
+        var clipboardContentEnabled: Boolean
+            get() =  prefHelper.getPref(CLIPBOARD_CONTENT_ENABLED, false)
+            set(v) = prefHelper.setPref(CLIPBOARD_CONTENT_ENABLED, v)
+        var clipboardContentTimeout: Int
+            get() =  prefHelper.getPref(CLIPBOARD_CONTENT_TIMEOUT, 30)
+            set(v) = prefHelper.setPref(CLIPBOARD_CONTENT_TIMEOUT, v)
+        var displayMode: CandidateView.DisplayMode
+            get() =  CandidateView.DisplayMode.fromString(prefHelper.getPref(DISPLAY_MODE, CandidateView.DisplayMode.DYNAMIC_SCROLLABLE.toString()))
+            set(v) = prefHelper.setPref(DISPLAY_MODE, v)
         var enabled: Boolean
             get() =  prefHelper.getPref(ENABLED, true)
             set(v) = prefHelper.setPref(ENABLED, v)
-        var suggestClipboardContent: Boolean
-            get() =  prefHelper.getPref(SUGGEST_CLIPBOARD_CONTENT, false)
-            set(v) = prefHelper.setPref(SUGGEST_CLIPBOARD_CONTENT, v)
         var usePrevWords: Boolean
             get() =  prefHelper.getPref(USE_PREV_WORDS, true)
             set(v) = prefHelper.setPref(USE_PREV_WORDS, v)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -273,6 +273,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
         }
         updateCapsState()
         setActiveKeyboardMode(keyboardMode)
+        smartbarView?.setCandidateSuggestionWords(System.nanoTime(), null)
         smartbarView?.updateSmartbarState()
     }
 
@@ -366,7 +367,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
                     }
                 }
             } else {
-                smartbarView?.setCandidateSuggestionWords(System.nanoTime(), listOf())
+                smartbarView?.setCandidateSuggestionWords(System.nanoTime(), null)
             }
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -24,6 +24,7 @@ import android.widget.Toast
 import android.widget.ViewFlipper
 import dev.patrickgold.florisboard.BuildConfig
 import dev.patrickgold.florisboard.R
+import dev.patrickgold.florisboard.ime.clip.provider.ClipboardItem
 import dev.patrickgold.florisboard.ime.core.*
 import dev.patrickgold.florisboard.ime.dictionary.Dictionary
 import dev.patrickgold.florisboard.ime.dictionary.DictionaryManager
@@ -351,7 +352,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
                         val suggestions = it.getTokenPredictions(
                             precedingTokens = listOf(),
                             currentToken = Token(activeEditorInstance.cachedInput.currentWord.text),
-                            maxSuggestionCount = 3,
+                            maxSuggestionCount = 16,
                             allowPossiblyOffensive = !florisboard.prefs.suggestion.blockPossiblyOffensive
                         ).toStringList()
                         if (BuildConfig.DEBUG) {
@@ -418,6 +419,10 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
 
     override fun onSmartbarCandidatePressed(word: String) {
         activeEditorInstance.commitCompletion(word)
+    }
+
+    override fun onSmartbarClipboardCandidatePressed(clipboardItem: ClipboardItem) {
+        activeEditorInstance.commitClipboardItem(clipboardItem)
     }
 
     override fun onSmartbarPrivateModeButtonClicked() {
@@ -692,28 +697,12 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
             }
             KeyCode.CLIPBOARD_CUT -> activeEditorInstance.performClipboardCut()
             KeyCode.CLIPBOARD_COPY -> activeEditorInstance.performClipboardCopy()
-            KeyCode.CLIPBOARD_PASTE -> {
-                activeEditorInstance.performClipboardPaste()
-                smartbarView?.resetClipboardSuggestion()
-            }
+            KeyCode.CLIPBOARD_PASTE -> activeEditorInstance.performClipboardPaste()
             KeyCode.CLIPBOARD_SELECT -> handleClipboardSelect()
             KeyCode.CLIPBOARD_SELECT_ALL -> activeEditorInstance.performClipboardSelectAll()
-            KeyCode.DELETE -> {
-                handleDelete()
-                if (ev.action == InputKeyEvent.Action.DOWN_UP || ev.action == InputKeyEvent.Action.UP) {
-                    smartbarView?.resetClipboardSuggestion()
-                }
-            }
-            KeyCode.DELETE_WORD -> {
-                handleDeleteWord()
-                if (ev.action == InputKeyEvent.Action.DOWN_UP || ev.action == InputKeyEvent.Action.UP) {
-                    smartbarView?.resetClipboardSuggestion()
-                }
-            }
-            KeyCode.ENTER -> {
-                handleEnter()
-                smartbarView?.resetClipboardSuggestion()
-            }
+            KeyCode.DELETE -> handleDelete()
+            KeyCode.DELETE_WORD -> handleDeleteWord()
+            KeyCode.ENTER -> handleEnter()
             KeyCode.INTERNAL_BATCH_EDIT -> {
                 florisboard.endInternalBatchEdit()
                 return
@@ -777,7 +766,6 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
                         }
                     }
                 }
-                smartbarView?.resetClipboardSuggestion()
             }
         }
         if (data.code != KeyCode.SHIFT && !capsLock && !inputEventDispatcher.isPressed(KeyCode.SHIFT)) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/CandidateView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/CandidateView.kt
@@ -89,6 +89,7 @@ class CandidateView : View, ThemeManager.OnThemeUpdatedListener {
         super.onAttachedToWindow()
         themeManager = ThemeManager.defaultOrNull()
         themeManager?.registerOnThemeUpdatedListener(this)
+        updateCandidates(candidates)
     }
 
     override fun onDetachedFromWindow() {
@@ -100,9 +101,11 @@ class CandidateView : View, ThemeManager.OnThemeUpdatedListener {
         velocityTracker = null
     }
 
-    fun updateCandidates(newCandidates: List<String>) {
+    fun updateCandidates(newCandidates: List<String>?) {
         candidates.clear()
-        candidates.addAll(newCandidates)
+        if (newCandidates != null) {
+            candidates.addAll(newCandidates)
+        }
         recomputeCandidates()
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/CandidateView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/CandidateView.kt
@@ -1,0 +1,496 @@
+/*
+ * Copyright (C) 2021 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.text.smartbar
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.Typeface
+import android.text.TextPaint
+import android.text.TextUtils
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.VelocityTracker
+import android.view.View
+import android.view.animation.AccelerateDecelerateInterpolator
+import android.widget.OverScroller
+import androidx.core.content.ContextCompat
+import dev.patrickgold.florisboard.R
+import dev.patrickgold.florisboard.ime.clip.provider.ClipboardItem
+import dev.patrickgold.florisboard.ime.theme.Theme
+import dev.patrickgold.florisboard.ime.theme.ThemeManager
+import dev.patrickgold.florisboard.ime.theme.ThemeValue
+import timber.log.Timber
+import java.lang.ref.WeakReference
+import java.util.*
+import kotlin.collections.ArrayList
+
+class CandidateView : View, ThemeManager.OnThemeUpdatedListener {
+    private var themeManager: ThemeManager? = null
+    private var eventListener: WeakReference<SmartbarView.EventListener?> = WeakReference(null)
+    private var clipboardContentTimeout: Int = 60_000
+    private var displayMode: DisplayMode = DisplayMode.DYNAMIC_SCROLLABLE
+
+    private val candidates: ArrayList<String> = ArrayList()
+    private var clipboardCandidate: ClipboardItem? = null
+    private var clipboardCandidateTime: Long = 0
+    private var computedCandidates: ArrayList<ComputedCandidate> = ArrayList()
+    private var computedCandidatesWidthPx: Int = 0
+    private var selectedIndex: Int = -1
+
+    private var backgroundPaint: Paint = Paint().apply { color = Color.BLACK }
+    private var candidateBackground: ThemeValue = ThemeValue.SolidColor.TRANSPARENT
+    private var candidateForeground: ThemeValue = ThemeValue.SolidColor.TRANSPARENT
+    private val candidateMarginH: Int = resources.getDimensionPixelOffset(R.dimen.smartbar_candidate_marginH)
+    private var dividerBackground: ThemeValue = ThemeValue.SolidColor.TRANSPARENT
+    private var dividerWidth: Int = resources.getDimensionPixelSize(R.dimen.smartbar_divider_width)
+    private val pasteDrawable = ContextCompat.getDrawable(context, R.drawable.ic_content_paste)
+    private var lastX: Float = 0.0f
+    private val scroller: OverScroller = OverScroller(context, AccelerateDecelerateInterpolator())
+    private val textPaint: TextPaint = TextPaint().apply {
+        alpha = 255
+        color = Color.BLACK
+        isAntiAlias = true
+        isFakeBoldText = false
+        textAlign = Paint.Align.CENTER
+        textSize = resources.getDimension(R.dimen.smartbar_candidate_textSize)
+        typeface = Typeface.DEFAULT
+    }
+    private var velocityTracker: VelocityTracker? = null
+
+    constructor(context: Context) : this(context, null)
+    constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
+    init {
+        isHorizontalScrollBarEnabled = false
+        isVerticalScrollBarEnabled = false
+        scrollTo(0, 0)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        themeManager = ThemeManager.defaultOrNull()
+        themeManager?.registerOnThemeUpdatedListener(this)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        themeManager?.unregisterOnThemeUpdatedListener(this)
+        themeManager = null
+        candidates.clear()
+        velocityTracker?.recycle()
+        velocityTracker = null
+    }
+
+    fun updateCandidates(newCandidates: List<String>) {
+        candidates.clear()
+        candidates.addAll(newCandidates)
+        recomputeCandidates()
+    }
+
+    fun updateClipboardCandidate(newClipboardCandidate: ClipboardItem) {
+        clipboardCandidate = newClipboardCandidate
+        clipboardCandidateTime = System.currentTimeMillis()
+        recomputeCandidates()
+    }
+
+    fun setEventListener(listener: SmartbarView.EventListener) {
+        eventListener = WeakReference(listener)
+    }
+
+    fun updateDisplaySettings(newDisplayMode: DisplayMode, newClipboardContentTimeout: Int) {
+        if (newClipboardContentTimeout != clipboardContentTimeout) {
+            clipboardContentTimeout = newClipboardContentTimeout
+        }
+        if (newDisplayMode != displayMode) {
+            displayMode = newDisplayMode
+            scroller.abortAnimation()
+            scrollTo(0, 0)
+        }
+    }
+
+    private fun recomputeCandidates() {
+        computedCandidates.clear()
+        if (clipboardCandidate != null && System.currentTimeMillis() - clipboardCandidateTime > clipboardContentTimeout) {
+            clipboardCandidate = null
+        }
+        val classicCandidateWidth = (measuredWidth - 2 * dividerWidth) / 3
+        val maxDynamicCandidateWidth = (measuredWidth * 0.7).toInt()
+        computedCandidatesWidthPx = 0
+        if (candidates.isEmpty()) {
+            if (clipboardCandidate != null) {
+                computedCandidates.add(ComputedCandidate.Clip(clipboardCandidate!!, Rect(
+                    0,
+                    0,
+                    measuredWidth,
+                    measuredHeight
+                )))
+            } else if (displayMode == DisplayMode.CLASSIC) {
+                for (n in 0 until 3) {
+                    val left = (classicCandidateWidth + dividerWidth) * n
+                    computedCandidates.add(ComputedCandidate.Empty(Rect(
+                        left,
+                        0,
+                        left + classicCandidateWidth,
+                        measuredHeight
+                    )))
+                }
+            }
+        } else if (candidates.size == 1 && clipboardCandidate == null) {
+            computedCandidates.add(ComputedCandidate.Word(candidates[0], Rect(
+                0,
+                0,
+                measuredWidth,
+                measuredHeight
+            )))
+        } else {
+            when (displayMode) {
+                DisplayMode.CLASSIC -> {
+                    if (clipboardCandidate == null) {
+                        for (n in 0 until candidates.size.coerceAtMost(3)) {
+                            val left = (classicCandidateWidth + dividerWidth) * n
+                            computedCandidates.add(ComputedCandidate.Word(candidates[n], Rect(
+                                left,
+                                0,
+                                left + classicCandidateWidth,
+                                measuredHeight
+                            )))
+                        }
+                    } else {
+                        computedCandidates.add(ComputedCandidate.Clip(clipboardCandidate!!, Rect(
+                            0,
+                            0,
+                            classicCandidateWidth,
+                            measuredHeight
+                        )))
+                        for (n in 0 until candidates.size.coerceAtMost(2)) {
+                            val left = (classicCandidateWidth + dividerWidth) * (n + 1)
+                            computedCandidates.add(ComputedCandidate.Word(candidates[n], Rect(
+                                left,
+                                0,
+                                left + classicCandidateWidth,
+                                measuredHeight
+                            )))
+                        }
+                    }
+                    if (computedCandidates.size < 3) {
+                        for (n in computedCandidates.size until 3) {
+                            val left = (classicCandidateWidth + dividerWidth) * n
+                            computedCandidates.add(ComputedCandidate.Empty(Rect(
+                                left,
+                                0,
+                                left + classicCandidateWidth,
+                                measuredHeight
+                            )))
+                        }
+                    }
+                }
+                DisplayMode.DYNAMIC -> {
+                    if (clipboardCandidate != null) {
+                        val candidateWidth = (textPaint.measureText(clipboardCandidate!!.text).toInt() + candidateMarginH + measuredHeight * 4 / 6).coerceAtMost(maxDynamicCandidateWidth)
+                        computedCandidates.add(ComputedCandidate.Clip(clipboardCandidate!!, Rect(
+                            0,
+                            0,
+                            candidateWidth,
+                            measuredHeight
+                        )))
+                        computedCandidatesWidthPx += candidateWidth
+                    }
+                    for (n in candidates.indices) {
+                        var tmpWidthPx = computedCandidatesWidthPx
+                        if (tmpWidthPx > 0) {
+                            tmpWidthPx += dividerWidth
+                        }
+                        val candidateWidth = (textPaint.measureText(candidates[n]).toInt() + 2 * candidateMarginH).coerceAtMost(maxDynamicCandidateWidth)
+                        tmpWidthPx += candidateWidth
+                        if (tmpWidthPx > measuredWidth) {
+                            break
+                        } else {
+                            computedCandidates.add(ComputedCandidate.Word(candidates[n], Rect(
+                                computedCandidatesWidthPx,
+                                0,
+                                computedCandidatesWidthPx + candidateWidth,
+                                measuredHeight
+                            )))
+                            computedCandidatesWidthPx = tmpWidthPx
+                        }
+                    }
+                    val widthToIncreasePerItem = (measuredWidth - computedCandidatesWidthPx) / computedCandidates.size
+                    for (n in computedCandidates.indices) {
+                        computedCandidates[n].geometry.let {
+                            it.left += n * widthToIncreasePerItem
+                            it.right += (n + 1) * widthToIncreasePerItem
+                        }
+                    }
+                }
+                DisplayMode.DYNAMIC_SCROLLABLE -> {
+                    if (clipboardCandidate != null) {
+                        val candidateWidth = (textPaint.measureText(clipboardCandidate!!.text).toInt() + candidateMarginH + measuredHeight * 4 / 6).coerceAtMost(maxDynamicCandidateWidth)
+                        computedCandidates.add(ComputedCandidate.Clip(clipboardCandidate!!, Rect(
+                            0,
+                            0,
+                            candidateWidth,
+                            measuredHeight
+                        )))
+                        computedCandidatesWidthPx += candidateWidth
+                    }
+                    for (n in candidates.indices) {
+                        if (computedCandidatesWidthPx > 0) {
+                            computedCandidatesWidthPx += dividerWidth
+                        }
+                        val candidateWidth = (textPaint.measureText(candidates[n]).toInt() + 2 * candidateMarginH).coerceAtMost(maxDynamicCandidateWidth)
+                        computedCandidates.add(ComputedCandidate.Word(candidates[n], Rect(
+                            computedCandidatesWidthPx,
+                            0,
+                            computedCandidatesWidthPx + candidateWidth,
+                            measuredHeight
+                        )))
+                        computedCandidatesWidthPx += candidateWidth
+                    }
+                }
+            }
+        }
+
+        selectedIndex = -1
+        scroller.abortAnimation()
+        scrollTo(0, 0)
+        invalidate()
+    }
+
+    override fun computeScroll() {
+        if (scroller.computeScrollOffset()) {
+            scrollTo(scroller.currX, scroller.currY)
+            invalidate()
+        }
+    }
+
+    private fun determineSelectedIndex(relX: Int, relY: Int): Int {
+        val absX = relX + scrollX
+        val absY = relY + scrollY
+        var retIndex = -1
+        for ((n, computedCandidate) in computedCandidates.withIndex()) {
+            if (computedCandidate.geometry.contains(absX, absY)) {
+                retIndex = n
+                break
+            }
+        }
+        return retIndex
+    }
+
+    private fun onCandidateClick(index: Int) {
+        computedCandidates.getOrNull(index)?.let { candidate ->
+            when (candidate) {
+                is ComputedCandidate.Word -> {
+                    eventListener.get()?.onSmartbarCandidatePressed(candidate.word)
+                }
+                is ComputedCandidate.Clip -> {
+                    eventListener.get()?.onSmartbarClipboardCandidatePressed(candidate.clipboardItem)
+                }
+                is ComputedCandidate.Empty -> {
+                }
+            }
+        }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent?): Boolean {
+        super.onTouchEvent(event)
+        event ?: return false
+
+        return when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                isPressed = true
+                selectedIndex = determineSelectedIndex(event.x.toInt(), event.y.toInt())
+                if (displayMode == DisplayMode.DYNAMIC_SCROLLABLE) {
+                    velocityTracker?.recycle()
+                    velocityTracker = VelocityTracker.obtain()
+                    velocityTracker?.addMovement(event)
+                    lastX = event.x
+                }
+                invalidate()
+                true
+            }
+            MotionEvent.ACTION_MOVE -> when (displayMode) {
+                DisplayMode.CLASSIC,
+                DisplayMode.DYNAMIC -> {
+                    computedCandidates.getOrNull(selectedIndex)?.let { candidate ->
+                        if (!candidate.geometry.contains(scrollX + event.x.toInt(), scrollY + event.y.toInt())) {
+                            selectedIndex = -1
+                            invalidate()
+                        }
+                    }
+                    true
+                }
+                DisplayMode.DYNAMIC_SCROLLABLE -> {
+                    velocityTracker?.addMovement(event)
+                    selectedIndex = -1
+                    if (computedCandidatesWidthPx > measuredWidth) {
+                        scrollTo((scrollX + lastX - event.x).toInt().coerceIn(0, computedCandidatesWidthPx - measuredWidth), 0)
+                        lastX = event.x
+                    }
+                    invalidate()
+                    true
+                }
+            }
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_CANCEL -> {
+                isPressed = false
+                if (event.actionMasked == MotionEvent.ACTION_UP) {
+                    onCandidateClick(selectedIndex)
+                }
+                selectedIndex = -1
+                if (displayMode == DisplayMode.DYNAMIC_SCROLLABLE) {
+                    velocityTracker?.let {
+                        it.addMovement(event)
+                        it.computeCurrentVelocity(1000)
+
+                        if (computedCandidatesWidthPx > measuredWidth) {
+                            scroller.fling(
+                                scrollX, 0,
+                                -it.xVelocity.toInt(), 0,
+                                0, computedCandidatesWidthPx - measuredWidth,
+                                0, 0,
+                                0, 0
+                            )
+                        }
+                        it.recycle()
+                        velocityTracker = null
+                    }
+                }
+                invalidate()
+                true
+            }
+            else -> false
+        }
+    }
+
+    override fun onThemeUpdated(theme: Theme) {
+        candidateBackground = theme.getAttr(Theme.Attr.WINDOW_SEMI_TRANSPARENT_COLOR)
+        candidateForeground = theme.getAttr(Theme.Attr.SMARTBAR_FOREGROUND)
+        dividerBackground = theme.getAttr(Theme.Attr.SMARTBAR_FOREGROUND_ALT)
+        invalidate()
+    }
+
+    override fun onDraw(canvas: Canvas?) {
+        super.onDraw(canvas)
+        canvas ?: return
+        Timber.i(computedCandidates.toString())
+        Timber.i(selectedIndex.toString())
+        textPaint.apply { color = candidateForeground.toSolidColor().color }
+        for ((n, computedCandidate) in computedCandidates.withIndex()) {
+            with(computedCandidate) {
+                if (n == selectedIndex) {
+                    backgroundPaint.apply { color = candidateBackground.toSolidColor().color }
+                    canvas.drawRect(geometry, backgroundPaint)
+                }
+                when (this) {
+                    is ComputedCandidate.Word -> {
+                        val ellipsizedWord = TextUtils.ellipsize(
+                            word, textPaint, geometry.width().toFloat() - candidateMarginH, TextUtils.TruncateAt.MIDDLE
+                        ).toString()
+                        canvas.drawText(
+                            ellipsizedWord,
+                            geometry.left + geometry.width() / 2.0f,
+                            geometry.top + geometry.height() / 2.0f - (textPaint.descent() + textPaint.ascent()) / 2.0f,
+                            textPaint
+                        )
+                    }
+                    is ComputedCandidate.Clip -> {
+                        pasteDrawable?.setTint(candidateForeground.toSolidColor().color)
+                        pasteDrawable?.setBounds(
+                            geometry.left + geometry.height() / 3,
+                            geometry.height() / 3,
+                            geometry.left + geometry.height() * 2 / 3,
+                            geometry.height() * 2 / 3
+                        )
+                        pasteDrawable?.draw(canvas)
+                        val pdWidth = geometry.height().toFloat()
+                        val ellipsizedWord = TextUtils.ellipsize(
+                            clipboardItem.text, textPaint, geometry.width().toFloat() - pdWidth, TextUtils.TruncateAt.MIDDLE
+                        ).toString()
+                        canvas.drawText(
+                            ellipsizedWord,
+                            geometry.left + geometry.width() / 2.0f + pdWidth / 2.0f - candidateMarginH,
+                            geometry.top + geometry.height() / 2.0f - (textPaint.descent() + textPaint.ascent()) / 2.0f,
+                            textPaint
+                        )
+                    }
+                    is ComputedCandidate.Empty -> {
+                    }
+                }
+                if (n + 1 < computedCandidates.size) {
+                    backgroundPaint.apply { color = dividerBackground.toSolidColor().color }
+                    canvas.drawRect(
+                        geometry.right.toFloat(),
+                        (geometry.height() / 6).toFloat(),
+                        (geometry.right + dividerWidth).toFloat(),
+                        (geometry.height() * 5 / 6).toFloat(),
+                        backgroundPaint
+                    )
+                }
+            }
+        }
+    }
+
+    private sealed class ComputedCandidate(val geometry: Rect) {
+        class Word(
+            val word: String,
+            geometry: Rect
+        ) : ComputedCandidate(geometry) {
+            override fun toString(): String {
+                return "Word { word=\"$word\", geometry=$geometry }"
+            }
+        }
+
+        class Empty(
+            geometry: Rect
+        ) : ComputedCandidate(geometry) {
+            override fun toString(): String {
+                return "Empty { geometry=$geometry }"
+            }
+        }
+
+        class Clip(
+            val clipboardItem: ClipboardItem,
+            geometry: Rect
+        ) : ComputedCandidate(geometry) {
+            override fun toString(): String {
+                return "Word { clipboardItem=$clipboardItem, geometry=$geometry }"
+            }
+        }
+    }
+
+    enum class DisplayMode {
+        CLASSIC,
+        DYNAMIC,
+        DYNAMIC_SCROLLABLE;
+
+        companion object {
+            fun fromString(string: String): DisplayMode {
+                return valueOf(string.toUpperCase(Locale.ENGLISH))
+            }
+        }
+
+        override fun toString(): String {
+            return super.toString().toLowerCase(Locale.ENGLISH)
+        }
+    }
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -282,7 +282,7 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
         }
     }
 
-    fun setCandidateSuggestionWords(suggestionInitDate: Long, suggestions: List<String>) {
+    fun setCandidateSuggestionWords(suggestionInitDate: Long, suggestions: List<String>?) {
         if (suggestionInitDate > lastSuggestionInitDate) {
             lastSuggestionInitDate = suggestionInitDate
             binding.candidates.updateCandidates(suggestions)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -267,17 +267,8 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
     }
 
     fun onPrimaryClipChanged() {
-        if (prefs.suggestion.enabled && prefs.suggestion.clipboardContentEnabled &&
-            florisboard?.activeEditorInstance?.isPrivateMode == false ) {
-
-            // only suggest if mime types make sense.
-            val shouldSuggestClipboardContents = florisboard.florisClipboardManager?.canBePasted(
-                florisboard.florisClipboardManager?.primaryClip
-            ) == true
-
-            if (shouldSuggestClipboardContents) {
-                florisboard.florisClipboardManager?.primaryClip?.let { binding.candidates.updateClipboardCandidate(it) }
-            }
+        if (prefs.suggestion.enabled && prefs.suggestion.clipboardContentEnabled && florisboard?.activeEditorInstance?.isPrivateMode == false ) {
+            florisboard.florisClipboardManager?.primaryClip?.let { binding.candidates.updateClipboardItem(it) }
             updateSmartbarState()
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -19,12 +19,12 @@ package dev.patrickgold.florisboard.ime.text.smartbar
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import android.widget.Button
 import androidx.annotation.IdRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.children
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.databinding.SmartbarBinding
+import dev.patrickgold.florisboard.ime.clip.provider.ClipboardItem
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.core.Subtype
@@ -32,8 +32,6 @@ import dev.patrickgold.florisboard.ime.text.key.KeyVariation
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
-import dev.patrickgold.florisboard.util.setBackgroundTintColor2
-import dev.patrickgold.florisboard.util.setDrawableTintColor2
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -51,7 +49,7 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
     private val florisboard: FlorisBoard? = FlorisBoard.getInstanceOrNull()
     private val prefs: PrefHelper = PrefHelper.getDefaultInstance(context)
     private val themeManager = ThemeManager.default()
-    private var eventListener: WeakReference<EventListener?>? = null
+    private var eventListener: WeakReference<EventListener?> = WeakReference(null)
     private val mainScope = MainScope()
     private var lastSuggestionInitDate: Long = 0
 
@@ -66,14 +64,11 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
             binding.quickActionToggle.rotation = if (v) 180.0f else 0.0f
             field = v
         }
-    private var shouldSuggestClipboardContents: Boolean = false
 
     private lateinit var binding: SmartbarBinding
     private var indexedActionStartArea: MutableList<Int> = mutableListOf()
     private var indexedMainArea: MutableList<Int> = mutableListOf()
     private var indexedActionEndArea: MutableList<Int> = mutableListOf()
-
-    private var candidateViewList: MutableList<Button> = mutableListOf()
 
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
@@ -102,11 +97,9 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
             indexedActionEndArea.add(view.id)
         }
 
-        candidateViewList.add(binding.candidate0)
-        candidateViewList.add(binding.candidate1)
-        candidateViewList.add(binding.candidate2)
+        binding.backButton.setOnClickListener { eventListener.get()?.onSmartbarBackButtonPressed() }
 
-        binding.backButton.setOnClickListener { eventListener?.get()?.onSmartbarBackButtonPressed() }
+        binding.candidates.updateDisplaySettings(prefs.suggestion.displayMode, prefs.suggestion.clipboardContentTimeout * 1_000)
 
         mainScope.launch(Dispatchers.Default) {
             florisboard?.let {
@@ -120,28 +113,6 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
                     binding.clipboardCursorRow.updateVisibility()
                 }
             }
-        }
-
-        binding.candidate0.setOnClickListener {
-            if (it is Button) {
-                eventListener?.get()?.onSmartbarCandidatePressed(it.text.toString())
-            }
-        }
-        binding.candidate1.setOnClickListener {
-            if (it is Button) {
-                eventListener?.get()?.onSmartbarCandidatePressed(it.text.toString())
-            }
-        }
-        binding.candidate2.setOnClickListener {
-            if (it is Button) {
-                eventListener?.get()?.onSmartbarCandidatePressed(it.text.toString())
-            }
-        }
-
-        binding.clipboardSuggestion.setOnClickListener {
-            florisboard?.activeEditorInstance?.performClipboardPaste()
-            shouldSuggestClipboardContents = false
-            updateSmartbarState()
         }
 
         mainScope.launch(Dispatchers.Default) {
@@ -159,13 +130,13 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
         }
 
         binding.privateModeButton.setOnClickListener {
-            eventListener?.get()?.onSmartbarPrivateModeButtonClicked()
+            eventListener.get()?.onSmartbarPrivateModeButtonClicked()
         }
 
         for (quickAction in binding.quickActions.children) {
             if (quickAction is SmartbarQuickActionButton) {
                 quickAction.id.let { quickActionId ->
-                    quickAction.setOnClickListener { eventListener?.get()?.onSmartbarQuickActionPressed(quickActionId) }
+                    quickAction.setOnClickListener { eventListener.get()?.onSmartbarQuickActionPressed(quickActionId) }
                 }
             }
         }
@@ -189,7 +160,6 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
     }
 
     override fun onDetachedFromWindow() {
-        eventListener = null
         florisboard?.textInputManager?.unregisterSmartbarView(this)
         themeManager.unregisterOnThemeUpdatedListener(this)
         super.onDetachedFromWindow()
@@ -248,6 +218,7 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
      */
     fun updateSmartbarState() {
         binding.clipboardCursorRow.updateVisibility()
+        binding.candidates.updateDisplaySettings(prefs.suggestion.displayMode, prefs.suggestion.clipboardContentTimeout * 1_000)
         when (florisboard) {
             null -> configureFeatureVisibility(
                 actionStartAreaVisible = false,
@@ -276,10 +247,6 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
                             KeyboardMode.PHONE2 -> null
                             else -> when {
                                 florisboard.activeEditorInstance.isComposingEnabled &&
-                                    shouldSuggestClipboardContents &&
-                                    florisboard.activeEditorInstance.selection.isCursorMode
-                                -> R.id.clipboard_suggestion_row
-                                florisboard.activeEditorInstance.isComposingEnabled &&
                                         florisboard.activeEditorInstance.selection.isCursorMode
                                     -> R.id.candidates
                                 else -> R.id.clipboard_cursor_row
@@ -300,55 +267,30 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
     }
 
     fun onPrimaryClipChanged() {
-        if (prefs.suggestion.enabled && prefs.suggestion.suggestClipboardContent &&
+        if (prefs.suggestion.enabled && prefs.suggestion.clipboardContentEnabled &&
             florisboard?.activeEditorInstance?.isPrivateMode == false ) {
 
-                // only suggest if mime types make sense.
-                shouldSuggestClipboardContents = florisboard.florisClipboardManager?.canBePasted(
-                    florisboard.florisClipboardManager?.primaryClip
-                ) == true
+            // only suggest if mime types make sense.
+            val shouldSuggestClipboardContents = florisboard.florisClipboardManager?.canBePasted(
+                florisboard.florisClipboardManager?.primaryClip
+            ) == true
 
-            val item = florisboard.florisClipboardManager?.primaryClip
-            when {
-                item?.text != null -> {
-                    binding.clipboardSuggestion.text = item.text
-                }
-                item?.uri != null -> {
-                    binding.clipboardSuggestion.text = "(Image) " + item.uri.toString()
-                }
-                else -> {
-                    binding.clipboardSuggestion.text = item?.text ?: "(Error while retrieving clipboard data)"
-                }
+            if (shouldSuggestClipboardContents) {
+                florisboard.florisClipboardManager?.primaryClip?.let { binding.candidates.updateClipboardCandidate(it) }
             }
             updateSmartbarState()
         }
     }
 
-    fun resetClipboardSuggestion() {
-        shouldSuggestClipboardContents = false
-        updateSmartbarState()
-    }
-
     fun setCandidateSuggestionWords(suggestionInitDate: Long, suggestions: List<String>) {
         if (suggestionInitDate > lastSuggestionInitDate) {
             lastSuggestionInitDate = suggestionInitDate
-            binding.candidate1.text = suggestions.getOrNull(0) ?: ""
-            binding.candidate0.text = suggestions.getOrNull(1) ?: ""
-            binding.candidate2.text = suggestions.getOrNull(2) ?: ""
+            binding.candidates.updateCandidates(suggestions)
         }
     }
 
     fun updateCandidateSuggestionCapsState() {
-        val tim = florisboard?.textInputManager ?: return
-        if (tim.capsLock) {
-            binding.candidate0.text = binding.candidate0.text.toString().toUpperCase(florisboard.activeSubtype.locale)
-            binding.candidate1.text = binding.candidate1.text.toString().toUpperCase(florisboard.activeSubtype.locale)
-            binding.candidate2.text = binding.candidate2.text.toString().toUpperCase(florisboard.activeSubtype.locale)
-        } else {
-            binding.candidate0.text = binding.candidate0.text.toString().toLowerCase(florisboard.activeSubtype.locale)
-            binding.candidate1.text = binding.candidate1.text.toString().toLowerCase(florisboard.activeSubtype.locale)
-            binding.candidate2.text = binding.candidate2.text.toString().toLowerCase(florisboard.activeSubtype.locale)
-        }
+        //
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -374,17 +316,12 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
 
     override fun onThemeUpdated(theme: Theme) {
         setBackgroundColor(theme.getAttr(Theme.Attr.SMARTBAR_BACKGROUND).toSolidColor().color)
-        setBackgroundTintColor2(binding.clipboardSuggestion, theme.getAttr(Theme.Attr.SMARTBAR_BUTTON_BACKGROUND).toSolidColor().color)
-        setDrawableTintColor2(binding.clipboardSuggestion, theme.getAttr(Theme.Attr.SMARTBAR_BUTTON_FOREGROUND).toSolidColor().color)
-        binding.clipboardSuggestion.setTextColor(theme.getAttr(Theme.Attr.SMARTBAR_BUTTON_FOREGROUND).toSolidColor().color)
-        for (view in candidateViewList) {
-            view.setTextColor(theme.getAttr(Theme.Attr.SMARTBAR_FOREGROUND).toSolidColor().color)
-        }
         invalidate()
     }
 
     fun setEventListener(listener: EventListener) {
         eventListener = WeakReference(listener)
+        binding.candidates.setEventListener(listener)
     }
 
     /**
@@ -394,6 +331,7 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
     interface EventListener {
         fun onSmartbarBackButtonPressed() {}
         fun onSmartbarCandidatePressed(word: String) {}
+        fun onSmartbarClipboardCandidatePressed(clipboardItem: ClipboardItem) {}
         //fun onSmartbarCandidateLongPressed() {}
         fun onSmartbarPrivateModeButtonClicked() {}
         fun onSmartbarQuickActionPressed(@IdRes quickActionId: Int) {}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeValue.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeValue.kt
@@ -17,7 +17,9 @@
 package dev.patrickgold.florisboard.ime.theme
 
 import android.content.Context
+import android.graphics.Canvas
 import android.graphics.Color
+import androidx.annotation.ColorInt
 import dev.patrickgold.florisboard.R
 
 /**
@@ -32,16 +34,22 @@ sealed class ThemeValue {
      */
     data class Reference(val group: String, val attr: String) : ThemeValue() {
         override fun toString(): String {
-            return super.toString()
+            return "@$group/$attr"
         }
     }
 
     /**
      * This holds a solid color as a color int.
      */
-    data class SolidColor(val color: Int) : ThemeValue() {
+    data class SolidColor(@ColorInt val color: Int) : ThemeValue() {
+        companion object {
+            val TRANSPARENT = SolidColor(Color.TRANSPARENT)
+            val BLACK = SolidColor(Color.BLACK)
+            val WHITE = SolidColor(Color.WHITE)
+        }
+
         override fun toString(): String {
-            return super.toString()
+            return "#" + String.format("%08X", color)
         }
 
         fun complimentaryTextColor(isAlt: Boolean = false): SolidColor {
@@ -71,7 +79,7 @@ sealed class ThemeValue {
      */
     data class LinearGradient(val dummy: Int) : ThemeValue() {
         override fun toString(): String {
-            return super.toString()
+            return "--undefined--"
         }
     }
 
@@ -80,7 +88,7 @@ sealed class ThemeValue {
      */
     data class RadialGradient(val dummy: Int) : ThemeValue() {
         override fun toString(): String {
-            return super.toString()
+            return "--undefined--"
         }
     }
 
@@ -89,7 +97,7 @@ sealed class ThemeValue {
      */
     data class OnOff(val state: Boolean) : ThemeValue() {
         override fun toString(): String {
-            return super.toString()
+            return state.toString()
         }
     }
 
@@ -99,7 +107,7 @@ sealed class ThemeValue {
      */
     data class Other(val rawValue: String) : ThemeValue() {
         override fun toString(): String {
-            return super.toString()
+            return rawValue
         }
     }
 
@@ -168,32 +176,6 @@ sealed class ThemeValue {
             }
             else -> {
                 OnOff(false)
-            }
-        }
-    }
-
-    /**
-     * Converts this theme value to a string representation.
-     */
-    override fun toString(): String {
-        return when (this) {
-            is Reference -> {
-                "@$group/$attr"
-            }
-            is SolidColor -> {
-                "#" + String.format("%08X", color)
-            }
-            is LinearGradient -> {
-                "--undefined--"
-            }
-            is RadialGradient -> {
-                "--undefined--"
-            }
-            is OnOff -> {
-                state.toString()
-            }
-            is Other -> {
-                rawValue
             }
         }
     }

--- a/app/src/main/res/layout/smartbar.xml
+++ b/app/src/main/res/layout/smartbar.xml
@@ -39,38 +39,9 @@
         app:layout_constraintEnd_toStartOf="@id/action_end_area"
         app:layout_constraintTop_toTopOf="parent">
 
-        <LinearLayout
+        <dev.patrickgold.florisboard.ime.text.smartbar.CandidateView
             android:id="@+id/candidates"
-            style="@style/SmartbarContainer">
-
-            <Button
-                android:id="@+id/candidate0"
-                style="@style/SmartbarCandidate"/>
-
-            <View style="@style/SmartbarDivider"/>
-
-            <Button
-                android:id="@+id/candidate1"
-                style="@style/SmartbarCandidate"/>
-
-            <View style="@style/SmartbarDivider"/>
-
-            <Button
-                android:id="@+id/candidate2"
-                style="@style/SmartbarCandidate"/>
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/clipboard_suggestion_row"
-            style="@style/SmartbarContainer">
-
-            <Button
-                android:id="@+id/clipboard_suggestion"
-                android:drawableStart="@drawable/ic_content_paste_with_padding"
-                style="@style/SmartbarQuickAction.ClipboardSuggestion"/>
-
-        </LinearLayout>
+            style="@style/SmartbarContainer"/>
 
         <LinearLayout
             android:id="@+id/quick_actions"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -176,4 +176,15 @@
         <item>follow_system</item>
         <item>follow_time</item>
     </string-array>
+
+    <string-array name="pref__suggestion__display_mode__entries">
+        <item>@string/pref__suggestion__display_mode__classic</item>
+        <item>@string/pref__suggestion__display_mode__dynamic</item>
+        <item>@string/pref__suggestion__display_mode__dynamic_scrollable</item>
+    </string-array>
+    <string-array name="pref__suggestion__display_mode__values">
+        <item>classic</item>
+        <item>dynamic</item>
+        <item>dynamic_scrollable</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -49,6 +49,9 @@
     <dimen name="smartbar_radius">20dp</dimen>
     <dimen name="smartbar_button_margin">4dp</dimen>
     <dimen name="smartbar_button_padding">6dp</dimen>
+    <dimen name="smartbar_candidate_textSize">14sp</dimen>
+    <dimen name="smartbar_candidate_marginH">16dp</dimen>
+    <dimen name="smartbar_divider_width">1dp</dimen>
 
     <dimen name="fab_margin">16dp</dimen>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,8 +223,13 @@
     <string translatable="false" name="pref__suggestion__use_pref_words__summary" comment="Preference summary">Use previous words for generating suggestions</string>
     <string translatable="false" name="pref__suggestion__block_possibly_offensive__label" comment="Preference title">[EXPERIMENTAL] Block possibly offensive words</string>
     <string translatable="false" name="pref__suggestion__block_possibly_offensive__summary" comment="Preference summary">Prevents possibly offensive words from being suggested while you type</string>
-    <string translatable="false" name="pref__suggestion__suggest_clipboard_content__label" comment="Preference title">[EXPERIMENTAL] Clipboard content suggestions</string>
-    <string translatable="false" name="pref__suggestion__suggest_clipboard_content__summary" comment="Preference summary">Suggest clipboard content to paste if previously copied</string>
+    <string translatable="false" name="pref__suggestion__clipboard_content_enabled__label" comment="Preference title">[EXPERIMENTAL] Clipboard content suggestions</string>
+    <string translatable="false" name="pref__suggestion__clipboard_content_enabled__summary" comment="Preference summary">Suggest clipboard content to paste if previously copied</string>
+    <string translatable="false" name="pref__suggestion__clipboard_content_timeout__label" comment="Preference title">[EXPERIMENTAL] Clipboard suggestion timeout</string>
+    <string translatable="false" name="pref__suggestion__display_mode__label" comment="Preference title">[EXPERIMENTAL] Suggestions display mode</string>
+    <string translatable="false" name="pref__suggestion__display_mode__classic" comment="Preference value">Classic (3 columns)</string>
+    <string translatable="false" name="pref__suggestion__display_mode__dynamic" comment="Preference value">Dynamic width</string>
+    <string translatable="false" name="pref__suggestion__display_mode__dynamic_scrollable" comment="Preference value">Dynamic width &amp; scrollable</string>
     <string name="pref__correction__title" comment="Preference group title">Corrections</string>
     <string name="pref__correction__auto_capitalization__label" comment="Preference title">Auto-capitalization</string>
     <string name="pref__correction__auto_capitalization__summary" comment="Preference summary">Capitalize words based on the current input context</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,31 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <style name="SmartbarCandidate">
-        <item name="android:layout_width">0dp</item>
-        <item name="android:layout_height">match_parent</item>
-        <item name="android:layout_weight">1</item>
-        <item name="android:background">@drawable/button_transparent_bg_on_press</item>
-        <item name="android:fontFamily">sans-serif</item>
-        <item name="android:gravity">center</item>
-        <item name="android:textAllCaps">false</item>
-        <item name="android:textStyle">normal</item>
-    </style>
-
     <style name="SmartbarContainer">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">match_parent</item>
         <item name="android:gravity">center</item>
         <item name="android:orientation">horizontal</item>
-    </style>
-
-    <style name="SmartbarDivider">
-        <item name="android:layout_width">1dp</item>
-        <item name="android:layout_height">match_parent</item>
-        <item name="android:layout_weight">0</item>
-        <item name="android:layout_marginTop">@dimen/smartbar_button_margin</item>
-        <item name="android:layout_marginBottom">@dimen/smartbar_button_margin</item>
-        <item name="android:background">?semiTransparentColor</item>
     </style>
 
     <style name="SmartbarQuickAction" parent="Widget.AppCompat.Button">
@@ -37,17 +17,6 @@
         <item name="android:padding">@dimen/smartbar_button_padding</item>
         <item name="android:scaleType">fitCenter</item>
         <item name="android:tint">#000000</item>
-    </style>
-
-    <style name="SmartbarQuickAction.ClipboardSuggestion">
-        <item name="android:layout_width">200dp</item>
-        <item name="android:layout_height">match_parent</item>
-        <item name="android:background">@drawable/shape_rect_rounded_2</item>
-        <item name="android:singleLine">true</item>
-        <item name="android:ellipsize">marquee</item>
-        <item name="android:fadingEdge">horizontal</item>
-        <item name="android:textAllCaps">false</item>
-        <item name="android:textStyle">normal</item>
     </style>
 
     <style name="SmartbarQuickAction.Toggle">

--- a/app/src/main/res/xml/prefs_typing.xml
+++ b/app/src/main/res/xml/prefs_typing.xml
@@ -21,6 +21,16 @@
             app:title="@string/pref__suggestion__enabled__label"
             app:summary="@string/pref__suggestion__enabled__summary"/>
 
+        <ListPreference
+            android:defaultValue="dynamic_scrollable"
+            app:dependency="suggestion__enabled"
+            app:entries="@array/pref__suggestion__display_mode__entries"
+            app:entryValues="@array/pref__suggestion__display_mode__values"
+            app:key="suggestion__display_mode"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__suggestion__display_mode__label"
+            app:useSimpleSummaryProvider="true"/>
+
         <SwitchPreferenceCompat
             android:defaultValue="true"
             app:dependency="suggestion__enabled"
@@ -40,10 +50,22 @@
         <SwitchPreferenceCompat
             android:defaultValue="true"
             app:dependency="suggestion__enabled"
-            app:key="suggestion__suggest_clipboard_content"
+            app:key="suggestion__clipboard_content_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__suggestion__suggest_clipboard_content__label"
-            app:summary="@string/pref__suggestion__suggest_clipboard_content__summary"/>
+            app:title="@string/pref__suggestion__clipboard_content_enabled__label"
+            app:summary="@string/pref__suggestion__clipboard_content_enabled__summary"/>
+
+        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
+            app:allowDividerAbove="false"
+            android:defaultValue="60"
+            app:dependency="suggestion__clipboard_content_enabled"
+            app:key="suggestion__clipboard_content_timeout"
+            app:min="30"
+            app:max="150"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__suggestion__clipboard_content_timeout__label"
+            app:seekBarIncrement="5"
+            app:unit=" s"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
This PR reworks the UI of both the suggestions bar and also integrates the clipboard suggestions way better, thus allowing for a better suggestions experience. Note, that this PR does not fix any problems/crashes in the backend nor does it update or add new languages, these will come in future patches.

In detail, this has changed:
- The suggestions can now be displayed in three display modes: `Classic`, `Dynamic` and `Dynamic Scrollable`. Defaults to `Dynamic Scrollable`. This allows for a better customization and also more than 3 entries can be shown when using one of the dynamic options. (Settings > Typing > Suggestions display mode)
- The clipboard paste suggestion is now fully integrated into the suggestion view and will not clear as soon as you start typing, thus improving the overall experience and usefulness. It will automatically clear after a specified time intervall (Settings > Typing > Clipboard content timeout). Closes #38, Fixes #424
- Words that are too long are now automatically ellisized, this preventing weird bugs or ugly multiline text. If only 1 suggestion is available, it will take up the whole screen. Fixes #425, Fixes #426
- Switching apps should now reset the suggestions. Fixes #429

This PR is now pretty complete in terms of features, though some fine adjustments and bug fixing will be done tomorrow by me.