### PR TITLE
Neo2 layout

### DIFF
--- a/app/src/main/assets/ime/config.json
+++ b/app/src/main/assets/ime/config.json
@@ -300,6 +300,16 @@
       }
     },
     {
+      "id": 204,
+      "languageTag": "de-DE-neobone",
+      "currencySet": "euro",
+      "preferred": {
+        "characters": "neo2",
+        "symbols": "neo2",
+        "numericRow": "neo2"
+      }
+    },
+    {
       "id": 301,
       "languageTag": "fr-FR",
       "currencySet": "euro",

--- a/app/src/main/assets/ime/text/characters/bone.json
+++ b/app/src/main/assets/ime/text/characters/bone.json
@@ -1,0 +1,50 @@
+{
+  "type": "characters",
+  "name": "bone",
+  "label": "Bone",
+  "authors": [ "ostrya" ],
+  "direction": "ltr",
+  "modifier": "neo2",
+  "arrangement": [
+    [
+      { "code":  106, "label": "j" },
+      { "code":  100, "label": "d" },
+      { "code":  117, "label": "u" },
+      { "code":   97, "label": "a" },
+      { "code":  120, "label": "x" },
+      { "code":  112, "label": "p" },
+      { "code":  104, "label": "h" },
+      { "code":  108, "label": "l" },
+      { "code":  109, "label": "m" },
+      { "code":  119, "label": "w" },
+      { "code":  223, "label": "ß", "shift": { "code": 7838, "label": "ẞ" }, "popup": {
+        "relevant": [
+          { "code":  180, "label": "´" }
+        ]
+      } }
+    ],
+    [
+      { "code":   99, "label": "c" },
+      { "code":  116, "label": "t" },
+      { "code":  105, "label": "i" },
+      { "code":  101, "label": "e" },
+      { "code":  111, "label": "o" },
+      { "code":   98, "label": "b" },
+      { "code":  110, "label": "n" },
+      { "code":  114, "label": "r" },
+      { "code":  115, "label": "s" },
+      { "code":  103, "label": "g" },
+      { "code":  113, "label": "q" }
+    ],
+    [
+      { "code":  102, "label": "f" },
+      { "code":  118, "label": "v" },
+      { "code":  252, "label": "ü" },
+      { "code":  228, "label": "ä" },
+      { "code":  246, "label": "ö" },
+      { "code":  121, "label": "y" },
+      { "code":  122, "label": "z" },
+      { "code":  107, "label": "k" }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/characters/bone.json
+++ b/app/src/main/assets/ime/text/characters/bone.json
@@ -7,44 +7,55 @@
   "modifier": "neo2",
   "arrangement": [
     [
-      { "code":  106, "label": "j" },
-      { "code":  100, "label": "d" },
-      { "code":  117, "label": "u" },
-      { "code":   97, "label": "a" },
-      { "code":  120, "label": "x" },
-      { "code":  112, "label": "p" },
-      { "code":  104, "label": "h" },
-      { "code":  108, "label": "l" },
-      { "code":  109, "label": "m" },
-      { "code":  119, "label": "w" },
-      { "code":  223, "label": "ß", "shift": { "code": 7838, "label": "ẞ" }, "popup": {
-        "relevant": [
-          { "code":  180, "label": "´" }
-        ]
-      } }
+      { "$": "auto_text_key", "code":  106, "label": "j" },
+      { "$": "auto_text_key", "code":  100, "label": "d" },
+      { "$": "auto_text_key", "code":  117, "label": "u" },
+      { "$": "auto_text_key", "code":   97, "label": "a" },
+      { "$": "auto_text_key", "code":  120, "label": "x" },
+      { "$": "auto_text_key", "code":  112, "label": "p" },
+      { "$": "auto_text_key", "code":  104, "label": "h" },
+      { "$": "auto_text_key", "code":  108, "label": "l" },
+      { "$": "auto_text_key", "code":  109, "label": "m" },
+      { "$": "auto_text_key", "code":  119, "label": "w" },
+      { "$": "case_selector",
+        "lower": {
+          "code":  223, "label": "ß", "popup": {
+            "relevant": [
+              { "code":  180, "label": "´" }
+            ]
+          }
+        },
+        "upper": {
+          "code": 7838, "label": "ẞ", "popup": {
+            "relevant": [
+              { "code":  180, "label": "´" }
+            ]
+          }
+        }
+      }
     ],
     [
-      { "code":   99, "label": "c" },
-      { "code":  116, "label": "t" },
-      { "code":  105, "label": "i" },
-      { "code":  101, "label": "e" },
-      { "code":  111, "label": "o" },
-      { "code":   98, "label": "b" },
-      { "code":  110, "label": "n" },
-      { "code":  114, "label": "r" },
-      { "code":  115, "label": "s" },
-      { "code":  103, "label": "g" },
-      { "code":  113, "label": "q" }
+      { "$": "auto_text_key", "code":   99, "label": "c" },
+      { "$": "auto_text_key", "code":  116, "label": "t" },
+      { "$": "auto_text_key", "code":  105, "label": "i" },
+      { "$": "auto_text_key", "code":  101, "label": "e" },
+      { "$": "auto_text_key", "code":  111, "label": "o" },
+      { "$": "auto_text_key", "code":   98, "label": "b" },
+      { "$": "auto_text_key", "code":  110, "label": "n" },
+      { "$": "auto_text_key", "code":  114, "label": "r" },
+      { "$": "auto_text_key", "code":  115, "label": "s" },
+      { "$": "auto_text_key", "code":  103, "label": "g" },
+      { "$": "auto_text_key", "code":  113, "label": "q" }
     ],
     [
-      { "code":  102, "label": "f" },
-      { "code":  118, "label": "v" },
-      { "code":  252, "label": "ü" },
-      { "code":  228, "label": "ä" },
-      { "code":  246, "label": "ö" },
-      { "code":  121, "label": "y" },
-      { "code":  122, "label": "z" },
-      { "code":  107, "label": "k" }
+      { "$": "auto_text_key", "code":  102, "label": "f" },
+      { "$": "auto_text_key", "code":  118, "label": "v" },
+      { "$": "auto_text_key", "code":  252, "label": "ü" },
+      { "$": "auto_text_key", "code":  228, "label": "ä" },
+      { "$": "auto_text_key", "code":  246, "label": "ö" },
+      { "$": "auto_text_key", "code":  121, "label": "y" },
+      { "$": "auto_text_key", "code":  122, "label": "z" },
+      { "$": "auto_text_key", "code":  107, "label": "k" }
     ]
   ]
 }

--- a/app/src/main/assets/ime/text/characters/extended_popups/de-DE-neobone.json
+++ b/app/src/main/assets/ime/text/characters/extended_popups/de-DE-neobone.json
@@ -1,0 +1,19 @@
+{
+  "type": "characters/extended_popups",
+  "name": "de-DE-neobone",
+  "authors": [ "ostrya" ],
+  "mapping": {
+    "uri": {
+      "~right": {
+        "main": { "code": -255, "label": ".com" },
+        "relevant": [
+          { "code": -255, "label": ".ch" },
+          { "code": -255, "label": ".de" },
+          { "code": -255, "label": ".at" },
+          { "code": -255, "label": ".net" }
+        ]
+      }
+    }
+  }
+}
+

--- a/app/src/main/assets/ime/text/characters/mod/neo2.json
+++ b/app/src/main/assets/ime/text/characters/mod/neo2.json
@@ -1,0 +1,53 @@
+{
+  "type": "characters/mod",
+  "name": "neo2",
+  "label": "Neo2",
+  "authors": [ "ostrya" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code":   -1, "label": "shift", "type": "modifier" },
+      { "code":    0, "type": "placeholder" },
+      { "code":   -5, "label": "delete", "type": "enter_editing" }
+    ],
+    [
+      { "code": -202, "label": "view_symbols", "type": "system_gui" },
+      { "code": -210, "label": "language_switch", "type": "system_gui" },
+      { "code": -213, "label": "switch_to_media_context", "type": "system_gui" },
+      { "code":   32, "label": "space" },
+      { "$": "variation_selector",
+        "default":  { "code":   44, "label": ",", "groupId": 1,
+          "popup": {
+            "main": { "code":   34, "label": "\"" },
+            "relevant": [
+              { "code": 8211, "label": "–" }
+            ]
+          } },
+        "email": { "code":   64, "label": "@", "groupId": 1,
+          "popup": {
+            "relevant": [
+              { "code": 44, "label": "," }
+            ]
+          } },
+        "uri": { "code":   47, "label": "/", "groupId": 1,
+          "popup": {
+            "relevant": [
+              { "code": 44, "label": "," }
+            ]
+          } }
+      },
+      { "$": "variation_selector",
+        "default": { "code":   46, "label": ".", "groupId": 2,
+          "popup": {
+            "relevant": [
+              { "code":  183, "label": "·" },
+              { "code":   39, "label": "'" }
+            ]
+          } },
+        "email": { "code":   46, "label": ".", "groupId": 2 },
+        "uri": { "code":   46, "label": ".", "groupId": 2 }
+      },
+      { "code":   10, "label": "enter", "groupId": 3, "type": "enter_editing" }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/characters/neo2.json
+++ b/app/src/main/assets/ime/text/characters/neo2.json
@@ -7,44 +7,55 @@
   "modifier": "neo2",
   "arrangement": [
     [
-      { "code":  120, "label": "x" },
-      { "code":  118, "label": "v" },
-      { "code":  108, "label": "l" },
-      { "code":   99, "label": "c" },
-      { "code":  119, "label": "w" },
-      { "code":  107, "label": "k" },
-      { "code":  104, "label": "h" },
-      { "code":  103, "label": "g" },
-      { "code":  102, "label": "f" },
-      { "code":  113, "label": "q" },
-      { "code":  223, "label": "ß", "shift": { "code": 7838, "label": "ẞ" }, "popup": {
-        "relevant": [
-          { "code":  180, "label": "´" }
-        ]
-      } }
+      { "$": "auto_text_key", "code":  120, "label": "x" },
+      { "$": "auto_text_key", "code":  118, "label": "v" },
+      { "$": "auto_text_key", "code":  108, "label": "l" },
+      { "$": "auto_text_key", "code":   99, "label": "c" },
+      { "$": "auto_text_key", "code":  119, "label": "w" },
+      { "$": "auto_text_key", "code":  107, "label": "k" },
+      { "$": "auto_text_key", "code":  104, "label": "h" },
+      { "$": "auto_text_key", "code":  103, "label": "g" },
+      { "$": "auto_text_key", "code":  102, "label": "f" },
+      { "$": "auto_text_key", "code":  113, "label": "q" },
+      { "$": "case_selector",
+        "lower": {
+          "code":  223, "label": "ß", "popup": {
+            "relevant": [
+              { "code":  180, "label": "´" }
+            ]
+          }
+        },
+        "upper": {
+          "code": 7838, "label": "ẞ", "popup": {
+            "relevant": [
+              { "code":  180, "label": "´" }
+            ]
+          }
+        }
+      }
     ],
     [
-      { "code":  117, "label": "u" },
-      { "code":  105, "label": "i" },
-      { "code":   97, "label": "a" },
-      { "code":  101, "label": "e" },
-      { "code":  111, "label": "o" },
-      { "code":  115, "label": "s" },
-      { "code":  110, "label": "n" },
-      { "code":  114, "label": "r" },
-      { "code":  116, "label": "t" },
-      { "code":  100, "label": "d" },
-      { "code":  121, "label": "y" }
+      { "$": "auto_text_key", "code":  117, "label": "u" },
+      { "$": "auto_text_key", "code":  105, "label": "i" },
+      { "$": "auto_text_key", "code":   97, "label": "a" },
+      { "$": "auto_text_key", "code":  101, "label": "e" },
+      { "$": "auto_text_key", "code":  111, "label": "o" },
+      { "$": "auto_text_key", "code":  115, "label": "s" },
+      { "$": "auto_text_key", "code":  110, "label": "n" },
+      { "$": "auto_text_key", "code":  114, "label": "r" },
+      { "$": "auto_text_key", "code":  116, "label": "t" },
+      { "$": "auto_text_key", "code":  100, "label": "d" },
+      { "$": "auto_text_key", "code":  121, "label": "y" }
     ],
     [
-      { "code":  252, "label": "ü" },
-      { "code":  246, "label": "ö" },
-      { "code":  228, "label": "ä" },
-      { "code":  112, "label": "p" },
-      { "code":  122, "label": "z" },
-      { "code":   98, "label": "b" },
-      { "code":  109, "label": "m" },
-      { "code":  106, "label": "j" }
+      { "$": "auto_text_key", "code":  252, "label": "ü" },
+      { "$": "auto_text_key", "code":  246, "label": "ö" },
+      { "$": "auto_text_key", "code":  228, "label": "ä" },
+      { "$": "auto_text_key", "code":  112, "label": "p" },
+      { "$": "auto_text_key", "code":  122, "label": "z" },
+      { "$": "auto_text_key", "code":   98, "label": "b" },
+      { "$": "auto_text_key", "code":  109, "label": "m" },
+      { "$": "auto_text_key", "code":  106, "label": "j" }
     ]
   ]
 }

--- a/app/src/main/assets/ime/text/characters/neo2.json
+++ b/app/src/main/assets/ime/text/characters/neo2.json
@@ -1,0 +1,50 @@
+{
+  "type": "characters",
+  "name": "neo2",
+  "label": "Neo2",
+  "authors": [ "ostrya" ],
+  "direction": "ltr",
+  "modifier": "neo2",
+  "arrangement": [
+    [
+      { "code":  120, "label": "x" },
+      { "code":  118, "label": "v" },
+      { "code":  108, "label": "l" },
+      { "code":   99, "label": "c" },
+      { "code":  119, "label": "w" },
+      { "code":  107, "label": "k" },
+      { "code":  104, "label": "h" },
+      { "code":  103, "label": "g" },
+      { "code":  102, "label": "f" },
+      { "code":  113, "label": "q" },
+      { "code":  223, "label": "ß", "shift": { "code": 7838, "label": "ẞ" }, "popup": {
+        "relevant": [
+          { "code":  180, "label": "´" }
+        ]
+      } }
+    ],
+    [
+      { "code":  117, "label": "u" },
+      { "code":  105, "label": "i" },
+      { "code":   97, "label": "a" },
+      { "code":  101, "label": "e" },
+      { "code":  111, "label": "o" },
+      { "code":  115, "label": "s" },
+      { "code":  110, "label": "n" },
+      { "code":  114, "label": "r" },
+      { "code":  116, "label": "t" },
+      { "code":  100, "label": "d" },
+      { "code":  121, "label": "y" }
+    ],
+    [
+      { "code":  252, "label": "ü" },
+      { "code":  246, "label": "ö" },
+      { "code":  228, "label": "ä" },
+      { "code":  112, "label": "p" },
+      { "code":  122, "label": "z" },
+      { "code":   98, "label": "b" },
+      { "code":  109, "label": "m" },
+      { "code":  106, "label": "j" }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/numeric/row/neo2.json
+++ b/app/src/main/assets/ime/text/numeric/row/neo2.json
@@ -43,9 +43,13 @@
         ]
       } },
       { "code":   55, "label": "7", "type": "numeric", "popup": {
-        "main": { "code": 8364, "label": "€" },
+        "main": { "code": -801, "label": "currency_slot_1" },
         "relevant": [
-          { "code":  165, "label": "¥" }
+          { "code": -802, "label": "currency_slot_2" },
+          { "code": -803, "label": "currency_slot_3" },
+          { "code": -804, "label": "currency_slot_4" },
+          { "code": -805, "label": "currency_slot_5" },
+          { "code": -806, "label": "currency_slot_6" }
         ]
       } },
       { "code":   56, "label": "8", "type": "numeric", "popup": {

--- a/app/src/main/assets/ime/text/numeric/row/neo2.json
+++ b/app/src/main/assets/ime/text/numeric/row/neo2.json
@@ -1,0 +1,76 @@
+{
+  "type": "numeric_row",
+  "name": "neo2",
+  "label": "Neo2",
+  "authors": [ "ostrya" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code":   49, "label": "1", "type": "numeric", "popup": {
+        "relevant": [
+          { "code": 176, "label": "°" },
+          { "code": 185, "label": "¹" }
+        ]
+      } },
+      { "code":   50, "label": "2", "type": "numeric", "popup": {
+        "relevant": [
+          { "code": 167, "label": "§" },
+          { "code": 178, "label": "²" }
+        ]
+      } },
+      { "code":   51, "label": "3", "type": "numeric", "popup": {
+        "relevant": [
+          { "code": 8467, "label": "ℓ" },
+          { "code":  179, "label": "³" }
+        ]
+      } },
+      { "code":   52, "label": "4", "type": "numeric", "popup": {
+        "relevant": [
+          { "code":  187, "label": "»" },
+          { "code": 8250, "label": "›" }
+        ]
+      } },
+      { "code":   53, "label": "5", "type": "numeric", "popup": {
+        "relevant": [
+          { "code":  171, "label": "«" },
+          { "code": 8249, "label": "‹" }
+        ]
+      } },
+      { "code":   54, "label": "6", "type": "numeric", "popup": {
+        "relevant": [
+          { "code":  36, "label": "$" },
+          { "code": 162, "label": "¢" }
+        ]
+      } },
+      { "code":   55, "label": "7", "type": "numeric", "popup": {
+        "main": { "code": 8364, "label": "€" },
+        "relevant": [
+          { "code":  165, "label": "¥" }
+        ]
+      } },
+      { "code":   56, "label": "8", "type": "numeric", "popup": {
+        "relevant": [
+          { "code": 8222, "label": "„" },
+          { "code": 8218, "label": "‚" }
+        ]
+      } },
+      { "code":   57, "label": "9", "type": "numeric", "popup": {
+        "relevant": [
+          { "code": 8220, "label": "“" },
+          { "code": 8216, "label": "‘" }
+        ]
+      } },
+      { "code":   48, "label": "0", "type": "numeric", "popup": {
+        "relevant": [
+          { "code": 8221, "label": "”" },
+          { "code": 8217, "label": "’" }
+        ]
+      } },
+      { "code":   45, "label": "-", "type": "numeric", "popup": {
+        "relevant": [
+          { "code": 8212, "label": "—" }
+        ]
+      } }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/symbols/mod/neo2.json
+++ b/app/src/main/assets/ime/text/symbols/mod/neo2.json
@@ -1,0 +1,22 @@
+{
+  "type": "symbols/mod",
+  "name": "neo2",
+  "label": "Neo2",
+  "authors": [ "ostrya" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code": -203, "label": "view_symbols2", "type": "system_gui" },
+      { "code":    0, "type": "placeholder" },
+      { "code":   -5, "label": "delete", "type": "enter_editing" }
+    ],
+    [
+      { "code": -201, "label": "view_characters", "type": "system_gui" },
+      { "code": -205, "label": "view_numeric_advanced", "type": "system_gui" },
+      { "code":   32, "label": "space" },
+      { "code":   34, "label": "\"" },
+      { "code":   39, "label": "'" },
+      { "code":   10, "label": "enter", "groupId": 3, "type": "enter_editing" }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/symbols/neo2.json
+++ b/app/src/main/assets/ime/text/symbols/neo2.json
@@ -1,0 +1,45 @@
+{
+  "type": "symbols",
+  "name": "neo2",
+  "label": "Neo2",
+  "authors": [ "ostrya" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code": 8230, "label": "…" },
+      { "code":   95, "label": "_" },
+      { "code":   91, "label": "[" },
+      { "code":   93, "label": "]" },
+      { "code":   94, "label": "^" },
+      { "code":   33, "label": "!" },
+      { "code":   60, "label": "<" },
+      { "code":   62, "label": ">" },
+      { "code":   61, "label": "=" },
+      { "code":   38, "label": "&" },
+      { "code":  383, "label": "ſ" }
+    ],
+    [
+      { "code":   92, "label": "\\" },
+      { "code":   47, "label": "/" },
+      { "code":  123, "label": "{" },
+      { "code":  125, "label": "}" },
+      { "code":   42, "label": "*" },
+      { "code":   63, "label": "?" },
+      { "code":   40, "label": "(" },
+      { "code":   41, "label": ")" },
+      { "code":   45, "label": "-" },
+      { "code":   58, "label": ":" },
+      { "code":   64, "label": "@" }
+    ],
+    [
+      { "code":   35, "label": "#" },
+      { "code":   36, "label": "$" },
+      { "code":  124, "label": "|" },
+      { "code":  126, "label": "~" },
+      { "code":   96, "label": "`" },
+      { "code":   43, "label": "+" },
+      { "code":   37, "label": "%" },
+      { "code":   59, "label": ";" }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/symbols/neo2.json
+++ b/app/src/main/assets/ime/text/symbols/neo2.json
@@ -4,6 +4,7 @@
   "label": "Neo2",
   "authors": [ "ostrya" ],
   "direction": "ltr",
+  "modifier": "neo2",
   "arrangement": [
     [
       { "code": 8230, "label": "…" },

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
@@ -151,7 +151,18 @@ class LayoutManager {
 
         val mainLayout = loadLayoutAsync(main).await().getOrNull()
         val modifierToLoad = if (mainLayout?.modifier != null) {
-            LTN(LayoutType.CHARACTERS_MOD, mainLayout.modifier)
+            val layoutType = when (mainLayout.type) {
+                LayoutType.SYMBOLS -> {
+                    LayoutType.SYMBOLS_MOD
+                }
+                LayoutType.SYMBOLS2 -> {
+                    LayoutType.SYMBOLS2_MOD
+                }
+                else -> {
+                    LayoutType.CHARACTERS_MOD
+                }
+            }
+            LTN(layoutType, mainLayout.modifier)
         } else {
             modifier
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/util/LocaleUtils.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/util/LocaleUtils.kt
@@ -25,7 +25,11 @@ object LocaleUtils {
         return when {
             string.contains(DELIMITER) -> {
                 val lc = string.split(DELIMITER)
-                Locale(lc[0], lc[1])
+                if (lc.size == 3) {
+                    Locale(lc[0], lc[1], lc[2])
+                } else {
+                    Locale(lc[0], lc[1])
+                }
             }
             else -> {
                 Locale(string)


### PR DESCRIPTION
Initial attempt at Neo2 / Bone layout

* For now, only layers 1, 2 and 3 are supported.
* Layer 2 is reachable via caps, apart from number row, comma and full stop (which I think are easier to use if not affected by caps). Instead, the relevant characters are added as popups.
* Layer 3 is set up as main popup, apart from number row, where
  a) due to existing number_row layout the main popup is already set
  b) the characters apart from the Euro sign are not used very often

The overall layout is kept as much as possible, with the following
exceptions:
* The number row contains only numbers to support the built-in number_row layout. The minus sign is moved to the lowest character row, while circumflex and grave accents are not included.
* To not overcrowd the layout and have the same number of keys for first and second row, the acute accent is not included as separate key but can be reached as additional popup to sharp s.
* The minus sign is put between m and j (or z and k respectively) where comma and full stop usually would be, because the backspace takes up too much space for both keys.
* Also, having comma and full stop on the same height with the space  key makes the layout more consistent with the existing layouts and the special usage as ~left and ~right keys.

Please note that I added a special `de_DE-neobone` locale variant:

The default de locale already defines a lot of extended popups which do not match the Neo2 / Bone layout logic. Adding a locale variant allows overriding those defaults. In addition, it allows adding custom popups for the number row. This especially allows including circumflex and grave accents as popups for 1 and 0 respectively.

<img src="https://user-images.githubusercontent.com/23086761/112900185-69af3c80-90e3-11eb-8252-c6657447d308.png" alt="bone" title="bone" width="200">
<img src="https://user-images.githubusercontent.com/23086761/112900189-6ae06980-90e3-11eb-83ad-1a9b8c0d7706.png" alt="neo2" title="neo2" width="200">
