### PR TITLE
Add IPA keyboard layout

### DIFF
--- a/app/src/main/assets/ime/config.json
+++ b/app/src/main/assets/ime/config.json
@@ -560,6 +560,16 @@
       "preferred": {
         "characters": "qwerty"
       }
+    },
+    {
+      "id": 2601,
+      "languageTag": "IPA-IPA",
+      "currencySet": "dollar",
+      "preferred": {
+        "characters": "ipa",
+        "symbols": "ipa",
+        "symbols2": "ipa"
+      }
     }
   ]
 }

--- a/app/src/main/assets/ime/text/characters/ipa.json
+++ b/app/src/main/assets/ime/text/characters/ipa.json
@@ -110,7 +110,7 @@
         "code": 112, "label": "p",
         "popup": {
           "relevant": [
-            { "code": 632, "label": "ɸ" }
+            { "code": 632, "label": "ɸ" },
             { "code": 651, "label": "ʋ" }
           ]
         },

--- a/app/src/main/assets/ime/text/characters/ipa.json
+++ b/app/src/main/assets/ime/text/characters/ipa.json
@@ -1,0 +1,301 @@
+{
+  "type": "characters",
+  "name": "ipa",
+  "authors": [
+    "Huy-Ngo"
+  ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      {
+        "code": 113, "label": "q",
+        "shift": { "code": 594, "label": "ɒ" }
+      },
+      {
+        "code": 119, "label": "w",
+        "popup": {
+          "relevant": [
+            { "code": 695, "label": "◌ʷ" },
+            { "code": 653, "label": "ʍ" }
+          ]
+        },
+        "shift": { "code": 653, "label": "ʍ" }
+      },
+      {
+        "code": 101, "label": "e",
+        "popup": {
+          "relevant": [
+            { "code": 600, "label": "ɘ" },
+            { "code": 604, "label": "ɜ" },
+            { "code": 601, "label": "ə" },
+            { "code": 602, "label": "ɚ" },
+            { "code": 603, "label": "ɛ" }
+          ]
+        },
+        "shift": { "code": 603, "label": "ɛ" }
+      },
+      {
+        "code": 114, "label": "r",
+        "popup": {
+          "relevant": [
+            { "code": 637, "label": "ɽ" },
+            { "code": 633, "label": "ɹ" },
+            { "code": 638, "label": "ɾ" },
+            { "code": 635, "label": "ɻ" },
+            { "code": 641, "label": "ʁ" },
+            { "code": 640, "label": "ʀ" }
+          ]
+        },
+        "shift": { "code": 640, "label": "ʀ" }
+      },
+      {
+        "code": 116, "label": "t",
+        "popup": {
+          "relevant": [
+            { "code": 648, "label": "ʈ" },
+            { "code": 7615, "label": "◌ᶿ" },
+            { "code": 952, "label": "θ" }
+          ]
+        },
+        "shift": { "code": 952, "label": "θ" }
+      },
+      {
+        "code": 121, "label": "y",
+        "popup": {
+          "relevant": [
+            { "code": 612, "label": "ɤ" },
+            { "code": 655, "label": "ʏ" }
+          ]
+        },
+        "shift": { "code": 655, "label": "ʏ" }
+      },
+      {
+        "code": 117, "label": "u",
+        "popup": {
+          "relevant": [
+            { "code": 7551, "label": "ᵿ" },
+            { "code": 649, "label": "ʉ" },
+            { "code": 650, "label": "ʊ" }
+          ]
+        },
+        "shift": { "code": 650, "label": "ʊ" }
+      },
+      {
+        "code": 105, "label": "i",
+        "popup": {
+          "relevant": [
+            { "code": 7574, "label": "ᵻ" },
+            { "code": 616, "label": "ɨ" },
+            { "code": 618, "label": "ɪ" }
+          ]
+        },
+        "shift": { "code": 618, "label": "ɪ" }
+      },
+      {
+        "code": 111, "label": "o",
+        "popup": {
+          "relevant": [
+            { "code": 664, "label": "ʘ" },
+            { "code": 248, "label": "ø" },
+            { "code": 606, "label": "ɞ" },
+            { "code": 339, "label": "œ" },
+            { "code": 629, "label": "ɵ" },
+            { "code": 630, "label": "ɶ" },
+            { "code": 596, "label": "ɔ" }
+          ]
+        },
+        "shift": { "code": 596, "label": "ɔ" }
+      },
+      {
+        "code": 112, "label": "p",
+        "popup": {
+          "relevant": [
+            { "code": 632, "label": "ɸ" }
+            { "code": 651, "label": "ʋ" }
+          ]
+        },
+        "shift": { "code": 651, "label": "ʋ" }
+      }
+    ],
+    [
+      {
+        "code": 97, "label": "a",
+        "popup": {
+          "relevant": [
+            { "code": 230, "label": "æ" },
+            { "code": 592, "label": "ɐ" },
+            { "code": 593, "label": "ɑ" }
+          ]
+        },
+        "shift": { "code": 593, "label": "ɑ" }
+      },
+      {
+        "code": 115, "label": "s",
+        "popup": {
+          "relevant": [
+            { "code": 642, "label": "ʂ" },
+            { "code": 597, "label": "ɕ" },
+            { "code": 643, "label": "ʃ" }
+          ]
+        },
+        "shift": { "code": 643, "label": "ʃ" }
+      },
+      {
+        "code": 100, "label": "d",
+        "popup": {
+          "relevant": [
+            { "code": 598, "label": "ɖ" },
+            { "code": 599, "label": "ɗ" },
+            { "code": 240, "label": "ð" }
+          ]
+        },
+        "shift": { "code": 240, "label": "ð" }
+      },
+      {
+        "code": 102, "label": "f",
+        "popup": {
+          "relevant": [
+            { "code": 632, "label": "ɸ" }
+          ]
+        },
+        "shift": { "code": 625, "label": "ɱ" }
+      },
+      {
+        "code": 103, "label": "g",
+        "popup": {
+          "relevant": [
+            { "code": 608, "label": "ɠ" },
+            { "code": 610, "label": "ɢ" },
+            { "code": 667, "label": "ʛ" },
+            { "code": 611, "label": "ɣ" }
+          ]
+        },
+        "shift": { "code": 611, "label": "ɣ" }
+      },
+      {
+        "code": 104, "label": "h",
+        "popup": {
+          "relevant": [
+            { "code": 614, "label": "ɦ" },
+            { "code": 615, "label": "ɧ" },
+            { "code": 295, "label": "ħ" },
+            { "code": 613, "label": "ɥ" },
+            { "code": 660, "label": "ʔ" },
+            { "code": 661, "label": "ʕ" },
+            { "code": 674, "label": "ʢ" },
+            { "code": 673, "label": "ʡ" },
+            { "code": 688, "label": "◌ʰ" },
+            { "code": 668, "label": "ʜ" }
+          ]
+        },
+        "shift": { "code": 613, "label": "ɥ" }
+      },
+      {
+        "code": 106, "label": "j",
+        "popup": {
+          "relevant": [
+            { "code": 668, "label": "ʝ" },
+            { "code": 607, "label": "ɟ" },
+            { "code": 690, "label": "◌ʲ" },
+            { "code": 664, "label": "ʄ" }
+          ]
+        },
+        "shift": { "code": 626, "label": "ɲ" }
+      },
+      {
+        "code": 107, "label": "k",
+        "shift": { "code": 620, "label": "ɬ" }
+      },
+      {
+        "code": 108, "label": "l",
+        "popup": {
+          "relevant": [
+            { "code": 620, "label": "ɬ" },
+            { "code": 634, "label": "ɺ" },
+            { "code": 671, "label": "ʟ" },
+            { "code": 654, "label": "ʎ" },
+            { "code": 622, "label": "ɮ" }
+          ]
+        },
+        "shift": { "code": 654, "label": "ʎ" }
+      }
+    ],
+    [
+      {
+        "code": 122, "label": "z",
+        "popup": {
+          "relevant": [
+            { "code": 656, "label": "ʐ" },
+            { "code": 657, "label": "ʑ" },
+            { "code": 658, "label": "ʒ" }
+          ]
+        },
+        "shift": { "code": 658, "label": "ʒ" }
+      },
+      {
+        "code": 120, "label": "x",
+        "popup": {
+          "relevant": [
+            { "code": 967, "label": "χ" }
+          ]
+        },
+        "shift": { "code": 967, "label": "χ" }
+      },
+      {
+        "code": 99, "label": "c",
+        "popup": {
+          "relevant": [
+            { "code": 231, "label": "ç" }
+          ]
+        },
+        "shift": { "code": 231, "label": "ç" }
+      },
+      {
+        "code": 118, "label": "v",
+        "popup": {
+          "relevant": [
+            { "code": 651, "label": "ʋ" },
+            { "code": 652, "label": "ʌ" }
+          ]
+        },
+        "shift": { "code": 652, "label": "ʌ" }
+      },
+      {
+        "code": 98, "label": "b",
+        "popup": {
+          "relevant": [
+            { "code": 595, "label": "ɓ" },
+            { "code": 665, "label": "ʙ" },
+            { "code": 946, "label": "β" }
+          ]
+        },
+        "shift": { "code": 946, "label": "β" }
+      },
+      {
+        "code": 110, "label": "n",
+        "popup": {
+          "relevant": [
+            { "code": 626, "label": "ɲ" },
+            { "code": 627, "label": "ɳ" },
+            { "code": 628, "label": "ɴ" },
+            { "code": 8319, "label": "◌ⁿ" },
+            { "code": 771, "label": "◌̃" },
+            { "code": 631, "label": "ŋ" }
+          ]
+        },
+        "shift": { "code": 631, "label": "ŋ" }
+      },
+      {
+        "code": 109, "label": "m",
+        "popup": {
+          "relevant": [
+            { "code": 625, "label": "ɱ" },
+            { "code": 624, "label": "ɰ" },
+            { "code": 623, "label": "ɯ" }
+          ]
+        },
+        "shift": { "code": 623, "label": "ɯ" }
+      }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/characters/ipa.json
+++ b/app/src/main/assets/ime/text/characters/ipa.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "ipa",
+  "label": "International Phonetic Alphabet",
   "authors": [
     "Huy-Ngo"
   ],
@@ -146,6 +147,7 @@
       {
         "code": 609, "label": "ɡ",
         "popup": {
+          "main": { "code": 103, "label": "g" },
           "relevant": [
             { "code": 608, "label": "ɠ" },
             { "code": 610, "label": "ɢ" },

--- a/app/src/main/assets/ime/text/characters/ipa.json
+++ b/app/src/main/assets/ime/text/characters/ipa.json
@@ -8,8 +8,7 @@
   "arrangement": [
     [
       {
-        "code": 113, "label": "q",
-        "shift": { "code": 594, "label": "ɒ" }
+        "code": 113, "label": "q"
       },
       {
         "code": 119, "label": "w",
@@ -18,8 +17,7 @@
             { "code": 695, "label": "◌ʷ" },
             { "code": 653, "label": "ʍ" }
           ]
-        },
-        "shift": { "code": 653, "label": "ʍ" }
+        }
       },
       {
         "code": 101, "label": "e",
@@ -31,8 +29,7 @@
             { "code": 602, "label": "ɚ" },
             { "code": 603, "label": "ɛ" }
           ]
-        },
-        "shift": { "code": 603, "label": "ɛ" }
+        }
       },
       {
         "code": 114, "label": "r",
@@ -45,8 +42,7 @@
             { "code": 641, "label": "ʁ" },
             { "code": 640, "label": "ʀ" }
           ]
-        },
-        "shift": { "code": 640, "label": "ʀ" }
+        }
       },
       {
         "code": 116, "label": "t",
@@ -56,8 +52,7 @@
             { "code": 7615, "label": "◌ᶿ" },
             { "code": 952, "label": "θ" }
           ]
-        },
-        "shift": { "code": 952, "label": "θ" }
+        }
       },
       {
         "code": 121, "label": "y",
@@ -66,8 +61,7 @@
             { "code": 612, "label": "ɤ" },
             { "code": 655, "label": "ʏ" }
           ]
-        },
-        "shift": { "code": 655, "label": "ʏ" }
+        }
       },
       {
         "code": 117, "label": "u",
@@ -77,8 +71,7 @@
             { "code": 649, "label": "ʉ" },
             { "code": 650, "label": "ʊ" }
           ]
-        },
-        "shift": { "code": 650, "label": "ʊ" }
+        }
       },
       {
         "code": 105, "label": "i",
@@ -88,8 +81,7 @@
             { "code": 616, "label": "ɨ" },
             { "code": 618, "label": "ɪ" }
           ]
-        },
-        "shift": { "code": 618, "label": "ɪ" }
+        }
       },
       {
         "code": 111, "label": "o",
@@ -103,18 +95,10 @@
             { "code": 630, "label": "ɶ" },
             { "code": 596, "label": "ɔ" }
           ]
-        },
-        "shift": { "code": 596, "label": "ɔ" }
+        }
       },
       {
-        "code": 112, "label": "p",
-        "popup": {
-          "relevant": [
-            { "code": 632, "label": "ɸ" },
-            { "code": 651, "label": "ʋ" }
-          ]
-        },
-        "shift": { "code": 651, "label": "ʋ" }
+        "code": 112, "label": "p"
       }
     ],
     [
@@ -123,11 +107,11 @@
         "popup": {
           "relevant": [
             { "code": 230, "label": "æ" },
+            { "code": 594, "label": "ɒ" },
             { "code": 592, "label": "ɐ" },
             { "code": 593, "label": "ɑ" }
           ]
-        },
-        "shift": { "code": 593, "label": "ɑ" }
+        }
       },
       {
         "code": 115, "label": "s",
@@ -137,8 +121,7 @@
             { "code": 597, "label": "ɕ" },
             { "code": 643, "label": "ʃ" }
           ]
-        },
-        "shift": { "code": 643, "label": "ʃ" }
+        }
       },
       {
         "code": 100, "label": "d",
@@ -148,8 +131,7 @@
             { "code": 599, "label": "ɗ" },
             { "code": 240, "label": "ð" }
           ]
-        },
-        "shift": { "code": 240, "label": "ð" }
+        }
       },
       {
         "code": 102, "label": "f",
@@ -157,11 +139,10 @@
           "relevant": [
             { "code": 632, "label": "ɸ" }
           ]
-        },
-        "shift": { "code": 625, "label": "ɱ" }
+        }
       },
       {
-        "code": 103, "label": "g",
+        "code": 609, "label": "ɡ",
         "popup": {
           "relevant": [
             { "code": 608, "label": "ɠ" },
@@ -169,8 +150,7 @@
             { "code": 667, "label": "ʛ" },
             { "code": 611, "label": "ɣ" }
           ]
-        },
-        "shift": { "code": 611, "label": "ɣ" }
+        }
       },
       {
         "code": 104, "label": "h",
@@ -180,15 +160,10 @@
             { "code": 615, "label": "ɧ" },
             { "code": 295, "label": "ħ" },
             { "code": 613, "label": "ɥ" },
-            { "code": 660, "label": "ʔ" },
-            { "code": 661, "label": "ʕ" },
-            { "code": 674, "label": "ʢ" },
-            { "code": 673, "label": "ʡ" },
             { "code": 688, "label": "◌ʰ" },
             { "code": 668, "label": "ʜ" }
           ]
-        },
-        "shift": { "code": 613, "label": "ɥ" }
+        }
       },
       {
         "code": 106, "label": "j",
@@ -199,12 +174,10 @@
             { "code": 690, "label": "◌ʲ" },
             { "code": 664, "label": "ʄ" }
           ]
-        },
-        "shift": { "code": 626, "label": "ɲ" }
+        }
       },
       {
-        "code": 107, "label": "k",
-        "shift": { "code": 620, "label": "ɬ" }
+        "code": 107, "label": "k"
       },
       {
         "code": 108, "label": "l",
@@ -216,8 +189,17 @@
             { "code": 654, "label": "ʎ" },
             { "code": 622, "label": "ɮ" }
           ]
-        },
-        "shift": { "code": 654, "label": "ʎ" }
+        }
+      },
+      {
+        "code": 660, "label": "ʔ",
+        "popup": {
+          "relevant": [
+            { "code": 661, "label": "ʕ" },
+            { "code": 674, "label": "ʢ" },
+            { "code": 673, "label": "ʡ" }
+          ]
+        }
       }
     ],
     [
@@ -229,8 +211,7 @@
             { "code": 657, "label": "ʑ" },
             { "code": 658, "label": "ʒ" }
           ]
-        },
-        "shift": { "code": 658, "label": "ʒ" }
+        }
       },
       {
         "code": 120, "label": "x",
@@ -238,8 +219,7 @@
           "relevant": [
             { "code": 967, "label": "χ" }
           ]
-        },
-        "shift": { "code": 967, "label": "χ" }
+        }
       },
       {
         "code": 99, "label": "c",
@@ -247,8 +227,7 @@
           "relevant": [
             { "code": 231, "label": "ç" }
           ]
-        },
-        "shift": { "code": 231, "label": "ç" }
+        }
       },
       {
         "code": 118, "label": "v",
@@ -257,8 +236,7 @@
             { "code": 651, "label": "ʋ" },
             { "code": 652, "label": "ʌ" }
           ]
-        },
-        "shift": { "code": 652, "label": "ʌ" }
+        }
       },
       {
         "code": 98, "label": "b",
@@ -268,8 +246,7 @@
             { "code": 665, "label": "ʙ" },
             { "code": 946, "label": "β" }
           ]
-        },
-        "shift": { "code": 946, "label": "β" }
+        }
       },
       {
         "code": 110, "label": "n",
@@ -282,8 +259,7 @@
             { "code": 771, "label": "◌̃" },
             { "code": 631, "label": "ŋ" }
           ]
-        },
-        "shift": { "code": 631, "label": "ŋ" }
+        }
       },
       {
         "code": 109, "label": "m",
@@ -293,8 +269,7 @@
             { "code": 624, "label": "ɰ" },
             { "code": 623, "label": "ɯ" }
           ]
-        },
-        "shift": { "code": 623, "label": "ɯ" }
+        }
       }
     ]
   ]

--- a/app/src/main/assets/ime/text/characters/ipa.json
+++ b/app/src/main/assets/ime/text/characters/ipa.json
@@ -27,6 +27,7 @@
             { "code": 604, "label": "ɜ" },
             { "code": 601, "label": "ə" },
             { "code": 602, "label": "ɚ" },
+            { "code": 7498, "label": "◌ᵊ" },
             { "code": 603, "label": "ɛ" }
           ]
         }
@@ -40,6 +41,7 @@
             { "code": 638, "label": "ɾ" },
             { "code": 635, "label": "ɻ" },
             { "code": 641, "label": "ʁ" },
+            { "code": 734, "label": "◌˞" },
             { "code": 640, "label": "ʀ" }
           ]
         }
@@ -148,6 +150,8 @@
             { "code": 608, "label": "ɠ" },
             { "code": 610, "label": "ɢ" },
             { "code": 667, "label": "ʛ" },
+            { "code": 667, "label": "ʛ" },
+            { "code": 736, "label": "◌ˠ" },
             { "code": 611, "label": "ɣ" }
           ]
         }
@@ -187,6 +191,7 @@
             { "code": 634, "label": "ɺ" },
             { "code": 671, "label": "ʟ" },
             { "code": 654, "label": "ʎ" },
+            { "code": 737, "label": "◌ˡ" },
             { "code": 622, "label": "ɮ" }
           ]
         }
@@ -197,6 +202,7 @@
           "relevant": [
             { "code": 661, "label": "ʕ" },
             { "code": 674, "label": "ʢ" },
+            { "code": 740, "label": "◌ˤ" },
             { "code": 673, "label": "ʡ" }
           ]
         }
@@ -217,6 +223,7 @@
         "code": 120, "label": "x",
         "popup": {
           "relevant": [
+            { "code": 739, "label": "◌ˣ" },
             { "code": 967, "label": "χ" }
           ]
         }

--- a/app/src/main/assets/ime/text/symbols/ipa.json
+++ b/app/src/main/assets/ime/text/symbols/ipa.json
@@ -6,91 +6,6 @@
   "direction": "ltr",
   "arrangement": [
     [
-      { "code":   809, "label": "◌̩", "popup": {
-        "main": { "code": 781, "label": "◌̍" }
-      } },
-      { "code":   815, "label": "◌̯", "popup": {
-        "main": { "code": 785, "label": "◌̑" }
-      } },
-      { "code":   794, "label": "◌̚" },
-      { "code":   805, "label": "◌̥", "popup": {
-        "main": { "code": 778, "label": "◌̊" }
-      } },
-      { "code":   804, "label": "◌̤" },
-      { "code":   812, "label": "◌̬" },
-      { "code":   816, "label": "◌̰" },
-      { "code":   810, "label": "◌̪", "popup": {
-        "main": { "code":   838, "label": "◌͆" }
-      } },
-      { "code":   826, "label": "◌̺" },
-      { "code":   779, "label": "◌̟", "popup": {
-        "main": { "code":  726, "label": "◌˖" }
-      } },
-      { "code":   776, "label": "◌̈" },
-      { "code":   91, "label": "[", "popup": {
-        "relevant": [
-          { "code":   40, "label": "(" },
-          { "code":   11816, "label": "⸨" },
-          { "code":   10214, "label": "⟦" },
-          { "code":   10216, "label": "⟨" },
-          { "code":   10218, "label": "⟩" },
-          { "code":  123, "label": "{" }
-        ]
-      } },
-      { "code":   826, "label": "◌̺" },
-      { "code":   93, "label": "]", "popup": {
-        "relevant": [
-          { "code":   41, "label": ")" },
-          { "code":   11817, "label": "⸩" },
-          { "code":   10215, "label": "⟦" },
-          { "code":   10217, "label": "⟩" },
-          { "code":   10219, "label": "⟫" },
-          { "code":  125, "label": "}" }
-        ]
-      } },
-      { "code":   47, "label": "/", "popup": {
-        "main": { "code": 92, "label": "\\" },
-        "relevant": [
-          { "code":   11005, "label": "⫽" },
-          { "code":   8214, "label": "‖" },
-          { "code":  124, "label": "|" }
-        ]
-      } }
-    ],
-    [
-      { "code":   797, "label": "◌̝", "popup": {
-        "main": { "code":   724, "label": "◌˔" },
-        "relevant": [
-          { "code":   798, "label": "◌̞" },
-          { "code":  725, "label": "◌˕" },
-          { "code":  792, "label": "◌̘" },
-          { "code":  793, "label": "◌̙" }
-        ]
-      } },
-      { "code":   828, "label": "◌̼" },
-      { "code":   827, "label": "◌̻" },
-      { "code":   829, "label": "◌̽" },
-      { "code":   825, "label": "◌̹", "popup": {
-        "main": { "code": 855, "label": "◌͗" },
-        "relevant": [
-          { "code":  796, "label": "◌̜" },
-          { "code":  849, "label": "◌͑" }
-        ]
-      } },
-      { "code":   800, "label": "◌̠", "popup": {
-        "main": { "code": 727, "label": "◌˗" }
-      } },
-      { "code":   771, "label": "◌̃", "popup": {
-        "main": { "code":  820, "label": "◌̴" },
-        "relevant": [
-          { "code":  734, "label": "◌˞" }
-        ]
-      } },
-      { "code":  865, "label": "◌͡", "popup": {
-        "main": { "code": 8255, "label": "‿" }
-      } }
-    ],
-    [
       { "code":   712, "label": "ˈ", "popup": {
         "main": { "code":   716, "label": "ˌ" }
       } },
@@ -126,6 +41,56 @@
       } },
       { "code":   741, "label": "˥", "popup": {
         "main": { "code": 779, "label": "◌̋" }
+      } },
+      { "code":  865, "label": "◌͡", "popup": {
+        "main": { "code": 8255, "label": "‿" }
+      } }
+    ],
+    [
+      { "code":   776, "label": "◌̈" },
+      { "code":   825, "label": "◌̹", "popup": {
+        "main": { "code": 855, "label": "◌͗" },
+        "relevant": [
+          { "code":  796, "label": "◌̜" },
+          { "code":  849, "label": "◌͑" }
+        ]
+      } },
+      { "code":   800, "label": "◌̠", "popup": {
+        "main": { "code": 727, "label": "◌˗" }
+      } },
+      { "code":   771, "label": "◌̃", "popup": {
+        "main": { "code":  820, "label": "◌̴" },
+        "relevant": [
+          { "code":  734, "label": "◌˞" }
+        ]
+      } },
+      { "code":   91, "label": "[", "popup": {
+        "relevant": [
+          { "code":   40, "label": "(" },
+          { "code":   11816, "label": "⸨" },
+          { "code":   10214, "label": "⟦" },
+          { "code":   10216, "label": "⟨" },
+          { "code":   10218, "label": "⟩" },
+          { "code":  123, "label": "{" }
+        ]
+      } },
+      { "code":   93, "label": "]", "popup": {
+        "relevant": [
+          { "code":   41, "label": ")" },
+          { "code":   11817, "label": "⸩" },
+          { "code":   10215, "label": "⟦" },
+          { "code":   10217, "label": "⟩" },
+          { "code":   10219, "label": "⟫" },
+          { "code":  125, "label": "}" }
+        ]
+      } },
+      { "code":   47, "label": "/", "popup": {
+        "main": { "code": 92, "label": "\\" },
+        "relevant": [
+          { "code":   11005, "label": "⫽" },
+          { "code":   8214, "label": "‖" },
+          { "code":  124, "label": "|" }
+        ]
       } }
     ]
   ]

--- a/app/src/main/assets/ime/text/symbols/ipa.json
+++ b/app/src/main/assets/ime/text/symbols/ipa.json
@@ -1,0 +1,132 @@
+{
+  "type": "symbols",
+  "name": "ipa",
+  "label": "International Phonetic Alphabet",
+  "authors": [ "Huy-Ngo" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code":   809, "label": "◌̩", "popup": {
+        "main": { "code": 781, "label": "◌̍" }
+      } },
+      { "code":   815, "label": "◌̯", "popup": {
+        "main": { "code": 785, "label": "◌̑" }
+      } },
+      { "code":   794, "label": "◌̚" },
+      { "code":   805, "label": "◌̥", "popup": {
+        "main": { "code": 778, "label": "◌̊" }
+      } },
+      { "code":   804, "label": "◌̤" },
+      { "code":   812, "label": "◌̬" },
+      { "code":   816, "label": "◌̰" },
+      { "code":   810, "label": "◌̪", "popup": {
+        "main": { "code":   838, "label": "◌͆" }
+      } },
+      { "code":   826, "label": "◌̺" },
+      { "code":   779, "label": "◌̟", "popup": {
+        "main": { "code":  726, "label": "◌˖" }
+      } },
+      { "code":   776, "label": "◌̈" },
+      { "code":   91, "label": "[", "popup": {
+        "relevant": [
+          { "code":   40, "label": "(" },
+          { "code":   11816, "label": "⸨" },
+          { "code":   10214, "label": "⟦" },
+          { "code":   10216, "label": "⟨" },
+          { "code":   10218, "label": "⟩" },
+          { "code":  123, "label": "{" }
+        ]
+      } },
+      { "code":   826, "label": "◌̺" },
+      { "code":   93, "label": "]", "popup": {
+        "relevant": [
+          { "code":   41, "label": ")" },
+          { "code":   11817, "label": "⸩" },
+          { "code":   10215, "label": "⟦" },
+          { "code":   10217, "label": "⟩" },
+          { "code":   10219, "label": "⟫" },
+          { "code":  125, "label": "}" }
+        ]
+      } },
+      { "code":   47, "label": "/", "popup": {
+        "main": { "code": 92, "label": "\\" },
+        "relevant": [
+          { "code":   11005, "label": "⫽" },
+          { "code":   8214, "label": "‖" },
+          { "code":  124, "label": "|" }
+        ]
+      } }
+    ],
+    [
+      { "code":   797, "label": "◌̝", "popup": {
+        "main": { "code":   724, "label": "◌˔" },
+        "relevant": [
+          { "code":   798, "label": "◌̞" },
+          { "code":  725, "label": "◌˕" },
+          { "code":  792, "label": "◌̘" },
+          { "code":  793, "label": "◌̙" }
+        ]
+      } },
+      { "code":   828, "label": "◌̼" },
+      { "code":   827, "label": "◌̻" },
+      { "code":   829, "label": "◌̽" },
+      { "code":   825, "label": "◌̹", "popup": {
+        "main": { "code": 855, "label": "◌͗" },
+        "relevant": [
+          { "code":  796, "label": "◌̜" },
+          { "code":  849, "label": "◌͑" }
+        ]
+      } },
+      { "code":   800, "label": "◌̠", "popup": {
+        "main": { "code": 727, "label": "◌˗" }
+      } },
+      { "code":   771, "label": "◌̃", "popup": {
+        "main": { "code":  820, "label": "◌̴" },
+        "relevant": [
+          { "code":  734, "label": "◌˞" }
+        ]
+      } },
+      { "code":  865, "label": "◌͡", "popup": {
+        "main": { "code": 8255, "label": "‿" }
+      } }
+    ],
+    [
+      { "code":   712, "label": "ˈ", "popup": {
+        "main": { "code":   716, "label": "ˌ" }
+      } },
+      { "code":   720, "label": "ː", "popup": {
+        "main": { "code": 721, "label": "ˑ" },
+        "relevant": [
+          { "code":  774, "label": "◌̆" }
+        ]
+      } },
+      { "code":   8599, "label": "↗︎", "popup": {
+        "main": { "code":   42779, "label": "ꜛ" }
+      } },
+      { "code":   8600, "label": "↘︎", "popup": {
+        "main": { "code":   42780, "label": "ꜜ" }
+      } },
+      { "code":   745, "label": "˩", "popup": {
+        "main": { "code":   783, "label": "◌̏" }
+      } },
+      { "code":   744, "label": "˨", "popup": {
+        "main": { "code":   768, "label": "◌̀" },
+        "relevant": [
+          { "code":   780, "label": "◌̌" }
+        ]
+      } },
+      { "code":   743, "label": "˧", "popup": {
+        "main": { "code":   772, "label": "◌̄" }
+      } },
+      { "code":   742, "label": "˦", "popup": {
+        "main": { "code":   769, "label": "◌́" },
+        "relevant": [
+          { "code":   770, "label": "◌̂" }
+        ]
+      } },
+      { "code":   741, "label": "˥", "popup": {
+        "main": { "code": 779, "label": "◌̋" }
+      } }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/symbols2/ipa.json
+++ b/app/src/main/assets/ime/text/symbols2/ipa.json
@@ -6,6 +6,41 @@
   "direction": "ltr",
   "arrangement": [
     [
+      { "code":   809, "label": "◌̩", "popup": {
+        "main": { "code": 781, "label": "◌̍" }
+      } },
+      { "code":   815, "label": "◌̯", "popup": {
+        "main": { "code": 785, "label": "◌̑" }
+      } },
+      { "code":   794, "label": "◌̚" },
+      { "code":   805, "label": "◌̥", "popup": {
+        "main": { "code": 778, "label": "◌̊" }
+      } },
+      { "code":   828, "label": "◌̼" },
+      { "code":   827, "label": "◌̻" },
+      { "code":   804, "label": "◌̤" },
+      { "code":   797, "label": "◌̝", "popup": {
+        "main": { "code":   724, "label": "◌˔" },
+        "relevant": [
+          { "code":   798, "label": "◌̞" },
+          { "code":  725, "label": "◌˕" },
+          { "code":  792, "label": "◌̘" },
+          { "code":  793, "label": "◌̙" }
+        ]
+      } },
+      { "code":   812, "label": "◌̬" },
+      { "code":   829, "label": "◌̽" },
+      { "code":   826, "label": "◌̺" }
+    ],
+    [
+      { "code":   816, "label": "◌̰" },
+      { "code":   810, "label": "◌̪", "popup": {
+        "main": { "code":   838, "label": "◌͆" }
+      } },
+      { "code":   826, "label": "◌̺" },
+      { "code":   799, "label": "◌̟", "popup": {
+        "main": { "code":  726, "label": "◌˖" }
+      } },
       { "code":   64, "label": "@" },
       { "code":   35, "label": "#", "popup": {
         "main": { "code": 8470, "label": "№" }
@@ -36,22 +71,7 @@
       } },
       { "code":   43, "label": "+", "popup": {
         "main": { "code":  177, "label": "±" }
-      } },
-      { "code":   40, "label": "(", "popup": {
-        "main": { "code":   60, "label": "<" },
-        "relevant": [
-          { "code":   91, "label": "[" },
-          { "code":  123, "label": "{" }
-        ]
-      } },
-      { "code":   41, "label": ")", "popup": {
-        "main": { "code":   62, "label": ">" },
-        "relevant": [
-          { "code":   93, "label": "]" },
-          { "code":  125, "label": "}" }
-        ]
-      } },
-      { "code":   47, "label": "/" }
+      } }
     ],
     [
       { "code":   42, "label": "*", "popup": {

--- a/app/src/main/assets/ime/text/symbols2/ipa.json
+++ b/app/src/main/assets/ime/text/symbols2/ipa.json
@@ -1,0 +1,97 @@
+{
+  "type": "symbols2",
+  "name": "ipa",
+  "label": "International Phonetic Alphabet",
+  "authors": [ "Huy-Ngo" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code":   64, "label": "@" },
+      { "code":   35, "label": "#", "popup": {
+        "main": { "code": 8470, "label": "№" }
+      } },
+      { "code": -801, "label": "currency_slot_1", "popup": {
+        "main": { "code": -802, "label": "currency_slot_2" },
+        "relevant": [
+          { "code": -806, "label": "currency_slot_6" },
+          { "code": -803, "label": "currency_slot_3" },
+          { "code": -804, "label": "currency_slot_4" },
+          { "code": -805, "label": "currency_slot_5" }
+        ]
+      } },
+      { "code":   37, "label": "%", "popup": {
+        "main": { "code": 8240, "label": "‰" },
+        "relevant": [
+          { "code": 8453, "label": "℅" }
+        ]
+      } },
+      { "code":   38, "label": "&" },
+      { "code":   45, "label": "-", "popup": {
+        "main": { "code":   95, "label": "_" },
+        "relevant": [
+          { "code": 8212, "label": "—" },
+          { "code": 8211, "label": "–" },
+          { "code":  183, "label": "·" }
+        ]
+      } },
+      { "code":   43, "label": "+", "popup": {
+        "main": { "code":  177, "label": "±" }
+      } },
+      { "code":   40, "label": "(", "popup": {
+        "main": { "code":   60, "label": "<" },
+        "relevant": [
+          { "code":   91, "label": "[" },
+          { "code":  123, "label": "{" }
+        ]
+      } },
+      { "code":   41, "label": ")", "popup": {
+        "main": { "code":   62, "label": ">" },
+        "relevant": [
+          { "code":   93, "label": "]" },
+          { "code":  125, "label": "}" }
+        ]
+      } },
+      { "code":   47, "label": "/" }
+    ],
+    [
+      { "code":   42, "label": "*", "popup": {
+        "main": { "code": 664, "label": "ʘ" },
+        "relevant": [
+          { "code": 450, "label": "ǂ" }
+        ]
+      } },
+      { "code":   34, "label": "\"", "popup": {
+        "main": { "code": 8221, "label": "”" },
+        "relevant": [
+          { "code": 8222, "label": "„" },
+          { "code": 8220, "label": "“" },
+          { "code":  171, "label": "«" },
+          { "code":  187, "label": "»" }
+        ]
+      } },
+      { "code":   39, "label": "'", "popup": {
+        "main": { "code": 700, "label": "ʼ" },
+        "relevant": [
+          { "code": 8218, "label": "‚" },
+          { "code": 8216, "label": "‘" },
+          { "code": 8217, "label": "’" },
+          { "code": 8249, "label": "‹" },
+          { "code": 8250, "label": "›" }
+        ]
+      } },
+      { "code":   58, "label": ":", "popup": {
+        "main": { "code":  8942, "label": "⋮" }
+      } },
+      { "code":   59, "label": ";" },
+      { "code":   33, "label": "!", "popup": {
+        "main": { "code":  161, "label": "¡" }
+      } },
+      { "code":   63, "label": "?", "popup": {
+        "main": { "code":  191, "label": "¿" },
+        "relevant": [
+          { "code": 8253, "label": "‽" }
+        ]
+      } }
+    ]
+  ]
+}


### PR DESCRIPTION
In this PR I want to resolve #558. I did not implement the scheme I proposed, because I realized neither are intuitive (for example, it is unintuitive to find ɱ at the extension of f rather than m).

Not all symbols are mapped yet, work in progress. Characters denoting length, tones, stress,... are not mapped.