### PR TITLE
Adjust popups in landscape mode

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupManager.kt
@@ -152,10 +152,10 @@ class PopupManager<T_KBD: View, T_KV: View>(
             when (keyboardView.resources.configuration.orientation) {
                 Configuration.ORIENTATION_LANDSCAPE -> {
                     if (keyboardView.isSmartbarKeyboardView) {
-                        keyPopupWidth = (keyView.measuredWidth * 0.6f).toInt()
+                        keyPopupWidth = (keyView.measuredWidth * 1.0f).toInt()
                         keyPopupHeight = (keyboardView.desiredKeyHeight * 3.0f * 1.2f).toInt()
                     } else {
-                        keyPopupWidth = (keyboardView.desiredKeyWidth * 0.6f).toInt()
+                        keyPopupWidth = (keyboardView.desiredKeyWidth * 1.0f).toInt()
                         keyPopupHeight = (keyboardView.desiredKeyHeight * 3.0f).toInt()
                     }
                 }


### PR DESCRIPTION
This PR fixes the popup width in landscape mode (the width is now synced with the key view width) and additionally fixes a few bugs.

Portrait (unchanged) | Landscape
---|---
![popups_portrait](https://user-images.githubusercontent.com/19412843/112761874-925d0680-8ffd-11eb-9292-197ce80b74dd.jpg) | ![popups_landscape](https://user-images.githubusercontent.com/19412843/112761877-96892400-8ffd-11eb-8515-7cc3c8f2794e.jpg)

---
Closes #504 
Closes #505 
Closes #417 