### PR TITLE
Add subtype specific symobol / numeric layouts & currency sets

### DIFF
--- a/app/src/main/assets/ime/config.json
+++ b/app/src/main/assets/ime/config.json
@@ -166,14 +166,16 @@
       "id": 801,
       "languageTag": "fa-FA",
       "preferred": {
-        "characters": "persian"
+        "characters": "persian",
+        "numericRow": "persian"
       }
     },
     {
       "id": 901,
       "languageTag": "ar",
       "preferred": {
-        "characters": "arabic"
+        "characters": "arabic",
+        "numericRow": "eastern_arabic"
       }
     },
     {

--- a/app/src/main/assets/ime/config.json
+++ b/app/src/main/assets/ime/config.json
@@ -1,9 +1,252 @@
 {
   "package": "dev.patrickgold.florisboard",
+  "currencySets": [
+    {
+      "name": "azerbaijani_manat",
+      "label": "Azerbaijani manat",
+      "slots": [
+        { "code": 8380, "label": "₼" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "bitcoin",
+      "label": "Bitcoin",
+      "slots": [
+        { "code": 8383, "label": "₿" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "dollar",
+      "label": "Dollar",
+      "slots": [
+        { "code":   36, "label": "$" },
+        { "code":  162, "label": "¢" },
+        { "code": 8364, "label": "€" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" },
+        { "code": 8369, "label": "₱" }
+      ]
+    },
+    {
+      "name": "euro",
+      "label": "Euro",
+      "slots": [
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":   36, "label": "$" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" },
+        { "code": 8369, "label": "₱" }
+      ]
+    },
+    {
+      "name": "indian_rupee",
+      "label": "Indian rupee",
+      "slots": [
+        { "code": 8377, "label": "₹" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "iranian_rial",
+      "label": "Iranian rial",
+      "slots": [
+        { "code":65020, "label": "﷼" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "israeli_new_shekel",
+      "label": "Israeli new shekel",
+      "slots": [
+        { "code": 8362, "label": "₪" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "kazakhstani_tenge",
+      "label": "Kazakhstani tenge",
+      "slots": [
+        { "code": 8380, "label": "₸" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "lao_kip",
+      "label": "Lao kip",
+      "slots": [
+        { "code": 8365, "label": "₭" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "mongolian_togrog",
+      "label": "Mongolian tögrög",
+      "slots": [
+        { "code": 8366, "label": "₮" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "nigerian_naira",
+      "label": "Nigerian naira",
+      "slots": [
+        { "code": 8358, "label": "₦" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "pakistani_rupee",
+      "label": "Pakistani rupee",
+      "slots": [
+        { "code": 8360, "label": "₨" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "paraguayan_guarani",
+      "label": "Paraguayan guaraní",
+      "slots": [
+        { "code": 8370, "label": "₲" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "peso",
+      "label": "Peso",
+      "slots": [
+        { "code": 8369, "label": "₱" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "pound",
+      "label": "Pound",
+      "slots": [
+        { "code":  163, "label": "£" },
+        { "code":  162, "label": "¢" },
+        { "code": 8364, "label": "€" },
+        { "code":   36, "label": "$" },
+        { "code":  165, "label": "¥" },
+        { "code": 8369, "label": "₱" }
+      ]
+    },
+    {
+      "name": "russian_ruble",
+      "label": "Russian ruble",
+      "slots": [
+        { "code": 8381, "label": "₽" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "south_korean_won",
+      "label": "South Korean won",
+      "slots": [
+        { "code": 8361, "label": "₩" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "turkish_lira",
+      "label": "Turkish lira",
+      "slots": [
+        { "code": 8378, "label": "₺" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "ukrainian_hryvnia",
+      "label": "Ukrainian hryvnia",
+      "slots": [
+        { "code": 8372, "label": "₴" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code":  165, "label": "¥" }
+      ]
+    },
+    {
+      "name": "yen",
+      "label": "Yen",
+      "slots": [
+        { "code":  165, "label": "¥" },
+        { "code":   36, "label": "$" },
+        { "code": 8364, "label": "€" },
+        { "code":  162, "label": "¢" },
+        { "code":  163, "label": "£" },
+        { "code": 8369, "label": "₱" }
+      ]
+    }
+  ],
   "defaultSubtypes": [
     {
       "id": 101,
       "languageTag": "en-US",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "qwerty"
       }
@@ -11,6 +254,7 @@
     {
       "id": 102,
       "languageTag": "en-UK",
+      "currencySet": "pound",
       "preferred": {
         "characters": "qwerty"
       }
@@ -18,6 +262,7 @@
     {
       "id": 103,
       "languageTag": "en-CA",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "qwerty"
       }
@@ -25,6 +270,7 @@
     {
       "id": 104,
       "languageTag": "en-AU",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "qwerty"
       }
@@ -32,6 +278,7 @@
     {
       "id": 201,
       "languageTag": "de-DE",
+      "currencySet": "euro",
       "preferred": {
         "characters": "qwertz"
       }
@@ -39,6 +286,7 @@
     {
       "id": 202,
       "languageTag": "de-AT",
+      "currencySet": "euro",
       "preferred": {
         "characters": "qwertz"
       }
@@ -46,6 +294,7 @@
     {
       "id": 203,
       "languageTag": "de-CH",
+      "currencySet": "euro",
       "preferred": {
         "characters": "swiss_german"
       }
@@ -53,6 +302,7 @@
     {
       "id": 301,
       "languageTag": "fr-FR",
+      "currencySet": "euro",
       "preferred": {
         "characters": "azerty"
       }
@@ -60,6 +310,7 @@
     {
       "id": 302,
       "languageTag": "fr-CA",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "canadian_french"
       }
@@ -67,6 +318,7 @@
     {
       "id": 303,
       "languageTag": "fr-CH",
+      "currencySet": "euro",
       "preferred": {
         "characters": "swiss_french"
       }
@@ -74,6 +326,7 @@
     {
       "id": 401,
       "languageTag": "it-IT",
+      "currencySet": "euro",
       "preferred": {
         "characters": "qwerty"
       }
@@ -81,6 +334,7 @@
     {
       "id": 402,
       "languageTag": "it-CH",
+      "currencySet": "euro",
       "preferred": {
         "characters": "swiss_italian"
       }
@@ -88,6 +342,7 @@
     {
       "id": 501,
       "languageTag": "es-ES",
+      "currencySet": "euro",
       "preferred": {
         "characters": "spanish"
       }
@@ -95,6 +350,7 @@
     {
       "id": 502,
       "languageTag": "es-US",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "spanish"
       }
@@ -102,6 +358,7 @@
     {
       "id": 503,
       "languageTag": "es-419",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "spanish"
       }
@@ -109,6 +366,7 @@
     {
       "id": 601,
       "languageTag": "pt-PT",
+      "currencySet": "euro",
       "preferred": {
         "characters": "qwerty"
       }
@@ -116,6 +374,7 @@
     {
       "id": 602,
       "languageTag": "pt-BR",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "qwerty"
       }
@@ -123,6 +382,7 @@
     {
       "id": 701,
       "languageTag": "nb-NO",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "norwegian"
       }
@@ -130,6 +390,7 @@
     {
       "id": 702,
       "languageTag": "nn-NO",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "norwegian"
       }
@@ -137,6 +398,7 @@
     {
       "id": 711,
       "languageTag": "sv-SE",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "swedish_finnish"
       }
@@ -144,6 +406,7 @@
     {
       "id": 721,
       "languageTag": "fi-FI",
+      "currencySet": "euro",
       "preferred": {
         "characters": "swedish_finnish"
       }
@@ -151,6 +414,7 @@
     {
       "id": 731,
       "languageTag": "da-DK",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "danish"
       }
@@ -158,6 +422,7 @@
     {
       "id": 741,
       "languageTag": "is-IS",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "icelandic"
       }
@@ -165,6 +430,7 @@
     {
       "id": 801,
       "languageTag": "fa-FA",
+      "currencySet": "iranian_rial",
       "preferred": {
         "characters": "persian",
         "numericRow": "persian"
@@ -173,6 +439,7 @@
     {
       "id": 901,
       "languageTag": "ar",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "arabic",
         "numericRow": "eastern_arabic"
@@ -181,6 +448,7 @@
     {
       "id": 1001,
       "languageTag": "hu",
+      "currencySet": "euro",
       "preferred": {
         "characters": "hungarian"
       }
@@ -188,6 +456,7 @@
     {
       "id": 1101,
       "languageTag": "eo",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "esperanto"
       }
@@ -195,6 +464,7 @@
     {
       "id": 1201,
       "languageTag": "hr",
+      "currencySet": "euro",
       "preferred": {
         "characters": "qwertz"
       }
@@ -202,6 +472,7 @@
     {
       "id": 1301,
       "languageTag": "ru",
+      "currencySet": "russian_ruble",
       "preferred": {
         "characters": "jcuken_russian"
       }
@@ -209,6 +480,7 @@
     {
       "id": 1401,
       "languageTag": "el",
+      "currencySet": "euro",
       "preferred": {
         "characters": "greek"
       }
@@ -216,6 +488,7 @@
     {
       "id": 1501,
       "languageTag": "ro",
+      "currencySet": "euro",
       "preferred": {
         "characters": "qwerty"
       }
@@ -223,6 +496,7 @@
     {
       "id": 1601,
       "languageTag": "pl",
+      "currencySet": "euro",
       "preferred": {
         "characters": "qwerty"
       }
@@ -230,6 +504,7 @@
     {
       "id": 1701,
       "languageTag": "bg-bg",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "bulgarian_phonetic"
       }
@@ -237,6 +512,7 @@
     {
       "id": 1801,
       "languageTag": "tr",
+      "currencySet": "turkish_lira",
       "preferred": {
         "characters": "qwerty"
       }
@@ -244,6 +520,7 @@
     {
       "id": 1901,
       "languageTag": "iw-IL",
+      "currencySet": "israeli_new_shekel",
       "preferred": {
         "characters": "hebrew"
       }
@@ -251,6 +528,7 @@
     {
       "id": 2001,
       "languageTag": "ckb",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "kurdish"
       }
@@ -258,6 +536,7 @@
     {
       "id": 2101,
       "languageTag": "sr-RS",
+      "currencySet": "dollar",
       "preferred": {
         "characters": "serbian_cyrillic"
       }
@@ -265,6 +544,7 @@
     {
       "id": 2201,
       "languageTag": "lv-LV",
+      "currencySet": "euro",
       "preferred": {
         "characters": "qwerty"
       }

--- a/app/src/main/assets/ime/config.json
+++ b/app/src/main/assets/ime/config.json
@@ -3,7 +3,7 @@
   "currencySets": [
     {
       "name": "azerbaijani_manat",
-      "label": "Azerbaijani manat",
+      "label": "Azerbaijani manat (₼)",
       "slots": [
         { "code": 8380, "label": "₼" },
         { "code":   36, "label": "$" },
@@ -15,7 +15,7 @@
     },
     {
       "name": "bitcoin",
-      "label": "Bitcoin",
+      "label": "Bitcoin (₿)",
       "slots": [
         { "code": 8383, "label": "₿" },
         { "code":   36, "label": "$" },
@@ -27,7 +27,7 @@
     },
     {
       "name": "dollar",
-      "label": "Dollar",
+      "label": "Dollar ($)",
       "slots": [
         { "code":   36, "label": "$" },
         { "code":  162, "label": "¢" },
@@ -39,7 +39,7 @@
     },
     {
       "name": "euro",
-      "label": "Euro",
+      "label": "Euro (€)",
       "slots": [
         { "code": 8364, "label": "€" },
         { "code":  162, "label": "¢" },
@@ -51,7 +51,7 @@
     },
     {
       "name": "indian_rupee",
-      "label": "Indian rupee",
+      "label": "Indian rupee (₹)",
       "slots": [
         { "code": 8377, "label": "₹" },
         { "code":   36, "label": "$" },
@@ -63,7 +63,7 @@
     },
     {
       "name": "iranian_rial",
-      "label": "Iranian rial",
+      "label": "Iranian rial (﷼)",
       "slots": [
         { "code":65020, "label": "﷼" },
         { "code":   36, "label": "$" },
@@ -75,7 +75,7 @@
     },
     {
       "name": "israeli_new_shekel",
-      "label": "Israeli new shekel",
+      "label": "Israeli new shekel (₪)",
       "slots": [
         { "code": 8362, "label": "₪" },
         { "code":   36, "label": "$" },
@@ -87,7 +87,7 @@
     },
     {
       "name": "kazakhstani_tenge",
-      "label": "Kazakhstani tenge",
+      "label": "Kazakhstani tenge (₸)",
       "slots": [
         { "code": 8380, "label": "₸" },
         { "code":   36, "label": "$" },
@@ -99,7 +99,7 @@
     },
     {
       "name": "lao_kip",
-      "label": "Lao kip",
+      "label": "Lao kip (₭)",
       "slots": [
         { "code": 8365, "label": "₭" },
         { "code":   36, "label": "$" },
@@ -111,7 +111,7 @@
     },
     {
       "name": "mongolian_togrog",
-      "label": "Mongolian tögrög",
+      "label": "Mongolian tögrög (₮)",
       "slots": [
         { "code": 8366, "label": "₮" },
         { "code":   36, "label": "$" },
@@ -123,7 +123,7 @@
     },
     {
       "name": "nigerian_naira",
-      "label": "Nigerian naira",
+      "label": "Nigerian naira (₦)",
       "slots": [
         { "code": 8358, "label": "₦" },
         { "code":   36, "label": "$" },
@@ -135,7 +135,7 @@
     },
     {
       "name": "pakistani_rupee",
-      "label": "Pakistani rupee",
+      "label": "Pakistani rupee (₨)",
       "slots": [
         { "code": 8360, "label": "₨" },
         { "code":   36, "label": "$" },
@@ -147,7 +147,7 @@
     },
     {
       "name": "paraguayan_guarani",
-      "label": "Paraguayan guaraní",
+      "label": "Paraguayan guaraní (₲)",
       "slots": [
         { "code": 8370, "label": "₲" },
         { "code":   36, "label": "$" },
@@ -159,7 +159,7 @@
     },
     {
       "name": "peso",
-      "label": "Peso",
+      "label": "Peso (₱)",
       "slots": [
         { "code": 8369, "label": "₱" },
         { "code":   36, "label": "$" },
@@ -171,7 +171,7 @@
     },
     {
       "name": "pound",
-      "label": "Pound",
+      "label": "Pound (£)",
       "slots": [
         { "code":  163, "label": "£" },
         { "code":  162, "label": "¢" },
@@ -183,7 +183,7 @@
     },
     {
       "name": "russian_ruble",
-      "label": "Russian ruble",
+      "label": "Russian ruble (₽)",
       "slots": [
         { "code": 8381, "label": "₽" },
         { "code":   36, "label": "$" },
@@ -195,7 +195,7 @@
     },
     {
       "name": "south_korean_won",
-      "label": "South Korean won",
+      "label": "South Korean won (₩)",
       "slots": [
         { "code": 8361, "label": "₩" },
         { "code":   36, "label": "$" },
@@ -207,7 +207,7 @@
     },
     {
       "name": "turkish_lira",
-      "label": "Turkish lira",
+      "label": "Turkish lira (₺)",
       "slots": [
         { "code": 8378, "label": "₺" },
         { "code":   36, "label": "$" },
@@ -219,7 +219,7 @@
     },
     {
       "name": "ukrainian_hryvnia",
-      "label": "Ukrainian hryvnia",
+      "label": "Ukrainian hryvnia (₴)",
       "slots": [
         { "code": 8372, "label": "₴" },
         { "code":   36, "label": "$" },
@@ -231,7 +231,7 @@
     },
     {
       "name": "yen",
-      "label": "Yen",
+      "label": "Yen (¥)",
       "slots": [
         { "code":  165, "label": "¥" },
         { "code":   36, "label": "$" },

--- a/app/src/main/assets/ime/config.json
+++ b/app/src/main/assets/ime/config.json
@@ -1,228 +1,271 @@
 {
   "package": "dev.patrickgold.florisboard",
-  "characterLayouts": {
-    "qwerty": "QWERTY",
-    "qwertz": "QWERTZ",
-    "azerty": "AZERTY",
-    "arabic": "Arabic",
-    "bepo": "BÉPO",
-    "bulgarian_bds": "Bulgarian (BDS)",
-    "bulgarian_phonetic": "Bulgarian (Phonetic)",
-    "canadian_french": "Canadian French (QWERTY)",
-    "colemak": "Colemak",
-    "danish": "Danish (QWERTY)",
-    "dvorak": "Dvorak",
-    "esperanto": "Esperanto",
-    "esperanto_with_hx": "Esperanto with 'ĥ'",
-    "greek": "Ελληνικά",
-    "hebrew": "עברית",
-    "hungarian": "Hungarian (QWERTZ)",
-    "icelandic": "Icelandic (QWERTY)",
-    "kurdish": "کوردی",
-    "norwegian": "Norwegian (QWERTY)",
-    "persian": "Persian",
-    "jcuken_russian": "Russian (JCUKEN)",
-    "serbian_latin": "Serbian (QWERTZ)",
-    "serbian_cyrillic": "Serbian (ЉЊЕРТЗ)",
-    "spanish": "Spanish (QWERTY)",
-    "swedish_finnish": "Swedish/Finnish (QWERTY)",
-    "swiss_german": "Swiss German (QWERTZ)",
-    "swiss_french": "Swiss French (QWERTZ)",
-    "swiss_italian": "Swiss Italian (QWERTZ)",
-    "turkish_q": "Turkish-Q",
-    "turkish_f": "Turkish-F",
-    "workman": "Workman"
-  },
   "defaultSubtypes": [
     {
       "id": 101,
       "languageTag": "en-US",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 102,
       "languageTag": "en-UK",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 103,
       "languageTag": "en-CA",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 104,
       "languageTag": "en-AU",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 201,
       "languageTag": "de-DE",
-      "preferredLayout": "qwertz"
+      "preferred": {
+        "characters": "qwertz"
+      }
     },
     {
       "id": 202,
       "languageTag": "de-AT",
-      "preferredLayout": "qwertz"
+      "preferred": {
+        "characters": "qwertz"
+      }
     },
     {
       "id": 203,
       "languageTag": "de-CH",
-      "preferredLayout": "swiss_german"
+      "preferred": {
+        "characters": "swiss_german"
+      }
     },
     {
       "id": 301,
       "languageTag": "fr-FR",
-      "preferredLayout": "azerty"
+      "preferred": {
+        "characters": "azerty"
+      }
     },
     {
       "id": 302,
       "languageTag": "fr-CA",
-      "preferredLayout": "canadian_french"
+      "preferred": {
+        "characters": "canadian_french"
+      }
     },
     {
       "id": 303,
       "languageTag": "fr-CH",
-      "preferredLayout": "swiss_french"
+      "preferred": {
+        "characters": "swiss_french"
+      }
     },
     {
       "id": 401,
       "languageTag": "it-IT",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 402,
       "languageTag": "it-CH",
-      "preferredLayout": "swiss_italian"
+      "preferred": {
+        "characters": "swiss_italian"
+      }
     },
     {
       "id": 501,
       "languageTag": "es-ES",
-      "preferredLayout": "spanish"
+      "preferred": {
+        "characters": "spanish"
+      }
     },
     {
       "id": 502,
       "languageTag": "es-US",
-      "preferredLayout": "spanish"
+      "preferred": {
+        "characters": "spanish"
+      }
     },
     {
       "id": 503,
       "languageTag": "es-419",
-      "preferredLayout": "spanish"
+      "preferred": {
+        "characters": "spanish"
+      }
     },
     {
       "id": 601,
       "languageTag": "pt-PT",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 602,
       "languageTag": "pt-BR",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 701,
       "languageTag": "nb-NO",
-      "preferredLayout": "norwegian"
+      "preferred": {
+        "characters": "norwegian"
+      }
     },
     {
       "id": 702,
       "languageTag": "nn-NO",
-      "preferredLayout": "norwegian"
+      "preferred": {
+        "characters": "norwegian"
+      }
     },
     {
       "id": 711,
       "languageTag": "sv-SE",
-      "preferredLayout": "swedish_finnish"
+      "preferred": {
+        "characters": "swedish_finnish"
+      }
     },
     {
       "id": 721,
       "languageTag": "fi-FI",
-      "preferredLayout": "swedish_finnish"
+      "preferred": {
+        "characters": "swedish_finnish"
+      }
     },
     {
       "id": 731,
       "languageTag": "da-DK",
-      "preferredLayout": "danish"
+      "preferred": {
+        "characters": "danish"
+      }
     },
     {
       "id": 741,
       "languageTag": "is-IS",
-      "preferredLayout": "icelandic"
+      "preferred": {
+        "characters": "icelandic"
+      }
     },
     {
       "id": 801,
       "languageTag": "fa-FA",
-      "preferredLayout": "persian"
+      "preferred": {
+        "characters": "persian"
+      }
     },
     {
       "id": 901,
       "languageTag": "ar",
-      "preferredLayout": "arabic"
+      "preferred": {
+        "characters": "arabic"
+      }
     },
     {
       "id": 1001,
       "languageTag": "hu",
-      "preferredLayout": "hungarian"
+      "preferred": {
+        "characters": "hungarian"
+      }
     },
     {
       "id": 1101,
       "languageTag": "eo",
-      "preferredLayout": "esperanto"
+      "preferred": {
+        "characters": "esperanto"
+      }
     },
     {
       "id": 1201,
       "languageTag": "hr",
-      "preferredLayout": "qwertz"
+      "preferred": {
+        "characters": "qwertz"
+      }
     },
     {
       "id": 1301,
       "languageTag": "ru",
-      "preferredLayout": "jcuken_russian"
+      "preferred": {
+        "characters": "jcuken_russian"
+      }
     },
     {
       "id": 1401,
       "languageTag": "el",
-      "preferredLayout": "greek"
+      "preferred": {
+        "characters": "greek"
+      }
     },
     {
       "id": 1501,
       "languageTag": "ro",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 1601,
       "languageTag": "pl",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 1701,
       "languageTag": "bg-bg",
-      "preferredLayout": "bulgarian_phonetic"
+      "preferred": {
+        "characters": "bulgarian_phonetic"
+      }
     },
     {
       "id": 1801,
       "languageTag": "tr",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     },
     {
       "id": 1901,
       "languageTag": "iw-IL",
-      "preferredLayout": "hebrew"
+      "preferred": {
+        "characters": "hebrew"
+      }
     },
     {
       "id": 2001,
       "languageTag": "ckb",
-      "preferredLayout": "kurdish"
+      "preferred": {
+        "characters": "kurdish"
+      }
     },
     {
       "id": 2101,
       "languageTag": "sr-RS",
-      "preferredLayout": "serbian_cyrillic"
+      "preferred": {
+        "characters": "serbian_cyrillic"
+      }
     },
     {
       "id": 2201,
       "languageTag": "lv-LV",
-      "preferredLayout": "qwerty"
+      "preferred": {
+        "characters": "qwerty"
+      }
     }
   ]
 }

--- a/app/src/main/assets/ime/config.json
+++ b/app/src/main/assets/ime/config.json
@@ -433,6 +433,8 @@
       "currencySet": "iranian_rial",
       "preferred": {
         "characters": "persian",
+        "symbols": "persian",
+        "symbols2": "persian",
         "numericRow": "persian"
       }
     },
@@ -442,6 +444,8 @@
       "currencySet": "dollar",
       "preferred": {
         "characters": "arabic",
+        "symbols": "eastern",
+        "symbols2": "eastern",
         "numericRow": "eastern_arabic"
       }
     },

--- a/app/src/main/assets/ime/text/characters/arabic.json
+++ b/app/src/main/assets/ime/text/characters/arabic.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "arabic",
+  "label": "Arabic",
   "authors": [ "HeiWiper" ],
   "direction": "rtl",
   "modifier": "arabic",

--- a/app/src/main/assets/ime/text/characters/azerty.json
+++ b/app/src/main/assets/ime/text/characters/azerty.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "azerty",
+  "label": "AZERTY",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/bepo.json
+++ b/app/src/main/assets/ime/text/characters/bepo.json
@@ -1,6 +1,7 @@
 {
     "type": "characters",
     "name": "bepo",
+    "label": "BÉPO",
     "authors": [ "salamandar" ],
     "direction": "ltr",
     "arrangement": [

--- a/app/src/main/assets/ime/text/characters/bulgarian_bds.json
+++ b/app/src/main/assets/ime/text/characters/bulgarian_bds.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "bulgarian_bds",
+  "label": "Bulgarian (BDS)",
   "authors": [ "iorvethe" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/bulgarian_phonetic.json
+++ b/app/src/main/assets/ime/text/characters/bulgarian_phonetic.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "bulgarian_phonetic",
+  "label": "Bulgarian (Phonetic)",
   "authors": [ "iorvethe" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/canadian_french.json
+++ b/app/src/main/assets/ime/text/characters/canadian_french.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "canadian_french",
+  "label": "Canadian French (QWERTY)",
   "authors": [ "The-Quantum-Alpha" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/colemak.json
+++ b/app/src/main/assets/ime/text/characters/colemak.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "colemak",
+  "label": "Colemak",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/danish.json
+++ b/app/src/main/assets/ime/text/characters/danish.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "danish",
+  "label": "Danish (QWERTY)",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/dvorak.json
+++ b/app/src/main/assets/ime/text/characters/dvorak.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "dvorak",
+  "label": "Dvorak",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "modifier": "dvorak",

--- a/app/src/main/assets/ime/text/characters/esperanto.json
+++ b/app/src/main/assets/ime/text/characters/esperanto.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "esperanto",
+  "label": "Esperanto",
   "authors": [ "jeremiah-miller", "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/esperanto_with_hx.json
+++ b/app/src/main/assets/ime/text/characters/esperanto_with_hx.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "esperanto_with_hx",
+  "label": "Esperanto with 'ĥ'",
   "authors": [ "jeremiah-miller", "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/extended_popups/fa.json
+++ b/app/src/main/assets/ime/text/characters/extended_popups/fa.json
@@ -4,56 +4,6 @@
   "authors": [ "PHELAT" ],
   "mapping": {
     "all": {
-      "ض": {
-        "relevant": [
-          { "code": 1777, "label": "۱" }
-        ]
-      },
-      "ص": {
-        "relevant": [
-          { "code": 1778, "label": "۲" }
-        ]
-      },
-      "ث": {
-        "relevant": [
-          { "code": 1779, "label": "۳" }
-        ]
-      },
-      "ق": {
-        "relevant": [
-          { "code": 1780, "label": "۴" }
-        ]
-      },
-      "ف": {
-        "relevant": [
-          { "code": 1781, "label": "۵" }
-        ]
-      },
-      "غ": {
-        "relevant": [
-          { "code": 1782, "label": "۶" }
-        ]
-      },
-      "ع": {
-        "relevant": [
-          { "code": 1783, "label": "۷" }
-        ]
-      },
-      "ه": {
-        "relevant": [
-          { "code": 1784, "label": "۸" }
-        ]
-      },
-      "خ": {
-        "relevant": [
-          { "code": 1785, "label": "۹" }
-        ]
-      },
-      "ح": {
-        "relevant": [
-          { "code": 1776, "label": "۰" }
-        ]
-      },
       "ی": {
         "relevant": [
           { "code": 1574, "label": "ئ" },

--- a/app/src/main/assets/ime/text/characters/greek.json
+++ b/app/src/main/assets/ime/text/characters/greek.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "greek",
+  "label": "Ελληνικά",
   "authors": [ "tsiflimagas" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/hebrew.json
+++ b/app/src/main/assets/ime/text/characters/hebrew.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "hebrew",
+  "label": "עברית",
   "authors": [ "Antony" ],
   "direction": "rtl",
   "modifier": "hebrew",

--- a/app/src/main/assets/ime/text/characters/hungarian.json
+++ b/app/src/main/assets/ime/text/characters/hungarian.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "hungarian",
+  "label": "Hungarian (QWERTZ)",
   "authors": [ "zoli111" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/icelandic.json
+++ b/app/src/main/assets/ime/text/characters/icelandic.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "icelandic",
+  "label": "Icelandic (QWERTY)",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/jcuken_russian.json
+++ b/app/src/main/assets/ime/text/characters/jcuken_russian.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "jcuken_russian",
+  "label": "Russian (JCUKEN)",
   "authors": [ "williamtheaker" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/kurdish.json
+++ b/app/src/main/assets/ime/text/characters/kurdish.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "kurdish",
+  "label": "کوردی",
   "authors": [ "GoRaN" ],
   "direction": "rtl",
   "modifier": "kurdish",

--- a/app/src/main/assets/ime/text/characters/mod/$default.json
+++ b/app/src/main/assets/ime/text/characters/mod/$default.json
@@ -1,6 +1,7 @@
 {
   "type": "characters/mod",
-  "name": "default",
+  "name": "$default",
+  "label": "Default",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/mod/arabic.json
+++ b/app/src/main/assets/ime/text/characters/mod/arabic.json
@@ -1,6 +1,7 @@
 {
   "type": "characters/mod",
   "name": "arabic",
+  "label": "Arabic",
   "authors": [ "HeiWiper" ],
   "direction": "rtl",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/mod/dvorak.json
+++ b/app/src/main/assets/ime/text/characters/mod/dvorak.json
@@ -1,6 +1,7 @@
 {
   "type": "characters/mod",
   "name": "dvorak",
+  "label": "Dvorak",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/mod/hebrew.json
+++ b/app/src/main/assets/ime/text/characters/mod/hebrew.json
@@ -1,6 +1,7 @@
 {
   "type": "characters/mod",
   "name": "hebrew",
+  "label": "עברית",
   "authors": [ "Antony" ],
   "direction": "rtl",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/mod/kurdish.json
+++ b/app/src/main/assets/ime/text/characters/mod/kurdish.json
@@ -1,6 +1,7 @@
 {
   "type": "characters/mod",
   "name": "kurdish",
+  "label": "کوردی",
   "authors": [ "GoRaN" ],
   "direction": "rtl",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/mod/persian.json
+++ b/app/src/main/assets/ime/text/characters/mod/persian.json
@@ -1,6 +1,7 @@
 {
   "type": "characters/mod",
   "name": "persian",
+  "label": "Persian",
   "authors": [ "PHELAT" ],
   "direction": "rtl",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/norwegian.json
+++ b/app/src/main/assets/ime/text/characters/norwegian.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "norwegian",
+  "label": "Norwegian (QWERTY)",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/persian.json
+++ b/app/src/main/assets/ime/text/characters/persian.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "persian",
+  "label": "Persian",
   "authors": [ "PHELAT" ],
   "direction": "rtl",
   "modifier": "persian",

--- a/app/src/main/assets/ime/text/characters/qwerty.json
+++ b/app/src/main/assets/ime/text/characters/qwerty.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "qwerty",
+  "label": "QWERTY",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/qwertz.json
+++ b/app/src/main/assets/ime/text/characters/qwertz.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "qwertz",
+  "label": "QWERTZ",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/serbian_cyrillic.json
+++ b/app/src/main/assets/ime/text/characters/serbian_cyrillic.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "serbian_cyrillic",
+  "label": "Serbian (ЉЊЕРТЗ)",
   "authors": ["GrbavaCigla"],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/serbian_latin.json
+++ b/app/src/main/assets/ime/text/characters/serbian_latin.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "serbian_latin",
+  "label": "Serbian (QWERTZ)",
   "authors": ["GrbavaCigla"],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/spanish.json
+++ b/app/src/main/assets/ime/text/characters/spanish.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "spanish",
+  "label": "Spanish (QWERTY)",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/swedish_finnish.json
+++ b/app/src/main/assets/ime/text/characters/swedish_finnish.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "swedish_finnish",
+  "label": "Swedish/Finnish (QWERTY)",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/swiss_french.json
+++ b/app/src/main/assets/ime/text/characters/swiss_french.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "swiss_french",
+  "label": "Swiss French (QWERTZ)",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/swiss_german.json
+++ b/app/src/main/assets/ime/text/characters/swiss_german.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "swiss_german",
+  "label": "Swiss German (QWERTZ)",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/swiss_italian.json
+++ b/app/src/main/assets/ime/text/characters/swiss_italian.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "swiss_italian",
+  "label": "Swiss Italian (QWERTZ)",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/turkish_f.json
+++ b/app/src/main/assets/ime/text/characters/turkish_f.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "turkish_f",
+  "label": "Turkish-F",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/turkish_q.json
+++ b/app/src/main/assets/ime/text/characters/turkish_q.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "turkish_q",
+  "label": "Turkish-Q",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/characters/workman.json
+++ b/app/src/main/assets/ime/text/characters/workman.json
@@ -1,6 +1,7 @@
 {
   "type": "characters",
   "name": "workman",
+  "label": "Workman",
   "authors": [ "icyphox" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/extension/clipboard_cursor_row.json
+++ b/app/src/main/assets/ime/text/extension/clipboard_cursor_row.json
@@ -1,6 +1,7 @@
 {
   "type": "extension",
   "name": "clipboard_cursor_row",
+  "label": "Clipboard Cursor Row",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/numeric/advanced/western_arabic.json
+++ b/app/src/main/assets/ime/text/numeric/advanced/western_arabic.json
@@ -1,6 +1,7 @@
 {
   "type": "numeric_advanced",
-  "name": "default",
+  "name": "western_arabic",
+  "label": "Western Arabic",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/numeric/row/eastern_arabic.json
+++ b/app/src/main/assets/ime/text/numeric/row/eastern_arabic.json
@@ -1,0 +1,91 @@
+{
+  "type": "numeric_row",
+  "name": "eastern_arabic",
+  "label": "Eastern Arabic",
+  "authors": [ "patrickgold" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code": 1633, "label": "١", "type": "numeric", "popup": {
+        "main": { "code":   49, "label": "1" },
+        "relevant": [
+          { "code": 8537, "label": "⅙" },
+          { "code": 8528, "label": "⅐" },
+          { "code": 8539, "label": "⅛" },
+          { "code": 8529, "label": "⅑" },
+          { "code": 8530, "label": "⅒" },
+          { "code":  185, "label": "¹" },
+          { "code":  189, "label": "½" },
+          { "code": 8531, "label": "⅓" },
+          { "code":  188, "label": "¼" },
+          { "code": 8533, "label": "⅕" }
+        ]
+      } },
+      { "code": 1634, "label": "٢", "type": "numeric", "popup": {
+        "main": { "code":   50, "label": "2" },
+        "relevant": [
+          { "code": 8532, "label": "⅔" },
+          { "code":  178, "label": "²" },
+          { "code": 8534, "label": "⅖" }
+        ]
+      } },
+      { "code": 1635, "label": "٣", "type": "numeric", "popup": {
+        "main": { "code":   51, "label": "3" },
+        "relevant": [
+          { "code": 8535, "label": "⅗" },
+          { "code":  190, "label": "¾" },
+          { "code":  179, "label": "³" },
+          { "code": 8540, "label": "⅜" }
+        ]
+      } },
+      { "code": 1636, "label": "٤", "type": "numeric", "popup": {
+        "main": { "code":   52, "label": "4" },
+        "relevant": [
+          { "code": 8536, "label": "⅘" },
+          { "code": 8308, "label": "⁴" }
+        ]
+      } },
+      { "code": 1637, "label": "٥", "type": "numeric", "popup": {
+        "main": { "code":   53, "label": "5" },
+        "relevant": [
+          { "code": 8538, "label": "⅚" },
+          { "code": 8309, "label": "⁵" },
+          { "code": 8541, "label": "⅝" }
+        ]
+      } },
+      { "code": 1638, "label": "٦", "type": "numeric", "popup": {
+        "main": { "code":   54, "label": "6" },
+        "relevant": [
+          { "code": 8310, "label": "⁶" }
+        ]
+      } },
+      { "code": 1639, "label": "٧", "type": "numeric", "popup": {
+        "main": { "code":   55, "label": "7" },
+        "relevant": [
+          { "code": 8542, "label": "⅞" },
+          { "code": 8311, "label": "⁷" }
+        ]
+      } },
+      { "code": 1640, "label": "٨", "type": "numeric", "popup": {
+        "main": { "code":   56, "label": "8" },
+        "relevant": [
+          { "code": 8312, "label": "⁸" }
+        ]
+      } },
+      { "code": 1641, "label": "٩", "type": "numeric", "popup": {
+        "main": { "code":   57, "label": "9" },
+        "relevant": [
+          { "code": 8313, "label": "⁹" }
+        ]
+      } },
+      { "code": 1632, "label": "٠", "type": "numeric", "popup": {
+        "main": { "code":   48, "label": "0" },
+        "relevant": [
+          { "code": 8319, "label": "ⁿ" },
+          { "code": 8709, "label": "∅" },
+          { "code": 8304, "label": "⁰" }
+        ]
+      } }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/numeric/row/persian.json
+++ b/app/src/main/assets/ime/text/numeric/row/persian.json
@@ -1,0 +1,91 @@
+{
+  "type": "numeric_row",
+  "name": "persian",
+  "label": "Persian",
+  "authors": [ "patrickgold" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code": 1777, "label": "۱", "type": "numeric", "popup": {
+        "main": { "code":   49, "label": "1" },
+        "relevant": [
+          { "code": 8537, "label": "⅙" },
+          { "code": 8528, "label": "⅐" },
+          { "code": 8539, "label": "⅛" },
+          { "code": 8529, "label": "⅑" },
+          { "code": 8530, "label": "⅒" },
+          { "code":  185, "label": "¹" },
+          { "code":  189, "label": "½" },
+          { "code": 8531, "label": "⅓" },
+          { "code":  188, "label": "¼" },
+          { "code": 8533, "label": "⅕" }
+        ]
+      } },
+      { "code": 1778, "label": "۲", "type": "numeric", "popup": {
+        "main": { "code":   50, "label": "2" },
+        "relevant": [
+          { "code": 8532, "label": "⅔" },
+          { "code":  178, "label": "²" },
+          { "code": 8534, "label": "⅖" }
+        ]
+      } },
+      { "code": 1779, "label": "۳", "type": "numeric", "popup": {
+        "main": { "code":   51, "label": "3" },
+        "relevant": [
+          { "code": 8535, "label": "⅗" },
+          { "code":  190, "label": "¾" },
+          { "code":  179, "label": "³" },
+          { "code": 8540, "label": "⅜" }
+        ]
+      } },
+      { "code": 1780, "label": "۴", "type": "numeric", "popup": {
+        "main": { "code":   52, "label": "4" },
+        "relevant": [
+          { "code": 8536, "label": "⅘" },
+          { "code": 8308, "label": "⁴" }
+        ]
+      } },
+      { "code": 1781, "label": "۵", "type": "numeric", "popup": {
+        "main": { "code":   53, "label": "5" },
+        "relevant": [
+          { "code": 8538, "label": "⅚" },
+          { "code": 8309, "label": "⁵" },
+          { "code": 8541, "label": "⅝" }
+        ]
+      } },
+      { "code": 1782, "label": "۶", "type": "numeric", "popup": {
+        "main": { "code":   54, "label": "6" },
+        "relevant": [
+          { "code": 8310, "label": "⁶" }
+        ]
+      } },
+      { "code": 1783, "label": "۷", "type": "numeric", "popup": {
+        "main": { "code":   55, "label": "7" },
+        "relevant": [
+          { "code": 8542, "label": "⅞" },
+          { "code": 8311, "label": "⁷" }
+        ]
+      } },
+      { "code": 1784, "label": "۸", "type": "numeric", "popup": {
+        "main": { "code":   56, "label": "8" },
+        "relevant": [
+          { "code": 8312, "label": "⁸" }
+        ]
+      } },
+      { "code": 1785, "label": "۹", "type": "numeric", "popup": {
+        "main": { "code":   57, "label": "9" },
+        "relevant": [
+          { "code": 8313, "label": "⁹" }
+        ]
+      } },
+      { "code": 1776, "label": "۰", "type": "numeric", "popup": {
+        "main": { "code":   48, "label": "0" },
+        "relevant": [
+          { "code": 8319, "label": "ⁿ" },
+          { "code": 8709, "label": "∅" },
+          { "code": 8304, "label": "⁰" }
+        ]
+      } }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/numeric/row/western_arabic.json
+++ b/app/src/main/assets/ime/text/numeric/row/western_arabic.json
@@ -1,5 +1,5 @@
 {
-  "type": "extension",
+  "type": "numeric_row",
   "name": "western_arabic",
   "label": "Western Arabic",
   "authors": [ "patrickgold" ],

--- a/app/src/main/assets/ime/text/numeric/row/western_arabic.json
+++ b/app/src/main/assets/ime/text/numeric/row/western_arabic.json
@@ -1,6 +1,7 @@
 {
   "type": "extension",
-  "name": "number_row",
+  "name": "western_arabic",
+  "label": "Western Arabic",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/numeric/western_arabic.json
+++ b/app/src/main/assets/ime/text/numeric/western_arabic.json
@@ -1,6 +1,7 @@
 {
   "type": "numeric",
-  "name": "default",
+  "name": "western_arabic",
+  "label": "Western Arabic",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/phone/telpad.json
+++ b/app/src/main/assets/ime/text/phone/telpad.json
@@ -1,6 +1,7 @@
 {
   "type": "phone",
-  "name": "default",
+  "name": "telpad",
+  "label": "Telephone Pad",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/phone2/telpad.json
+++ b/app/src/main/assets/ime/text/phone2/telpad.json
@@ -1,6 +1,7 @@
 {
   "type": "phone2",
-  "name": "default",
+  "name": "telpad",
+  "label": "Telephone Pad",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/symbols/eastern.json
+++ b/app/src/main/assets/ime/text/symbols/eastern.json
@@ -1,0 +1,102 @@
+{
+  "type": "symbols",
+  "name": "eastern",
+  "label": "Eastern",
+  "authors": [ "patrickgold" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code":   64, "label": "@" },
+      { "code":   35, "label": "#", "popup": {
+        "main": { "code": 8470, "label": "№" }
+      } },
+      { "code": -801, "label": "currency_slot_1", "popup": {
+        "main": { "code": -802, "label": "currency_slot_2" },
+        "relevant": [
+          { "code": -806, "label": "currency_slot_6" },
+          { "code": -803, "label": "currency_slot_3" },
+          { "code": -804, "label": "currency_slot_4" },
+          { "code": -805, "label": "currency_slot_5" }
+        ]
+      } },
+      { "code": 1642, "label": "٪", "popup": {
+        "main": { "code":   37, "label": "%" },
+        "relevant": [
+          { "code": 8453, "label": "℅" },
+          { "code": 8240, "label": "‰" }
+        ]
+      } },
+      { "code":   38, "label": "&" },
+      { "code":   45, "label": "-", "popup": {
+        "main": { "code":   95, "label": "_" },
+        "relevant": [
+          { "code": 8212, "label": "—" },
+          { "code": 8211, "label": "–" },
+          { "code":  183, "label": "·" }
+        ]
+      } },
+      { "code":   43, "label": "+", "popup": {
+        "main": { "code":  177, "label": "±" }
+      } },
+      { "code":   40, "label": "(", "popup": {
+        "main": { "code":64830, "label": "﴾" },
+        "relevant": [
+          { "code":   91, "label": "[" },
+          { "code":   60, "label": "<" },
+          { "code":  123, "label": "{" }
+        ]
+      } },
+      { "code":   41, "label": ")", "popup": {
+        "main": { "code":64831, "label": "﴿" },
+        "relevant": [
+          { "code":   93, "label": "]" },
+          { "code":   62, "label": ">" },
+          { "code":  125, "label": "}" }
+        ]
+      } },
+      { "code":   47, "label": "/" }
+    ],
+    [
+      { "code":   42, "label": "*", "popup": {
+        "main": { "code": 9733, "label": "★" },
+        "relevant": [
+          { "code": 1645, "label": "٭" }
+        ]
+      } },
+      { "code":   34, "label": "\"", "popup": {
+        "main": { "code": 8221, "label": "”" },
+        "relevant": [
+          { "code": 8222, "label": "„" },
+          { "code": 8220, "label": "“" },
+          { "code":  171, "label": "«" },
+          { "code":  187, "label": "»" }
+        ]
+      } },
+      { "code":   39, "label": "'", "popup": {
+        "main": { "code": 8217, "label": "’" },
+        "relevant": [
+          { "code": 8218, "label": "‚" },
+          { "code": 8216, "label": "‘" },
+          { "code": 8249, "label": "‹" },
+          { "code": 8250, "label": "›" }
+        ]
+      } },
+      { "code":   58, "label": ":", "popup": {
+        "main": { "code":  8942, "label": "⋮" }
+      } },
+      { "code": 1563, "label": "؛", "popup": {
+        "main": { "code":   59, "label": ";" }
+      } },
+      { "code":   33, "label": "!", "popup": {
+        "main": { "code":  161, "label": "¡" }
+      } },
+      { "code": 1567, "label": "؟", "popup": {
+        "main": { "code":   63, "label": "?" },
+        "relevant": [
+          { "code":  191, "label": "¿" },
+          { "code": 8253, "label": "‽" }
+        ]
+      } }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/symbols/mod/$default.json
+++ b/app/src/main/assets/ime/text/symbols/mod/$default.json
@@ -1,6 +1,7 @@
 {
   "type": "symbols/mod",
-  "name": "default",
+  "name": "$default",
+  "label": "Default",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/symbols/persian.json
+++ b/app/src/main/assets/ime/text/symbols/persian.json
@@ -1,0 +1,102 @@
+{
+  "type": "symbols",
+  "name": "persian",
+  "label": "Persian",
+  "authors": [ "patrickgold" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code":   64, "label": "@" },
+      { "code":   35, "label": "#", "popup": {
+        "main": { "code": 8470, "label": "№" }
+      } },
+      { "code": -801, "label": "currency_slot_1", "popup": {
+        "main": { "code": -802, "label": "currency_slot_2" },
+        "relevant": [
+          { "code": -806, "label": "currency_slot_6" },
+          { "code": -803, "label": "currency_slot_3" },
+          { "code": -804, "label": "currency_slot_4" },
+          { "code": -805, "label": "currency_slot_5" }
+        ]
+      } },
+      { "code": 1642, "label": "٪", "popup": {
+        "main": { "code":   37, "label": "%" },
+        "relevant": [
+          { "code": 8453, "label": "℅" },
+          { "code": 8240, "label": "‰" }
+        ]
+      } },
+      { "code":   38, "label": "&" },
+      { "code":   45, "label": "-", "popup": {
+        "main": { "code":   95, "label": "_" },
+        "relevant": [
+          { "code": 8212, "label": "—" },
+          { "code": 8211, "label": "–" },
+          { "code":  183, "label": "·" }
+        ]
+      } },
+      { "code":   43, "label": "+", "popup": {
+        "main": { "code":  177, "label": "±" }
+      } },
+      { "code":   40, "label": "(", "popup": {
+        "main": { "code":64830, "label": "﴾" },
+        "relevant": [
+          { "code":   91, "label": "[" },
+          { "code":   60, "label": "<" },
+          { "code":  123, "label": "{" }
+        ]
+      } },
+      { "code":   41, "label": ")", "popup": {
+        "main": { "code":64831, "label": "﴿" },
+        "relevant": [
+          { "code":   93, "label": "]" },
+          { "code":   62, "label": ">" },
+          { "code":  125, "label": "}" }
+        ]
+      } },
+      { "code": 1643, "label": "٫", "popup": {
+        "main": { "code": 1644, "label": "٬" },
+        "relevant": [
+          { "code":   42, "label": "*" },
+          { "code":   34, "label": "\"" },
+          { "code":   39, "label": "'" }
+        ]
+      } }
+    ],
+    [
+      { "code":   47, "label": "/" },
+      { "code":  171, "label": "«", "popup": {
+        "main": { "code": 8249, "label": "‹" },
+        "relevant": [
+          { "code":   60, "label": "<" },
+          { "code": 8804, "label": "≤" },
+          { "code":10216, "label": "⟨" }
+        ]
+      } },
+      { "code":  187, "label": "»", "popup": {
+        "main": { "code": 8250, "label": "›" },
+        "relevant": [
+          { "code":10217, "label": "⟩" },
+          { "code": 8805, "label": "≥" },
+          { "code":   62, "label": ">" }
+        ]
+      } },
+      { "code":   58, "label": ":", "popup": {
+        "main": { "code":  8942, "label": "⋮" }
+      } },
+      { "code": 1563, "label": "؛", "popup": {
+        "main": { "code":   59, "label": ";" }
+      } },
+      { "code":   33, "label": "!", "popup": {
+        "main": { "code":  161, "label": "¡" }
+      } },
+      { "code": 1567, "label": "؟", "popup": {
+        "main": { "code":   63, "label": "?" },
+        "relevant": [
+          { "code":  191, "label": "¿" },
+          { "code": 8253, "label": "‽" }
+        ]
+      } }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/symbols/western.json
+++ b/app/src/main/assets/ime/text/symbols/western.json
@@ -1,6 +1,7 @@
 {
   "type": "symbols",
-  "name": "western_default",
+  "name": "western",
+  "label": "Western",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/symbols/western.json
+++ b/app/src/main/assets/ime/text/symbols/western.json
@@ -10,13 +10,13 @@
       { "code":   35, "label": "#", "popup": {
         "main": { "code": 8470, "label": "№" }
       } },
-      { "code":   36, "label": "$", "popup": {
-        "main": { "code": 8364, "label": "€" },
+      { "code": -801, "label": "currency_slot_1", "popup": {
+        "main": { "code": -802, "label": "currency_slot_2" },
         "relevant": [
-          { "code": 8369, "label": "₱" },
-          { "code":  162, "label": "¢" },
-          { "code":  163, "label": "£" },
-          { "code":  165, "label": "¥" }
+          { "code": -806, "label": "currency_slot_6" },
+          { "code": -803, "label": "currency_slot_3" },
+          { "code": -804, "label": "currency_slot_4" },
+          { "code": -805, "label": "currency_slot_5" }
         ]
       } },
       { "code":   37, "label": "%", "popup": {

--- a/app/src/main/assets/ime/text/symbols2/eastern.json
+++ b/app/src/main/assets/ime/text/symbols2/eastern.json
@@ -1,0 +1,83 @@
+{
+  "type": "symbols2",
+  "name": "eastern",
+  "label": "Eastern",
+  "authors": [ "patrickgold" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code":  126, "label": "~" },
+      { "code":   96, "label": "`" },
+      { "code":  124, "label": "|" },
+      { "code": 8226, "label": "•", "popup": {
+        "main": { "code": 9834, "label": "♪" },
+        "relevant": [
+          { "code": 9827, "label": "♣" },
+          { "code": 9824, "label": "♠" },
+          { "code": 9829, "label": "♥" },
+          { "code": 9830, "label": "♦" }
+        ]
+      } },
+      { "code": 8730, "label": "√" },
+      { "code":  960, "label": "π", "popup": {
+        "main": { "code":  928, "label": "Π" },
+        "relevant": [
+          { "code":  969, "label": "ω" },
+          { "code":  945, "label": "α" },
+          { "code":  946, "label": "β" },
+          { "code":  937, "label": "Ω" },
+          { "code":  956, "label": "μ" }
+        ]
+      } },
+      { "code":  247, "label": "÷" },
+      { "code":  215, "label": "×" },
+      { "code":  182, "label": "¶", "popup": {
+        "main": { "code":  167, "label": "§" }
+      } },
+      { "code": 8710, "label": "∆" }
+    ],
+    [
+      { "code": -805, "label": "currency_slot_5" },
+      { "code": -804, "label": "currency_slot_4" },
+      { "code": -803, "label": "currency_slot_3" },
+      { "code": -802, "label": "currency_slot_2" },
+      { "code":   94, "label": "^", "popup": {
+        "main": { "code": 8593, "label": "↑" },
+        "relevant": [
+          { "code": 8592, "label": "←" },
+          { "code": 8595, "label": "↓" },
+          { "code": 8594, "label": "→" }
+        ]
+      } },
+      { "code":  176, "label": "°", "popup": {
+        "main": { "code": 8242, "label": "′" },
+        "relevant": [
+          { "code": 8243, "label": "″" }
+        ]
+      } },
+      { "code":   61, "label": "=", "popup": {
+        "main": { "code": 8800, "label": "≠" },
+        "relevant": [
+          { "code": 8734, "label": "∞" },
+          { "code": 8776, "label": "≈" }
+        ]
+      } },
+      { "code":  123, "label": "{", "popup": {
+        "main": { "code":   40, "label": "(" }
+      } },
+      { "code":  125, "label": "}", "popup": {
+        "main": { "code":   41, "label": ")" }
+      } },
+      { "code":   92, "label": "\\" }
+    ],
+    [
+      { "code":   95, "label": "_" },
+      { "code":  169, "label": "©" },
+      { "code":  174, "label": "®" },
+      { "code": 8482, "label": "™" },
+      { "code": 10003, "label": "✓" },
+      { "code":   91, "label": "[" },
+      { "code":   93, "label": "]" }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/symbols2/mod/$default.json
+++ b/app/src/main/assets/ime/text/symbols2/mod/$default.json
@@ -1,6 +1,7 @@
 {
   "type": "symbols2/mod",
-  "name": "default",
+  "name": "$default",
+  "label": "Default",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/assets/ime/text/symbols2/persian.json
+++ b/app/src/main/assets/ime/text/symbols2/persian.json
@@ -1,0 +1,83 @@
+{
+  "type": "symbols2",
+  "name": "persian",
+  "label": "Persian",
+  "authors": [ "patrickgold" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code":  126, "label": "~" },
+      { "code":   96, "label": "`" },
+      { "code":  124, "label": "|" },
+      { "code": 8226, "label": "•", "popup": {
+        "main": { "code": 9834, "label": "♪" },
+        "relevant": [
+          { "code": 9827, "label": "♣" },
+          { "code": 9824, "label": "♠" },
+          { "code": 9829, "label": "♥" },
+          { "code": 9830, "label": "♦" }
+        ]
+      } },
+      { "code": 8730, "label": "√" },
+      { "code":  960, "label": "π", "popup": {
+        "main": { "code":  928, "label": "Π" },
+        "relevant": [
+          { "code":  969, "label": "ω" },
+          { "code":  945, "label": "α" },
+          { "code":  946, "label": "β" },
+          { "code":  937, "label": "Ω" },
+          { "code":  956, "label": "μ" }
+        ]
+      } },
+      { "code":  247, "label": "÷" },
+      { "code":  215, "label": "×" },
+      { "code":  182, "label": "¶", "popup": {
+        "main": { "code":  167, "label": "§" }
+      } },
+      { "code": 8710, "label": "∆" }
+    ],
+    [
+      { "code": -805, "label": "currency_slot_5" },
+      { "code": -804, "label": "currency_slot_4" },
+      { "code": -803, "label": "currency_slot_3" },
+      { "code": -802, "label": "currency_slot_2" },
+      { "code":   94, "label": "^", "popup": {
+        "main": { "code": 8593, "label": "↑" },
+        "relevant": [
+          { "code": 8592, "label": "←" },
+          { "code": 8595, "label": "↓" },
+          { "code": 8594, "label": "→" }
+        ]
+      } },
+      { "code":  176, "label": "°", "popup": {
+        "main": { "code": 8242, "label": "′" },
+        "relevant": [
+          { "code": 8243, "label": "″" }
+        ]
+      } },
+      { "code":   61, "label": "=", "popup": {
+        "main": { "code": 8800, "label": "≠" },
+        "relevant": [
+          { "code": 8734, "label": "∞" },
+          { "code": 8776, "label": "≈" }
+        ]
+      } },
+      { "code":  123, "label": "{", "popup": {
+        "main": { "code":   40, "label": "(" }
+      } },
+      { "code":  125, "label": "}", "popup": {
+        "main": { "code":   41, "label": ")" }
+      } },
+      { "code":   92, "label": "\\" }
+    ],
+    [
+      { "code":   95, "label": "_" },
+      { "code":  169, "label": "©" },
+      { "code":  174, "label": "®" },
+      { "code": 8482, "label": "™" },
+      { "code": 10003, "label": "✓" },
+      { "code":   91, "label": "[" },
+      { "code":   93, "label": "]" }
+    ]
+  ]
+}

--- a/app/src/main/assets/ime/text/symbols2/western.json
+++ b/app/src/main/assets/ime/text/symbols2/western.json
@@ -37,10 +37,10 @@
       { "code": 8710, "label": "∆" }
     ],
     [
-      { "code":  163, "label": "£" },
-      { "code":  162, "label": "¢" },
-      { "code": 8364, "label": "€" },
-      { "code":  165, "label": "¥" },
+      { "code": -805, "label": "currency_slot_5" },
+      { "code": -804, "label": "currency_slot_4" },
+      { "code": -803, "label": "currency_slot_3" },
+      { "code": -802, "label": "currency_slot_2" },
       { "code":   94, "label": "^", "popup": {
         "main": { "code": 8593, "label": "↑" },
         "relevant": [

--- a/app/src/main/assets/ime/text/symbols2/western.json
+++ b/app/src/main/assets/ime/text/symbols2/western.json
@@ -1,6 +1,7 @@
 {
   "type": "symbols2",
-  "name": "western_default",
+  "name": "western",
+  "label": "Western",
   "authors": [ "patrickgold" ],
   "direction": "ltr",
   "arrangement": [

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisActivity.kt
@@ -26,8 +26,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.viewbinding.ViewBinding
 import com.google.android.material.snackbar.Snackbar
 import dev.patrickgold.florisboard.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 
-abstract class FlorisActivity<V : ViewBinding> : AppCompatActivity() {
+abstract class FlorisActivity<V : ViewBinding> : AppCompatActivity(), CoroutineScope by MainScope() {
     private var _binding: V? = null
     protected val binding: V
         get() = _binding!!
@@ -54,6 +57,7 @@ abstract class FlorisActivity<V : ViewBinding> : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        cancel()
         _binding = null
         _prefs = null
         errorDialog?.dismiss()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisApplication.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisApplication.kt
@@ -21,7 +21,6 @@ import dev.patrickgold.florisboard.BuildConfig
 import dev.patrickgold.florisboard.crashutility.CrashUtility
 import dev.patrickgold.florisboard.ime.dictionary.DictionaryManager
 import dev.patrickgold.florisboard.ime.extension.AssetManager
-import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
@@ -38,7 +37,6 @@ class FlorisApplication : Application(), CoroutineScope by MainScope() {
         val assetManager = AssetManager.init(this)
         DictionaryManager.init(this)
         ThemeManager.init(this, assetManager, prefHelper)
-        LayoutManager.init(this)
         prefHelper.initDefaultPreferences()
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisApplication.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisApplication.kt
@@ -21,10 +21,13 @@ import dev.patrickgold.florisboard.BuildConfig
 import dev.patrickgold.florisboard.crashutility.CrashUtility
 import dev.patrickgold.florisboard.ime.dictionary.DictionaryManager
 import dev.patrickgold.florisboard.ime.extension.AssetManager
+import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
 import timber.log.Timber
 
-class FlorisApplication : Application() {
+class FlorisApplication : Application(), CoroutineScope by MainScope() {
     override fun onCreate() {
         super.onCreate()
         if (BuildConfig.DEBUG) {
@@ -35,6 +38,7 @@ class FlorisApplication : Application() {
         val assetManager = AssetManager.init(this)
         DictionaryManager.init(this)
         ThemeManager.init(this, assetManager, prefHelper)
+        LayoutManager.init(this)
         prefHelper.initDefaultPreferences()
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -49,10 +49,10 @@ import dev.patrickgold.florisboard.ime.onehanded.OneHandedMode
 import dev.patrickgold.florisboard.ime.popup.PopupLayerView
 import dev.patrickgold.florisboard.ime.text.TextInputManager
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
+import dev.patrickgold.florisboard.ime.text.key.CurrencySet
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyData
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
-import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import dev.patrickgold.florisboard.setup.SetupActivity
@@ -60,7 +60,6 @@ import dev.patrickgold.florisboard.util.*
 import timber.log.Timber
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -400,9 +399,10 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardManager
         prefs.sync()
         val newIsNumberRowVisible = prefs.keyboard.numberRow
         if (isNumberRowVisible != newIsNumberRowVisible) {
-            LayoutManager.default().clearLayoutCache(KeyboardMode.CHARACTERS)
+            textInputManager.layoutManager.clearLayoutCache(KeyboardMode.CHARACTERS)
             isNumberRowVisible = newIsNumberRowVisible
         }
+        textInputManager.layoutManager.clearLayoutCache()
         themeManager.update()
         updateOneHandedPanelVisibility()
         activeSubtype = subtypeManager.getActiveSubtype() ?: Subtype.DEFAULT
@@ -847,35 +847,58 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardManager
      * ime/config.json so it can be parsed. Used by [SubtypeManager] and by the prefs.
      * NOTE: this class and its corresponding json file is subject to change in future versions.
      * @property packageName The package name of this IME.
+     * @property currencySets The predefined currency sets for this IME, available for selection
+     *  in the Settings UI.
      * @property defaultSubtypes A list of predefined default subtypes. This subtypes are used to
      *  define which locales are supported and which layout is preferred for that locale.
+     * @property currencySetNames Helper list for Settings Subtype Spinner elements.
+     * @property currencySetLabels Helper list for Settings Subtype Spinner elements.
      * @property defaultSubtypesLanguageCodes Helper list for Settings Subtype Spinner elements.
      * @property defaultSubtypesLanguageNames Helper list for Settings Subtype Spinner elements.
      */
     data class ImeConfig(
         @Json(name = "package")
         val packageName: String,
+        val currencySets: List<CurrencySet> = listOf(),
         val defaultSubtypes: List<DefaultSubtype> = listOf()
     ) {
+        val currencySetNames: List<String>
+        val currencySetLabels: List<String>
         val defaultSubtypesLanguageCodes: List<String>
         val defaultSubtypesLanguageNames: List<String>
 
         init {
-            val tmpList = mutableListOf<Pair<String, String>>()
-            for (defaultSubtype in defaultSubtypes) {
-                tmpList.add(Pair(defaultSubtype.locale.toString(), defaultSubtype.locale.displayName))
+            val tmpCurrencyList = mutableListOf<Pair<String, String>>()
+            for (currencySet in currencySets) {
+                tmpCurrencyList.add(Pair(currencySet.name, currencySet.label))
             }
-            // Sort language list alphabetically by the display name of a language
-            tmpList.sortBy { it.second }
-            // Move selected English variants to the top of the list
-            for (languageCode in listOf("en_CA", "en_AU", "en_UK", "en_US")) {
-                val index: Int = tmpList.indexOfFirst { it.first == languageCode }
+            // Sort currency set list alphabetically by the label of a currency set
+            tmpCurrencyList.sortBy { it.second }
+            // Move selected currency variants to the top of the list
+            for (currencyName in listOf("euro", "dollar")) {
+                val index: Int = tmpCurrencyList.indexOfFirst { it.first == currencyName }
                 if (index > 0) {
-                    tmpList.add(0, tmpList.removeAt(index))
+                    tmpCurrencyList.add(0, tmpCurrencyList.removeAt(index))
                 }
             }
-            defaultSubtypesLanguageCodes = tmpList.map { it.first }.toList()
-            defaultSubtypesLanguageNames = tmpList.map { it.second }.toList()
+            currencySetNames = tmpCurrencyList.map { it.first }.toList()
+            currencySetLabels = tmpCurrencyList.map { it.second }.toList()
+
+            val tmpSubtypeList = mutableListOf<Pair<String, String>>()
+            for (defaultSubtype in defaultSubtypes) {
+                tmpSubtypeList.add(Pair(defaultSubtype.locale.toString(), defaultSubtype.locale.displayName))
+            }
+            // Sort language list alphabetically by the display name of a language
+            tmpSubtypeList.sortBy { it.second }
+            // Move selected English variants to the top of the list
+            for (languageCode in listOf("en_CA", "en_AU", "en_UK", "en_US")) {
+                val index: Int = tmpSubtypeList.indexOfFirst { it.first == languageCode }
+                if (index > 0) {
+                    tmpSubtypeList.add(0, tmpSubtypeList.removeAt(index))
+                }
+            }
+            defaultSubtypesLanguageCodes = tmpSubtypeList.map { it.first }.toList()
+            defaultSubtypesLanguageNames = tmpSubtypeList.map { it.second }.toList()
         }
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -52,6 +52,7 @@ import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyData
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
+import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import dev.patrickgold.florisboard.setup.SetupActivity
@@ -399,7 +400,7 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardManager
         prefs.sync()
         val newIsNumberRowVisible = prefs.keyboard.numberRow
         if (isNumberRowVisible != newIsNumberRowVisible) {
-            textInputManager.layoutManager.clearLayoutCache(KeyboardMode.CHARACTERS)
+            LayoutManager.default().clearLayoutCache(KeyboardMode.CHARACTERS)
             isNumberRowVisible = newIsNumberRowVisible
         }
         themeManager.update()
@@ -846,9 +847,6 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardManager
      * ime/config.json so it can be parsed. Used by [SubtypeManager] and by the prefs.
      * NOTE: this class and its corresponding json file is subject to change in future versions.
      * @property packageName The package name of this IME.
-     * @property characterLayouts A map of valid layout names to use from. Each value defined
-     *  should have a <layout_name>.json file in ime/text/characters/ to avoid empty layouts.
-     *  The key is the layout name, the value is the layout label (string shown in UI).
      * @property defaultSubtypes A list of predefined default subtypes. This subtypes are used to
      *  define which locales are supported and which layout is preferred for that locale.
      * @property defaultSubtypesLanguageCodes Helper list for Settings Subtype Spinner elements.
@@ -857,7 +855,6 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardManager
     data class ImeConfig(
         @Json(name = "package")
         val packageName: String,
-        val characterLayouts: Map<String, String> = mapOf(),
         val defaultSubtypes: List<DefaultSubtype> = listOf()
     ) {
         val defaultSubtypesLanguageCodes: List<String>

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -124,6 +124,7 @@ class PrefHelper(
     }
 
     companion object {
+        private val OLD_SUBTYPES_REGEX = """^([\-0-9]+\/[\-a-zA-Z0-9]+\/[a-zA-Z\_]+[;]*)+${'$'}""".toRegex()
         private var defaultInstance: PrefHelper? = null
 
         @Synchronized
@@ -148,6 +149,10 @@ class PrefHelper(
         //theme.dayThemeRef = "assets:ime/theme/floris_day.json"
         //theme.nightThemeRef = "assets:ime/theme/floris_night.json"
         //setPref(Localization.SUBTYPES, "-234/de-AT/euro/c=qwertz")
+        val subtypes = getPref(Localization.SUBTYPES, "")
+        if (subtypes.matches(OLD_SUBTYPES_REGEX)) {
+            setPref(Localization.SUBTYPES, "")
+        }
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -147,7 +147,7 @@ class PrefHelper(
         PreferenceManager.setDefaultValues(context, R.xml.prefs_typing, true)
         //theme.dayThemeRef = "assets:ime/theme/floris_day.json"
         //theme.nightThemeRef = "assets:ime/theme/floris_night.json"
-        setPref(Localization.SUBTYPES, "-234/de-AT/c=qwertz")
+        //setPref(Localization.SUBTYPES, "-234/de-AT/c=qwertz")
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -147,8 +147,7 @@ class PrefHelper(
         PreferenceManager.setDefaultValues(context, R.xml.prefs_typing, true)
         //theme.dayThemeRef = "assets:ime/theme/floris_day.json"
         //theme.nightThemeRef = "assets:ime/theme/floris_night.json"
-        //setPref(Keyboard.SUBTYPES, "")
-        //setPref(Internal.IS_IME_SET_UP, false)
+        setPref(Localization.SUBTYPES, "-234/de-AT/c=qwertz")
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -147,7 +147,7 @@ class PrefHelper(
         PreferenceManager.setDefaultValues(context, R.xml.prefs_typing, true)
         //theme.dayThemeRef = "assets:ime/theme/floris_day.json"
         //theme.nightThemeRef = "assets:ime/theme/floris_night.json"
-        //setPref(Localization.SUBTYPES, "-234/de-AT/c=qwertz")
+        //setPref(Localization.SUBTYPES, "-234/de-AT/euro/c=qwertz")
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/Subtype.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/Subtype.kt
@@ -17,6 +17,7 @@
 package dev.patrickgold.florisboard.ime.core
 
 import com.squareup.moshi.Json
+import dev.patrickgold.florisboard.ime.text.layout.LayoutType
 import dev.patrickgold.florisboard.util.LocaleUtils
 import java.util.*
 
@@ -26,20 +27,18 @@ import java.util.*
  * @property id The ID of this subtype. Although this can be any numeric value, its value
  *  typically matches the one of the [DefaultSubtype] with the same locale.
  * @property locale The locale this subtype is bound to.
- * @property layout The name of the layout the user wants to use within the bounds of this subtype.
- *  Must be a string which also exists in [FlorisBoard.ImeConfig.characterLayouts]. If the value is
- *  not included within this list, no layout will be shown to the user.
+ * @property layoutMap The layout map to properly display the correct layout for each layout type.
  */
 data class Subtype(
     var id: Int,
     var locale: Locale,
-    var layout: String
+    var layoutMap: SubtypeLayoutMap
 ) {
     companion object {
         /**
          * Subtype to use when prefs do not contain any valid subtypes.
          */
-        val DEFAULT = Subtype(-1, Locale.ENGLISH, "qwerty")
+        val DEFAULT = Subtype(-1, Locale.ENGLISH, SubtypeLayoutMap(characters = "qwerty"))
 
         /**
          * Converts the string representation of this object to a [Subtype]. Must be in the
@@ -49,11 +48,11 @@ data class Subtype(
          *  <id>/<language_tag>/<layout_name>
          * Eg: 101/en_US/qwerty
          *     201/de-DE/qwertz
-         * If the given [string] does not match this format an [InvalidPropertiesFormatException]
+         * If the given [str] does not match this format an [InvalidPropertiesFormatException]
          * will be thrown.
          */
-        fun fromString(string: String): Subtype {
-            val data = string.split("/")
+        fun fromString(str: String): Subtype {
+            val data = str.split("/")
             if (data.size != 3) {
                 throw InvalidPropertiesFormatException(
                     "Given string contains more or less than 3 properties..."
@@ -63,7 +62,7 @@ data class Subtype(
                 return Subtype(
                     data[0].toInt(),
                     locale,
-                    data[2]
+                    SubtypeLayoutMap.fromString(data[2])
                 )
             }
         }
@@ -71,11 +70,142 @@ data class Subtype(
 
     /**
      * Converts this object into its string representation. Format:
-     *  <id>/<language_tag>/<layout_name>
+     *  <id>/<language_tag>/<layout_map>
      */
     override fun toString(): String {
         val languageTag = locale.toLanguageTag()
-        return "$id/$languageTag/$layout"
+        return "$id/$languageTag/$layoutMap"
+    }
+}
+
+data class SubtypeLayoutMap(
+    val characters: String = CHARACTERS_DEFAULT,
+    val symbols: String = SYMBOLS_DEFAULT,
+    val symbols2: String = SYMBOLS2_DEFAULT,
+    val numeric: String = NUMERIC_DEFAULT,
+    val numericAdvanced: String = NUMERIC_ADVANCED_DEFAULT,
+    val numericRow: String = NUMERIC_ROW_DEFAULT,
+    val phone: String = PHONE_DEFAULT,
+    val phone2: String = PHONE2_DEFAULT,
+) {
+    companion object {
+        private const val CHARACTERS_CODE =             "c"
+        private const val SYMBOLS_CODE =                "s"
+        private const val SYMBOLS2_CODE =               "s2"
+        private const val NUMERIC_CODE =                "n"
+        private const val NUMERIC_ADVANCED_CODE =       "na"
+        private const val NUMERIC_ROW_CODE =            "nr"
+        private const val PHONE_CODE =                  "p"
+        private const val PHONE2_CODE =                 "p2"
+
+        private const val EQUALS =                      "="
+        private const val DELIMITER =                   ","
+
+        private const val CHARACTERS_DEFAULT =          "qwerty"
+        private const val SYMBOLS_DEFAULT =             "western"
+        private const val SYMBOLS2_DEFAULT =            "western"
+        private const val NUMERIC_DEFAULT =             "western_arabic"
+        private const val NUMERIC_ADVANCED_DEFAULT =    "western_arabic"
+        private const val NUMERIC_ROW_DEFAULT =         "western_arabic"
+        private const val PHONE_DEFAULT =               "telpad"
+        private const val PHONE2_DEFAULT =              "telpad"
+
+        fun fromString(str: String): SubtypeLayoutMap {
+            var characters: String = CHARACTERS_DEFAULT
+            var symbols: String = SYMBOLS_DEFAULT
+            var symbols2: String = SYMBOLS2_DEFAULT
+            var numeric: String = NUMERIC_DEFAULT
+            var numericAdvanced: String = NUMERIC_ADVANCED_DEFAULT
+            var numericRow: String = NUMERIC_ROW_DEFAULT
+            var phone: String = PHONE_DEFAULT
+            var phone2: String = PHONE2_DEFAULT
+            for (layout in str.split(DELIMITER)) {
+                val layoutSplit = layout.split(EQUALS)
+                if (layoutSplit.size == 2) {
+                    val code = layoutSplit[0].trim()
+                    val layoutName = layoutSplit[1].trim()
+                    when (code) {
+                        CHARACTERS_CODE -> characters = layoutName
+                        SYMBOLS_CODE -> symbols = layoutName
+                        SYMBOLS2_CODE -> symbols2 = layoutName
+                        NUMERIC_CODE -> numeric = layoutName
+                        NUMERIC_ADVANCED_CODE -> numericAdvanced = layoutName
+                        NUMERIC_ROW_CODE -> numericRow = layoutName
+                        PHONE_CODE -> phone = layoutName
+                        PHONE2_CODE -> phone2 = layoutName
+                    }
+                }
+            }
+            return SubtypeLayoutMap(
+                characters, symbols, symbols2, numeric, numericAdvanced, numericRow, phone, phone2
+            )
+        }
+    }
+
+    operator fun get(layoutType: LayoutType): String? {
+        return when (layoutType) {
+            LayoutType.CHARACTERS -> characters
+            LayoutType.SYMBOLS -> symbols
+            LayoutType.SYMBOLS2 -> symbols2
+            LayoutType.NUMERIC -> numeric
+            LayoutType.NUMERIC_ADVANCED -> numericAdvanced
+            LayoutType.NUMERIC_ROW -> numericRow
+            LayoutType.PHONE -> phone
+            LayoutType.PHONE2 -> phone2
+            else -> null
+        }
+    }
+
+    override fun toString(): String {
+        return StringBuilder(128).run {
+            append(CHARACTERS_CODE)
+            append(EQUALS)
+            append(characters)
+
+            append(DELIMITER)
+
+            append(SYMBOLS_CODE)
+            append(EQUALS)
+            append(symbols)
+
+            append(DELIMITER)
+
+            append(SYMBOLS2_CODE)
+            append(EQUALS)
+            append(symbols2)
+
+            append(DELIMITER)
+
+            append(NUMERIC_ROW_CODE)
+            append(EQUALS)
+            append(numericRow)
+
+            append(DELIMITER)
+
+            append(NUMERIC_CODE)
+            append(EQUALS)
+            append(numeric)
+
+            append(DELIMITER)
+
+            append(NUMERIC_ADVANCED_CODE)
+            append(EQUALS)
+            append(numericAdvanced)
+
+            append(DELIMITER)
+
+            append(PHONE_CODE)
+            append(EQUALS)
+            append(phone)
+
+            append(DELIMITER)
+
+            append(PHONE2_CODE)
+            append(EQUALS)
+            append(phone2)
+
+            toString()
+        }
     }
 }
 
@@ -83,14 +213,11 @@ data class Subtype(
  * Data class which represents a predefined set of language and preferred layout.
  * @property id The ID of this subtype.
  * @property locale The locale of this subtype. Beware its different name in json: 'languageTag'.
- * @property preferredLayout The preferred layout for this subtype's locale.
- *  Must be a string which also exists in [FlorisBoard.ImeConfig.characterLayouts]. If the value is
- *  not included within this list, no layout will be shown to the user if the user selects the
- *  predefined layout value.
+ * @property preferred The preferred layout map for this subtype's locale.
  */
 data class DefaultSubtype(
     var id: Int,
     @Json(name = "languageTag")
     var locale: Locale,
-    var preferredLayout: String
+    var preferred: SubtypeLayoutMap
 )

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/SubtypeManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/SubtypeManager.kt
@@ -19,11 +19,16 @@ package dev.patrickgold.florisboard.ime.core
 import android.content.Context
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dev.patrickgold.florisboard.ime.extension.AssetRef
+import dev.patrickgold.florisboard.ime.extension.AssetSource
+import dev.patrickgold.florisboard.ime.theme.ThemeManager
+import dev.patrickgold.florisboard.ime.theme.ThemeMetaOnly
 import dev.patrickgold.florisboard.util.LocaleUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.*
 
 /**
@@ -37,7 +42,6 @@ import java.util.*
  *  list of [Subtype]s. When setting this property, the given list is converted to a raw string
  *  and written to prefs.
  */
-@Suppress("SameParameterValue")
 class SubtypeManager(
     private val context: Context,
     private val prefs: PrefHelper
@@ -110,20 +114,20 @@ class SubtypeManager(
     }
 
     /**
-     * Creates a [Subtype] from the given [locale] and [layoutName] and adds it to the subtype
+     * Creates a [Subtype] from the given [locale] and [layoutMap] and adds it to the subtype
      * list, if it does not exist.
      *
      * @param locale The locale of the subtype to be added.
-     * @param layoutName The layout name of the subtype to be added.
+     * @param layoutMap The layout map of the subtype to be added.
      * @return True if the subtype was added, false otherwise. A return value of false indicates
      *  that the subtype already exists.
      */
-    fun addSubtype(locale: Locale, layoutName: String): Boolean {
+    fun addSubtype(locale: Locale, layoutMap: SubtypeLayoutMap): Boolean {
         return addSubtype(
             Subtype(
-                (locale.hashCode() + layoutName.hashCode()),
+                (locale.hashCode() + layoutMap.hashCode()),
                 locale,
-                layoutName
+                layoutMap
             )
         )
     }
@@ -193,7 +197,7 @@ class SubtypeManager(
         for (subtype in subtypeList) {
             if (subtype.id == subtypeToModify.id) {
                 subtype.locale = subtypeToModify.locale
-                subtype.layout = subtypeToModify.layout
+                subtype.layoutMap = subtypeToModify.layoutMap
                 break
             }
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/extension/Asset.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/extension/Asset.kt
@@ -55,10 +55,5 @@ interface Asset {
          * Creates an empty Asset of type [T].
          */
         fun empty(): T
-
-        /**
-         * Loads an Asset of type [T] from the specified path.
-         */
-        fun fromFile(context: Context, path: String): Result<T> = Result.failure(NotImplementedError())
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/extension/AssetManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/extension/AssetManager.kt
@@ -58,6 +58,8 @@ class AssetManager private constructor(private val applicationContext: Context) 
                 )
             }
         }
+
+        fun defaultOrNull(): AssetManager? = defaultInstance
     }
 
     fun deleteAsset(ref: AssetRef): Result<Unit> {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupSet.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupSet.kt
@@ -90,7 +90,7 @@ class PopupSet<T> (
     }
 
     override fun iterator(): Iterator<T> {
-        TODO("Not yet implemented")
+        return PopupSetIterator(this)
     }
 
     override fun isEmpty(): Boolean {
@@ -115,5 +115,31 @@ class PopupSet<T> (
             }
         }
         relevant = tempRelevant.toList()
+    }
+
+    class PopupSetIterator<T> internal constructor (
+        private val popupSet: PopupSet<T>
+    ) : Iterator<T> {
+        var index = HINT_INDEX
+
+        override fun next(): T = popupSet[index++]
+
+        override fun hasNext(): Boolean {
+            if (index == HINT_INDEX) {
+                if (popupSet.getOrNull(index) != null) {
+                    return true
+                } else {
+                    index++
+                }
+            }
+            if (index == MAIN_INDEX) {
+                if (popupSet.getOrNull(index) != null) {
+                    return true
+                } else {
+                    index++
+                }
+            }
+            return popupSet.getOrNull(index) != null
+        }
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -327,10 +327,10 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
             }
             // TODO: heavy load on main thread
             for (keyboardMode in KeyboardMode.values()) {
-                if (keyboardMode != KeyboardMode.SMARTBAR_CLIPBOARD_CURSOR_ROW && keyboardMode != KeyboardMode.SMARTBAR_NUMBER_ROW) {
-                    val keyboardView = keyboardViews[keyboardMode]
-                    keyboardView?.computedLayout = LayoutManager.default().fetchComputedLayoutAsync(keyboardMode, newSubtype, florisboard.prefs).await()
-                    keyboardView?.updateVisibility()
+                val keyboardView = keyboardViews[keyboardMode]
+                if (keyboardView != null) {
+                    keyboardView.computedLayout = LayoutManager.default().fetchComputedLayoutAsync(keyboardMode, newSubtype, florisboard.prefs).await()
+                    keyboardView.updateVisibility()
                 }
             }
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/CurrencySet.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/CurrencySet.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.text.key
+
+import kotlin.math.abs
+
+class CurrencySet(
+    val name: String,
+    val label: String,
+    private val slots: List<KeyData>
+) {
+    companion object {
+        fun isCurrencySlot(keyCode: Int): Boolean {
+            return when (keyCode) {
+                KeyCode.CURRENCY_SLOT_1,
+                KeyCode.CURRENCY_SLOT_2,
+                KeyCode.CURRENCY_SLOT_3,
+                KeyCode.CURRENCY_SLOT_4,
+                KeyCode.CURRENCY_SLOT_5,
+                KeyCode.CURRENCY_SLOT_6 -> true
+                else -> false
+            }
+        }
+
+        fun default(): CurrencySet = CurrencySet(
+            name = "\$default",
+            label = "Default",
+            slots = listOf(
+                KeyData(code =   36, label = "$"),
+                KeyData(code =  162, label = "¢"),
+                KeyData(code = 8364, label = "€"),
+                KeyData(code =  163, label = "£"),
+                KeyData(code =  165, label = "¥"),
+                KeyData(code = 8369, label = "₱")
+            )
+        )
+    }
+
+    fun getSlot(keyCode: Int): KeyData? {
+        val slot = abs(keyCode) - abs(KeyCode.CURRENCY_SLOT_1)
+        return slots.getOrNull(slot)
+    }
+
+    override fun toString(): String {
+        return "${CurrencySet::class.simpleName} { name=$name, label\"$label\", slots=$slots }"
+    }
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
@@ -90,6 +90,13 @@ object KeyCode {
     const val TOGGLE_ONE_HANDED_MODE_RIGHT =-216
     const val URI_COMPONENT_TLD =           -255
 
+    const val CURRENCY_SLOT_1 =             -801
+    const val CURRENCY_SLOT_2 =             -802
+    const val CURRENCY_SLOT_3 =             -803
+    const val CURRENCY_SLOT_4 =             -804
+    const val CURRENCY_SLOT_5 =             -805
+    const val CURRENCY_SLOT_6 =             -806
+
     const val INTERNAL_BATCH_EDIT =         -901
 
     const val KESHIDA =                     1600

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -35,7 +35,7 @@ import dev.patrickgold.florisboard.ime.text.gestures.SwipeGesture
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyData
 import dev.patrickgold.florisboard.ime.text.key.KeyView
-import dev.patrickgold.florisboard.ime.text.layout.ComputedLayoutData
+import dev.patrickgold.florisboard.ime.text.layout.ComputedLayout
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import dev.patrickgold.florisboard.util.ViewLayoutUtils
@@ -54,7 +54,7 @@ class KeyboardView : FlexboxLayout, FlorisBoard.EventListener, SwipeGesture.List
     private var activeKeyViews: MutableMap<Int, KeyView> = mutableMapOf()
     private var initialKeyCodes: MutableMap<Int, Int> = mutableMapOf()
 
-    var computedLayout: ComputedLayoutData? = null
+    var computedLayout: ComputedLayout? = null
         set(v) {
             field = v
             buildLayout()
@@ -86,7 +86,7 @@ class KeyboardView : FlexboxLayout, FlorisBoard.EventListener, SwipeGesture.List
         )
         onWindowShown()
         if (isLoadingPlaceholderKeyboard) {
-            computedLayout = ComputedLayoutData.PRE_GENERATED_LOADING_KEYBOARD
+            computedLayout = ComputedLayout.PRE_GENERATED_LOADING_KEYBOARD
         }
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/Layout.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/Layout.kt
@@ -16,20 +16,23 @@
 
 package dev.patrickgold.florisboard.ime.text.layout
 
+import dev.patrickgold.florisboard.ime.extension.Asset
 import dev.patrickgold.florisboard.ime.text.key.FlorisKeyData
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyType
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
 
-typealias LayoutDataArrangement = List<List<FlorisKeyData>>
-data class LayoutData(
+typealias LayoutArrangement = List<List<FlorisKeyData>>
+data class Layout(
     val type: LayoutType,
-    val name: String,
+    override val name: String,
+    override val label: String,
+    override val authors: List<String>,
     val direction: String,
     val modifier: String?,
-    val arrangement: LayoutDataArrangement = listOf()
-) {
-    private fun getComputedLayoutDataArrangement(): ComputedLayoutDataArrangement {
+    val arrangement: LayoutArrangement = listOf()
+) : Asset {
+    private fun getComputedLayoutArrangement(): ComputedLayoutArrangement {
         val ret = mutableListOf<MutableList<FlorisKeyData>>()
         for (row in arrangement) {
             val retRow = mutableListOf<FlorisKeyData>()
@@ -41,22 +44,31 @@ data class LayoutData(
         return ret
     }
 
-    fun toComputedLayoutData(keyboardMode: KeyboardMode): ComputedLayoutData {
-        return ComputedLayoutData(
-            keyboardMode, name, direction, getComputedLayoutDataArrangement()
+    fun toComputedLayout(keyboardMode: KeyboardMode): ComputedLayout {
+        return ComputedLayout(
+            keyboardMode, name, direction, getComputedLayoutArrangement()
         )
     }
 }
 
-typealias ComputedLayoutDataArrangement = MutableList<MutableList<FlorisKeyData>>
-data class ComputedLayoutData(
+data class LayoutMetaOnly(
+    val type: LayoutType,
+    override val name: String,
+    override val label: String,
+    override val authors: List<String>,
+    val direction: String,
+    val modifier: String?
+) : Asset
+
+typealias ComputedLayoutArrangement = MutableList<MutableList<FlorisKeyData>>
+data class ComputedLayout(
     val mode: KeyboardMode,
     val name: String,
     val direction: String,
-    val arrangement: ComputedLayoutDataArrangement = mutableListOf()
+    val arrangement: ComputedLayoutArrangement = mutableListOf()
 ) {
     companion object {
-        val PRE_GENERATED_LOADING_KEYBOARD = ComputedLayoutData(
+        val PRE_GENERATED_LOADING_KEYBOARD = ComputedLayout(
             mode = KeyboardMode.CHARACTERS,
             name = "__loading_keyboard__",
             direction = "ltr",

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutType.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutType.kt
@@ -12,6 +12,7 @@ enum class LayoutType {
     EXTENSION,
     NUMERIC,
     NUMERIC_ADVANCED,
+    NUMERIC_ROW,
     PHONE,
     PHONE2,
     SYMBOLS,

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -30,7 +30,6 @@ import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.text.key.KeyVariation
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
-import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import kotlinx.coroutines.Dispatchers
@@ -104,10 +103,11 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
 
         mainScope.launch(Dispatchers.Default) {
             florisboard?.let {
-                val layout = LayoutManager.default().fetchComputedLayoutAsync(
+                val layout = florisboard.textInputManager.layoutManager.fetchComputedLayoutAsync(
                     KeyboardMode.SMARTBAR_CLIPBOARD_CURSOR_ROW,
                     Subtype.DEFAULT,
-                    prefs
+                    prefs,
+                    florisboard.subtypeManager.getCurrencySet(Subtype.DEFAULT)
                 ).await()
                 withContext(Dispatchers.Main) {
                     binding.clipboardCursorRow.computedLayout = layout
@@ -118,10 +118,11 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
 
         mainScope.launch(Dispatchers.Default) {
             florisboard?.let {
-                val layout = LayoutManager.default().fetchComputedLayoutAsync(
+                val layout = florisboard.textInputManager.layoutManager.fetchComputedLayoutAsync(
                     KeyboardMode.SMARTBAR_NUMBER_ROW,
                     Subtype.DEFAULT,
-                    prefs
+                    prefs,
+                    florisboard.subtypeManager.getCurrencySet(Subtype.DEFAULT)
                 ).await()
                 withContext(Dispatchers.Main) {
                     binding.numberRow.computedLayout = layout

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -30,6 +30,7 @@ import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.text.key.KeyVariation
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
+import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import kotlinx.coroutines.Dispatchers
@@ -103,7 +104,7 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
 
         mainScope.launch(Dispatchers.Default) {
             florisboard?.let {
-                val layout = florisboard.textInputManager.layoutManager.fetchComputedLayoutAsync(
+                val layout = LayoutManager.default().fetchComputedLayoutAsync(
                     KeyboardMode.SMARTBAR_CLIPBOARD_CURSOR_ROW,
                     Subtype.DEFAULT,
                     prefs
@@ -117,7 +118,7 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
 
         mainScope.launch(Dispatchers.Default) {
             florisboard?.let {
-                val layout = it.textInputManager.layoutManager.fetchComputedLayoutAsync(
+                val layout = LayoutManager.default().fetchComputedLayoutAsync(
                     KeyboardMode.SMARTBAR_NUMBER_ROW,
                     Subtype.DEFAULT,
                     prefs

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/SettingsMainActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/SettingsMainActivity.kt
@@ -33,9 +33,12 @@ import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.databinding.SettingsActivityBinding
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.core.SubtypeManager
+import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
 import dev.patrickgold.florisboard.settings.fragments.*
 import dev.patrickgold.florisboard.util.AppVersionUtils
 import dev.patrickgold.florisboard.util.PackageManagerUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
 
 internal const val FRAGMENT_TAG = "FRAGMENT_TAG"
 private const val PREF_RES_ID = "PREF_RES_ID"
@@ -44,9 +47,11 @@ private const val ADVANCED_REQ_CODE = 0x145F
 
 class SettingsMainActivity : AppCompatActivity(),
     BottomNavigationView.OnNavigationItemSelectedListener,
-    SharedPreferences.OnSharedPreferenceChangeListener {
+    SharedPreferences.OnSharedPreferenceChangeListener,
+    CoroutineScope by MainScope() {
 
     lateinit var binding: SettingsActivityBinding
+    lateinit var layoutManager: LayoutManager
     private lateinit var prefs: PrefHelper
     lateinit var subtypeManager: SubtypeManager
 
@@ -55,6 +60,7 @@ class SettingsMainActivity : AppCompatActivity(),
         prefs.initDefaultPreferences()
         prefs.sync()
         subtypeManager = SubtypeManager(this, prefs)
+        layoutManager = LayoutManager(this)
 
         val mode = when (prefs.advanced.settingsTheme) {
             "light" -> AppCompatDelegate.MODE_NIGHT_NO

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
@@ -51,7 +51,6 @@ import kotlinx.coroutines.launch
  */
 class ThemeEditorActivity : AppCompatActivity() {
     private lateinit var binding: ThemeEditorActivityBinding
-    private lateinit var layoutManager: LayoutManager
     private val mainScope = MainScope()
     private lateinit var prefs: PrefHelper
     private val themeManager: ThemeManager = ThemeManager.default()
@@ -99,7 +98,7 @@ class ThemeEditorActivity : AppCompatActivity() {
         supportActionBar?.title = resources.getString(R.string.settings__theme_editor__title)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        layoutManager = LayoutManager(this).apply {
+        LayoutManager.default().apply {
             preloadComputedLayout(KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs)
         }
 
@@ -322,7 +321,7 @@ class ThemeEditorActivity : AppCompatActivity() {
             }
         }
         mainScope.launch {
-            binding.keyboardPreview.computedLayout = layoutManager.fetchComputedLayoutAsync(
+            binding.keyboardPreview.computedLayout = LayoutManager.default().fetchComputedLayoutAsync(
                 KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs
             ).await()
             binding.keyboardPreview.onThemeUpdated(editedTheme)

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeEditorActivity.kt
@@ -35,6 +35,7 @@ import dev.patrickgold.florisboard.databinding.ThemeEditorMetaDialogBinding
 import dev.patrickgold.florisboard.ime.core.PrefHelper
 import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.extension.AssetRef
+import dev.patrickgold.florisboard.ime.text.key.CurrencySet
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
 import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
 import dev.patrickgold.florisboard.ime.theme.Theme
@@ -52,6 +53,7 @@ import kotlinx.coroutines.launch
 class ThemeEditorActivity : AppCompatActivity() {
     private lateinit var binding: ThemeEditorActivityBinding
     private val mainScope = MainScope()
+    private lateinit var layoutManager: LayoutManager
     private lateinit var prefs: PrefHelper
     private val themeManager: ThemeManager = ThemeManager.default()
 
@@ -83,6 +85,8 @@ class ThemeEditorActivity : AppCompatActivity() {
         binding = ThemeEditorActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        layoutManager = LayoutManager(mainScope)
+
         AssetRef.fromString(intent.getStringExtra(EXTRA_THEME_REF) ?: "").onSuccess { ref ->
             editedThemeRef = ref
             themeManager.loadTheme(ref).onSuccess { theme ->
@@ -98,8 +102,8 @@ class ThemeEditorActivity : AppCompatActivity() {
         supportActionBar?.title = resources.getString(R.string.settings__theme_editor__title)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        LayoutManager.default().apply {
-            preloadComputedLayout(KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs)
+        layoutManager.apply {
+            preloadComputedLayout(KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs, CurrencySet.default())
         }
 
         buildUi()
@@ -321,8 +325,8 @@ class ThemeEditorActivity : AppCompatActivity() {
             }
         }
         mainScope.launch {
-            binding.keyboardPreview.computedLayout = LayoutManager.default().fetchComputedLayoutAsync(
-                KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs
+            binding.keyboardPreview.computedLayout = layoutManager.fetchComputedLayoutAsync(
+                KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs, CurrencySet.default()
             ).await()
             binding.keyboardPreview.onThemeUpdated(editedTheme)
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
@@ -50,7 +50,6 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
-    private lateinit var layoutManager: LayoutManager
     private val mainScope = MainScope()
     private val themeManager: ThemeManager = ThemeManager.default()
 
@@ -147,7 +146,7 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
         binding.themeEditBtn.setOnClickListener { onActionClicked(it) }
         binding.themeExportBtn.setOnClickListener { onActionClicked(it) }
 
-        layoutManager = LayoutManager(this).apply {
+        LayoutManager.default().apply {
             preloadComputedLayout(KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs)
         }
 
@@ -393,7 +392,7 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
             setCheckedRadioButton(selectId!!)
         }
         mainScope.launch {
-            binding.keyboardPreview.computedLayout = layoutManager.fetchComputedLayoutAsync(
+            binding.keyboardPreview.computedLayout = LayoutManager.default().fetchComputedLayoutAsync(
                 KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs
             ).await()
             binding.keyboardPreview.onThemeUpdated(selectedTheme)

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
@@ -39,18 +39,18 @@ import dev.patrickgold.florisboard.ime.extension.AssetManager
 import dev.patrickgold.florisboard.ime.extension.AssetRef
 import dev.patrickgold.florisboard.ime.extension.AssetSource
 import dev.patrickgold.florisboard.ime.extension.ExternalContentUtils
+import dev.patrickgold.florisboard.ime.text.key.CurrencySet
 import dev.patrickgold.florisboard.ime.text.keyboard.KeyboardMode
 import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import dev.patrickgold.florisboard.ime.theme.ThemeMetaOnly
 import dev.patrickgold.florisboard.util.ViewLayoutUtils
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
-    private val mainScope = MainScope()
+    private lateinit var layoutManager: LayoutManager
     private val themeManager: ThemeManager = ThemeManager.default()
 
     private var key: String = ""
@@ -123,6 +123,8 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        layoutManager = LayoutManager(this)
+
         key = intent.getStringExtra(EXTRA_KEY) ?: ""
         defaultValue = intent.getStringExtra(EXTRA_DEFAULT_VALUE) ?: ""
         selectedRef = evaluateSelectedRef()
@@ -146,8 +148,8 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
         binding.themeEditBtn.setOnClickListener { onActionClicked(it) }
         binding.themeExportBtn.setOnClickListener { onActionClicked(it) }
 
-        LayoutManager.default().apply {
-            preloadComputedLayout(KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs)
+        layoutManager.apply {
+            preloadComputedLayout(KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs, CurrencySet.default())
         }
 
         buildUi()
@@ -391,9 +393,9 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
         } else {
             setCheckedRadioButton(selectId!!)
         }
-        mainScope.launch {
-            binding.keyboardPreview.computedLayout = LayoutManager.default().fetchComputedLayoutAsync(
-                KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs
+        launch {
+            binding.keyboardPreview.computedLayout = layoutManager.fetchComputedLayoutAsync(
+                KeyboardMode.CHARACTERS, Subtype.DEFAULT, prefs, CurrencySet.default()
             ).await()
             binding.keyboardPreview.onThemeUpdated(selectedTheme)
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/fragments/TypingFragment.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/fragments/TypingFragment.kt
@@ -21,16 +21,24 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import androidx.appcompat.widget.AppCompatSpinner
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.databinding.ListItemBinding
 import dev.patrickgold.florisboard.databinding.SettingsFragmentTypingBinding
 import dev.patrickgold.florisboard.databinding.SettingsFragmentTypingSubtypeDialogBinding
+import dev.patrickgold.florisboard.ime.core.SubtypeLayoutMap
+import dev.patrickgold.florisboard.ime.text.layout.LayoutManager
+import dev.patrickgold.florisboard.ime.text.layout.LayoutType
 import dev.patrickgold.florisboard.settings.SettingsMainActivity
 import dev.patrickgold.florisboard.util.LocaleUtils
+import dev.patrickgold.florisboard.util.initItems
+import dev.patrickgold.florisboard.util.setOnSelectedListener
 
 class TypingFragment : SettingsMainActivity.SettingsFragment() {
+    private val layoutManager: LayoutManager
+        get() = LayoutManager.default()
+
     private lateinit var binding: SettingsFragmentTypingBinding
     /**
      * Must always have a reference to the open AlertDialog to dismiss the AlertDialog in the event
@@ -42,7 +50,7 @@ class TypingFragment : SettingsMainActivity.SettingsFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = SettingsFragmentTypingBinding.inflate(inflater, container, false)
         binding.subtypeAddBtn.setOnClickListener { showAddSubtypeDialog() }
 
@@ -64,36 +72,44 @@ class TypingFragment : SettingsMainActivity.SettingsFragment() {
         super.onDestroy()
     }
 
+    private fun getSpinnerForLayoutType(
+        dialogView: SettingsFragmentTypingSubtypeDialogBinding,
+        layoutType: LayoutType
+    ): AppCompatSpinner? {
+        return when (layoutType) {
+            LayoutType.CHARACTERS -> dialogView.charactersLayoutSpinner
+            LayoutType.SYMBOLS -> dialogView.symbolsLayoutSpinner
+            LayoutType.SYMBOLS2 -> dialogView.symbols2LayoutSpinner
+            LayoutType.NUMERIC -> dialogView.numericLayoutSpinner
+            LayoutType.NUMERIC_ADVANCED -> dialogView.numericAdvancedLayoutSpinner
+            LayoutType.NUMERIC_ROW -> dialogView.numericRowLayoutSpinner
+            LayoutType.PHONE -> dialogView.phoneLayoutSpinner
+            LayoutType.PHONE2 -> dialogView.phone2LayoutSpinner
+            else -> null
+        }
+    }
+
     private fun showAddSubtypeDialog() {
-        val dialogView =
-            SettingsFragmentTypingSubtypeDialogBinding.inflate(layoutInflater)
-        val languageAdapter: ArrayAdapter<String> = ArrayAdapter(
-            requireContext(),
-            android.R.layout.simple_spinner_dropdown_item,
-            subtypeManager.imeConfig.defaultSubtypesLanguageNames
+        val dialogView = SettingsFragmentTypingSubtypeDialogBinding.inflate(layoutInflater)
+
+        dialogView.languageSpinner.initItems(
+            labels = subtypeManager.imeConfig.defaultSubtypesLanguageNames
         )
-        dialogView.languageSpinner.adapter = languageAdapter
-        // Add listener to languageSpinner to automatically pre-select the preferred layout for the
-        // selected language in layoutSpinner.
-        dialogView.languageSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>?, view: View?, pos: Int, id: Long) {
-                val selectedCode = subtypeManager.imeConfig.defaultSubtypesLanguageCodes[pos]
-                val defaultSubtype = subtypeManager.getDefaultSubtypeForLocale(LocaleUtils.stringToLocale(selectedCode)) ?: return
-                dialogView.layoutSpinner.setSelection(
-                    subtypeManager.imeConfig.characterLayouts.keys.toList().indexOf(defaultSubtype.preferredLayout)
+        dialogView.languageSpinner.setOnSelectedListener { pos ->
+            val selectedCode = subtypeManager.imeConfig.defaultSubtypesLanguageCodes[pos]
+            val defaultSubtype = subtypeManager.getDefaultSubtypeForLocale(LocaleUtils.stringToLocale(selectedCode)) ?: return@setOnSelectedListener
+            for (layoutType in LayoutType.values()) {
+                getSpinnerForLayoutType(dialogView, layoutType)?.setSelection(
+                    layoutManager.getMetaNameListFor(layoutType).indexOf(defaultSubtype.preferred[layoutType] ?: "").coerceAtLeast(0)
                 )
             }
-
-            override fun onNothingSelected(parent: AdapterView<*>?) {
-                // Auto-generated stub method
-            }
         }
-        val layoutAdapter: ArrayAdapter<String> = ArrayAdapter(
-            requireContext(),
-            android.R.layout.simple_spinner_dropdown_item,
-            subtypeManager.imeConfig.characterLayouts.values.toList()
-        )
-        dialogView.layoutSpinner.adapter = layoutAdapter
+        for (layoutType in LayoutType.values()) {
+            getSpinnerForLayoutType(dialogView, layoutType)?.initItems(
+                labels = layoutManager.getMetaLabelListFor(layoutType)
+            )
+        }
+
         AlertDialog.Builder(context).apply {
             setTitle(R.string.settings__localization__subtype_add_title)
             setCancelable(true)
@@ -107,8 +123,17 @@ class TypingFragment : SettingsMainActivity.SettingsFragment() {
             // already exists.
             activeDialogWindow?.getButton(AlertDialog.BUTTON_POSITIVE)?.setOnClickListener {
                 val languageCode = subtypeManager.imeConfig.defaultSubtypesLanguageCodes[dialogView.languageSpinner.selectedItemPosition]
-                val layoutName = subtypeManager.imeConfig.characterLayouts.keys.toList()[dialogView.layoutSpinner.selectedItemPosition]
-                val success = subtypeManager.addSubtype(LocaleUtils.stringToLocale(languageCode), layoutName)
+                val layoutMap = SubtypeLayoutMap(
+                    characters = layoutManager.getMetaNameListFor(LayoutType.CHARACTERS)[dialogView.charactersLayoutSpinner.selectedItemPosition],
+                    symbols = layoutManager.getMetaNameListFor(LayoutType.SYMBOLS)[dialogView.symbolsLayoutSpinner.selectedItemPosition],
+                    symbols2 = layoutManager.getMetaNameListFor(LayoutType.SYMBOLS2)[dialogView.symbols2LayoutSpinner.selectedItemPosition],
+                    numeric = layoutManager.getMetaNameListFor(LayoutType.NUMERIC)[dialogView.numericLayoutSpinner.selectedItemPosition],
+                    numericAdvanced = layoutManager.getMetaNameListFor(LayoutType.NUMERIC_ADVANCED)[dialogView.numericAdvancedLayoutSpinner.selectedItemPosition],
+                    numericRow = layoutManager.getMetaNameListFor(LayoutType.NUMERIC_ROW)[dialogView.numericRowLayoutSpinner.selectedItemPosition],
+                    phone = layoutManager.getMetaNameListFor(LayoutType.PHONE)[dialogView.phoneLayoutSpinner.selectedItemPosition],
+                    phone2 = layoutManager.getMetaNameListFor(LayoutType.PHONE2)[dialogView.phone2LayoutSpinner.selectedItemPosition],
+                )
+                val success = subtypeManager.addSubtype(LocaleUtils.stringToLocale(languageCode), layoutMap)
                 if (!success) {
                     dialogView.errorBox.setText(R.string.settings__localization__subtype_error_already_exists)
                     dialogView.errorBox.visibility = View.VISIBLE
@@ -122,35 +147,39 @@ class TypingFragment : SettingsMainActivity.SettingsFragment() {
 
     private fun showEditSubtypeDialog(id: Int) {
         val subtype = subtypeManager.getSubtypeById(id) ?: return
-        val dialogView =
-            SettingsFragmentTypingSubtypeDialogBinding.inflate(layoutInflater)
-        val languageAdapter: ArrayAdapter<String> = ArrayAdapter(
-            requireContext(),
-            android.R.layout.simple_spinner_dropdown_item,
-            subtypeManager.imeConfig.defaultSubtypesLanguageNames
+        val dialogView = SettingsFragmentTypingSubtypeDialogBinding.inflate(layoutInflater)
+
+        dialogView.languageSpinner.initItems(
+            labels = subtypeManager.imeConfig.defaultSubtypesLanguageNames,
+            keys = subtypeManager.imeConfig.defaultSubtypesLanguageCodes,
+            defaultSelectedKey = subtype.locale.toString()
         )
-        dialogView.languageSpinner.adapter = languageAdapter
-        dialogView.languageSpinner.setSelection(
-            subtypeManager.imeConfig.defaultSubtypesLanguageCodes.indexOf(subtype.locale.toString())
-        )
-        val layoutAdapter: ArrayAdapter<String> = ArrayAdapter(
-            requireContext(),
-            android.R.layout.simple_spinner_dropdown_item,
-            subtypeManager.imeConfig.characterLayouts.values.toList()
-        )
-        dialogView.layoutSpinner.adapter = layoutAdapter
-        dialogView.layoutSpinner.setSelection(
-            subtypeManager.imeConfig.characterLayouts.keys.toList().indexOf(subtype.layout)
-        )
+        for (layoutType in LayoutType.values()) {
+            getSpinnerForLayoutType(dialogView, layoutType)?.initItems(
+                labels = layoutManager.getMetaLabelListFor(layoutType),
+                keys = layoutManager.getMetaNameListFor(layoutType),
+                defaultSelectedKey = subtype.layoutMap[layoutType] ?: ""
+            )
+        }
+
         AlertDialog.Builder(context).apply {
             setTitle(R.string.settings__localization__subtype_edit_title)
             setCancelable(true)
             setView(dialogView.root)
             setPositiveButton(R.string.settings__localization__subtype_apply) { _, _ ->
                 val languageCode = subtypeManager.imeConfig.defaultSubtypesLanguageCodes[dialogView.languageSpinner.selectedItemPosition]
-                val layoutName = subtypeManager.imeConfig.characterLayouts.keys.toList()[dialogView.layoutSpinner.selectedItemPosition]
+                val layoutMap = SubtypeLayoutMap(
+                    characters = layoutManager.getMetaNameListFor(LayoutType.CHARACTERS)[dialogView.charactersLayoutSpinner.selectedItemPosition],
+                    symbols = layoutManager.getMetaNameListFor(LayoutType.SYMBOLS)[dialogView.symbolsLayoutSpinner.selectedItemPosition],
+                    symbols2 = layoutManager.getMetaNameListFor(LayoutType.SYMBOLS2)[dialogView.symbols2LayoutSpinner.selectedItemPosition],
+                    numeric = layoutManager.getMetaNameListFor(LayoutType.NUMERIC)[dialogView.numericLayoutSpinner.selectedItemPosition],
+                    numericAdvanced = layoutManager.getMetaNameListFor(LayoutType.NUMERIC_ADVANCED)[dialogView.numericAdvancedLayoutSpinner.selectedItemPosition],
+                    numericRow = layoutManager.getMetaNameListFor(LayoutType.NUMERIC_ROW)[dialogView.numericRowLayoutSpinner.selectedItemPosition],
+                    phone = layoutManager.getMetaNameListFor(LayoutType.PHONE)[dialogView.phoneLayoutSpinner.selectedItemPosition],
+                    phone2 = layoutManager.getMetaNameListFor(LayoutType.PHONE2)[dialogView.phone2LayoutSpinner.selectedItemPosition],
+                )
                 subtype.locale = LocaleUtils.stringToLocale(languageCode)
-                subtype.layout = layoutName
+                subtype.layoutMap = layoutMap
                 subtypeManager.modifySubtypeWithSameId(subtype)
                 updateSubtypeListView()
             }
@@ -173,10 +202,9 @@ class TypingFragment : SettingsMainActivity.SettingsFragment() {
         } else {
             binding.subtypeNotConfWarning.visibility = View.GONE
             for (subtype in subtypes) {
-                val itemView =
-                    ListItemBinding.inflate(layoutInflater)
+                val itemView = ListItemBinding.inflate(layoutInflater)
                 itemView.title.text = subtype.locale.displayName
-                itemView.summary.text = subtypeManager.imeConfig.characterLayouts[subtype.layout]
+                itemView.summary.text = layoutManager.getMetaFor(LayoutType.CHARACTERS, subtype.layoutMap.characters)?.label ?: "???"
                 itemView.root.setOnClickListener { showEditSubtypeDialog(subtype.id) }
                 binding.subtypeListView.addView(itemView.root)
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/util/AppCompatSpinnerUtils.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/util/AppCompatSpinnerUtils.kt
@@ -1,0 +1,36 @@
+package dev.patrickgold.florisboard.util
+
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.appcompat.widget.AppCompatSpinner
+
+fun AppCompatSpinner.initItems(labels: List<String>, keys: List<String>, defaultSelectedKey: String) {
+    this.initItems(labels, keys.indexOf(defaultSelectedKey).coerceAtLeast(0))
+}
+
+fun AppCompatSpinner.initItems(labels: List<String>, initSelection: Int) {
+    this.initItems(labels)
+    this.setSelection(initSelection)
+}
+
+fun AppCompatSpinner.initItems(labels: List<String>) {
+    val adapter = ArrayAdapter(
+        this.context,
+        android.R.layout.simple_spinner_dropdown_item,
+        labels
+    )
+    this.adapter = adapter
+}
+
+fun AppCompatSpinner.setOnSelectedListener(callback: (Int) -> Unit) {
+    this.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            callback(position)
+        }
+
+        override fun onNothingSelected(parent: AdapterView<*>?) {
+            // Stub
+        }
+    }
+}

--- a/app/src/main/res/layout/settings_fragment_typing_subtype_dialog.xml
+++ b/app/src/main/res/layout/settings_fragment_typing_subtype_dialog.xml
@@ -61,6 +61,10 @@
 
         </LinearLayout>
 
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="24dp"/>
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -118,6 +122,10 @@
 
         </LinearLayout>
 
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="24dp"/>
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -174,6 +182,10 @@
                 android:layout_height="48dp"/>
 
         </LinearLayout>
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="24dp"/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/settings_fragment_typing_subtype_dialog.xml
+++ b/app/src/main/res/layout/settings_fragment_typing_subtype_dialog.xml
@@ -108,6 +108,25 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_currency_set"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/currency_set_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:text="@string/settings__localization__subtype_numeric_layout"
                 android:paddingHorizontal="8dp"/>
 

--- a/app/src/main/res/layout/settings_fragment_typing_subtype_dialog.xml
+++ b/app/src/main/res/layout/settings_fragment_typing_subtype_dialog.xml
@@ -1,59 +1,199 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="16dp">
-
-    <!-- TODO: improve the design and UX of this layout -->
-
-    <TextView
-        android:id="@+id/error_box"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/colorError"
-        tools:text="@string/settings__localization__subtype_error_already_exists"
-        android:textColor="@color/textColorError"
-        android:layout_marginBottom="8dp"
-        android:padding="8dp"
-        android:visibility="gone"/>
+    android:layout_height="wrap_content">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingVertical="8dp">
+        android:padding="16dp">
+
+        <!-- TODO: improve the design and UX of this layout -->
 
         <TextView
+            android:id="@+id/error_box"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/settings__localization__subtype_locale"
-            android:paddingHorizontal="8dp"/>
+            android:background="@color/colorError"
+            tools:text="@string/settings__localization__subtype_error_already_exists"
+            android:textColor="@color/textColorError"
+            android:layout_marginBottom="8dp"
+            android:padding="8dp"
+            android:visibility="gone"/>
 
-        <androidx.appcompat.widget.AppCompatSpinner
-            android:id="@+id/language_spinner"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="48dp"/>
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingVertical="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_locale"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/language_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_characters_layout"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/characters_layout_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_symbols_layout"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/symbols_layout_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_symbols2_layout"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/symbols2_layout_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_numeric_layout"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/numeric_layout_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_numeric_advanced_layout"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/numeric_advanced_layout_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_numeric_row_layout"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/numeric_row_layout_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_phone_layout"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/phone_layout_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings__localization__subtype_phone2_layout"
+                android:paddingHorizontal="8dp"/>
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/phone2_layout_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"/>
+
+        </LinearLayout>
 
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingTop="8dp">
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/settings__localization__subtype_layout"
-            android:paddingHorizontal="8dp"/>
-
-        <androidx.appcompat.widget.AppCompatSpinner
-            android:id="@+id/layout_spinner"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"/>
-
-    </LinearLayout>
-
-</LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -61,7 +61,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">حذف</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">تعديل نوع فرعي</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">اللغة</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">تخطيط لوحة المفاتيح</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">هذا النوع الفرعي موجود مسبقا!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">مظهر لوحة المفاتيح</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">غير محدد</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Изтриване</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Редактиране на подтип</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Език</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Клавиатурна подредба</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Този подтип вече съществува!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Тема на клавиатурата</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Недефинирано</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -45,7 +45,6 @@
     <string name="settings__localization__subtype_apply" comment="Subtype dialog apply button">Primjeni</string>
     <string name="settings__localization__subtype_cancel" comment="Subtype dialog cancel button">Odustani</string>
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Obriši</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Raspored tastature</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Nedefinisano</string>
     <string name="pref__theme__mode__always_day" comment="Preference value for theme mode">Uvijek dan</string>
     <string name="pref__theme__mode__always_night" comment="Preference value for theme mode">Uvijek noć</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Eliminar</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Editar el subtipus</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Local</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Disposició de teclat</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Aquest subtipus ja existeix!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tema del teclat</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Indefinit</string>

--- a/app/src/main/res/values-ckb-rIR/strings.xml
+++ b/app/src/main/res/values-ckb-rIR/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">سڕینەوە</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">دەستکاریکردن تەختەکلیل</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">زمان</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">شێوازەکانی تەختەکلیل</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">ئەم زمانە پێشتر زیادکراوە لە لیستەکەدا هەیە!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">ڕووکارەکانی تەختەکلیل</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">بێ ناو</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -61,7 +61,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Vymazat</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Upravit podtyp</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Místní</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Rozpoložení klávesnice</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Tento podtyp již existuje!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Motiv klávesnice</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Definován</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -60,7 +60,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Slet</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Ændre undertastatur</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Landestandard</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Tastaturlayout</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Dette undertastatur findes allerede!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tastaturtema</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Ikke defineret</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Entfernen</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Benutzerdefinierten Eingabestil bearbeiten</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Gebietsschema</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Tastatur-Layout</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Dieser Eingabestil ist bereits vorhanden!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tastaturdesign</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Nicht definiert</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -61,7 +61,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Διαγραφή</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Επεξεργασία υποτύπου</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Ρυθμίσεις γλώσσας</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Διάταξη πληκτρολογίου</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Αυτός ο υποτύπος υπάρχει ήδη!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Θέμα πληκτρολογίου</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Μη ορισμένο</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -43,7 +43,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Forigi</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Redakti subspeco</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Lokaĵaro</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Klavaro</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Ĉi tiu subtipo jam ekzistas!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Klavaro etoso</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Nedifinita</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Eliminar</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Editar subtipo</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Localización</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Distribución de teclado</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">¡Este subtipo ya existe!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tema de teclado</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Sin definir</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">حذف</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">ویرایش زیر-نوعی</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">منطقه</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">چیدمان صفحه کلید</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">این زیرنوع درحال حاضر وجود دارد!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">طرح زمینه صفحه کلید</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">تعریف نشده</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -56,7 +56,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Poista</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Muokkaa asettelua</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Kielialue</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Näppäimistöasettelu</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Tämä asettelu on jo lisätty!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Näppäimistön teema</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Ei määritelty</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Supprimer</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Modifier la disposition</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Locale</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Disposition du clavier</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Cette disposition existe déjà !</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Thème du clavier</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Non défini</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Törlés</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Altípus szerkesztése</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Terület</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Billentyűzetkiosztás</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Ez az altípus már létezik!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Billentyűzet téma</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Nem meghatározott</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Elimina</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Modifica stile di input</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Localizzazione</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Layout della tastiera</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Questo stile di input esiste già !</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tema tastiera</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Sconosciuto</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -61,7 +61,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">מחק</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">ערוך תת-סוג</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">שפה</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">תצורת מקשים</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">תת הסוג הזה כבר קיים!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">ערכת נושא של המקלדת</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">לא מוגדר</string>

--- a/app/src/main/res/values-lv-rLV/strings.xml
+++ b/app/src/main/res/values-lv-rLV/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Izdzēst</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Labot apakšveidu</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Lokalizācija</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Tastatūras izkārtojums</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Šis apakšveids jau pastāv!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tastatūras izskats</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Nenoteikts</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Verwijderen</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Indeling bewerken</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Landinstelling</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Toetsenbordindeling</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Deze indeling bestaat al!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Toetsenbordthema</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Ongedefinieerd</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Usuń</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Edytuj układ</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Ustawienia regionalne</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Układ klawiatury</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Ten układ już istnieje!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Motyw klawiatury</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Niezdefiniowany</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Excluir</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Editar formato de digitação</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Idioma</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Formato do teclado</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Este formato de digitação já existe!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tema do teclado</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Indefinido</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Remover</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Editar subtipo</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Configuração regional</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Disposição de teclado</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Este subtipo já existe!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tema do teclado</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Indefinido</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Удалить</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Редактировать подтип</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Локализация</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Раскладка клавиатуры</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Этот подтип уже существует!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Тема клавиатуры</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Не определено</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -35,7 +35,6 @@
     <string name="settings__localization__subtype_cancel" comment="Subtype dialog cancel button">Откажи</string>
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Избриши</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Локал</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Распоред тастатуре</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Тема тастатуре</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Недефинисано</string>
     <string name="pref__theme__mode__label" comment="Label of the theme mode preference">Мод теме</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -58,7 +58,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Radera</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Redigera undertyp</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Språk</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Tangentbordslayout</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Denna undertyp finns redan!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Tangentbordstema</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Odefinierad</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -62,7 +62,6 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Видалити</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Редагувати підтип</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Локалізація</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Розкладка клавіатури</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">Цей підтип вже існує!</string>
     <string name="settings__theme__title" comment="Title of the Theme fragment">Тема клавіатури</string>
     <string name="settings__theme__undefined" comment="General string for an undefined preference value">Не визначено</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,14 @@
     <string name="settings__localization__subtype_delete" comment="Subtype dialog delete button">Delete</string>
     <string name="settings__localization__subtype_edit_title" comment="Title of subtype dialog when editing an existing subtype">Edit subtype</string>
     <string name="settings__localization__subtype_locale" comment="Label for locale dropdown in subtype dialog">Locale</string>
-    <string name="settings__localization__subtype_layout" comment="Label for keyboard layout dropdown in subtype dialog">Keyboard layout</string>
+    <string name="settings__localization__subtype_characters_layout" comment="Label for layout dropdown in subtype dialog">Characters layout</string>
+    <string name="settings__localization__subtype_symbols_layout" comment="Label for layout dropdown in subtype dialog">Symbols primary layout</string>
+    <string name="settings__localization__subtype_symbols2_layout" comment="Label for layout dropdown in subtype dialog">Symbols secondary layout</string>
+    <string name="settings__localization__subtype_numeric_layout" comment="Label for layout dropdown in subtype dialog">Numeric layout</string>
+    <string name="settings__localization__subtype_numeric_advanced_layout" comment="Label for layout dropdown in subtype dialog">Numeric (advanced) layout</string>
+    <string name="settings__localization__subtype_numeric_row_layout" comment="Label for layout dropdown in subtype dialog">Number row layout</string>
+    <string name="settings__localization__subtype_phone_layout" comment="Label for layout dropdown in subtype dialog">Phone primary layout</string>
+    <string name="settings__localization__subtype_phone2_layout" comment="Label for layout dropdown in subtype dialog">Phone secondary layout</string>
     <string name="settings__localization__subtype_error_already_exists" comment="Error message shown in subtype dialog when a subtype to add already exists">This subtype already exists!</string>
 
     <string name="settings__theme__title" comment="Title of the Theme fragment">Keyboard theme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="settings__localization__subtype_characters_layout" comment="Label for layout dropdown in subtype dialog">Characters layout</string>
     <string name="settings__localization__subtype_symbols_layout" comment="Label for layout dropdown in subtype dialog">Symbols primary layout</string>
     <string name="settings__localization__subtype_symbols2_layout" comment="Label for layout dropdown in subtype dialog">Symbols secondary layout</string>
+    <string name="settings__localization__subtype_currency_set" comment="Label for currency set dropdown in subtype dialog">Currency set</string>
     <string name="settings__localization__subtype_numeric_layout" comment="Label for layout dropdown in subtype dialog">Numeric layout</string>
     <string name="settings__localization__subtype_numeric_advanced_layout" comment="Label for layout dropdown in subtype dialog">Numeric (advanced) layout</string>
     <string name="settings__localization__subtype_numeric_row_layout" comment="Label for layout dropdown in subtype dialog">Number row layout</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,7 +75,7 @@
     <string name="settings__localization__subtype_characters_layout" comment="Label for layout dropdown in subtype dialog">Characters layout</string>
     <string name="settings__localization__subtype_symbols_layout" comment="Label for layout dropdown in subtype dialog">Symbols primary layout</string>
     <string name="settings__localization__subtype_symbols2_layout" comment="Label for layout dropdown in subtype dialog">Symbols secondary layout</string>
-    <string name="settings__localization__subtype_currency_set" comment="Label for currency set dropdown in subtype dialog">Currency set</string>
+    <string name="settings__localization__subtype_currency_set" comment="Label for currency set dropdown in subtype dialog. 'set' is used as a noun here and can be compared to a group of elements (in this case currency symbols).">Currency set</string>
     <string name="settings__localization__subtype_numeric_layout" comment="Label for layout dropdown in subtype dialog">Numeric layout</string>
     <string name="settings__localization__subtype_numeric_advanced_layout" comment="Label for layout dropdown in subtype dialog">Numeric (advanced) layout</string>
     <string name="settings__localization__subtype_numeric_row_layout" comment="Label for layout dropdown in subtype dialog">Number row layout</string>


### PR DESCRIPTION
This PR is a major improvement in implementing layouts for different languages and regions, as with this PR it is possible to add subtype specific layouts for all layout types, specifically for symbol and numeric layouts.

**Important**: This version changes the subtype internal preference syntax, causing a one-time reset of all defined subtypes, if they are found in the old syntax. This avoids that the app crashes when trying to open the subtype selection screen.

### Subtype specific layouts for all types

It is now possible to select custom layouts for all layout types and thus further customize the subtype:

![Screenshot_20210402-192323](https://user-images.githubusercontent.com/19412843/113440479-cc0e8280-93ec-11eb-99d7-e8b1db11b5d2.jpg)

With this, I also added some pre-defined symbol and numeric layouts for Arabic and Persian, no more left-to-right question mark for Arabic/Persian users :smile: 

![Screenshot_20210402-192418](https://user-images.githubusercontent.com/19412843/113440574-fe1fe480-93ec-11eb-88f9-33d5421aef54.jpg)

Closes #120
Closes #503 

### Currency sets

For now, there's a relative broad selection of currency sets available to choose from. The selection happens on a per-subtype basis, meaning you can freely choose `euro` for German and `dollar`for English for instance.

<table>
<tr>
<td colspan="2">Initially available sets</td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/19412843/113440061-fca1ec80-93eb-11eb-9363-201cc80165d9.jpg"></td>
<td><img src="https://user-images.githubusercontent.com/19412843/113440088-06c3eb00-93ec-11eb-85e1-765ea6a13c3e.jpg"></td>
</tr>
</table>

It is easy to add new curreency sets in the IME config json file by adding a currency set entry to the `currencySets` array. Note that adding custom currency sets in the runtime UI will come at a later stage (probably with layout customization but I am unsure).

Closes #210 
