### PR TITLE
Add support for proper display of Combining Diacritical Marks

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupManager.kt
@@ -127,7 +127,7 @@ class PopupManager<T_KBD: View, T_KV: View>(
                     }
                     else -> {
                         PopupExtendedView.Element.Label(
-                            keyView.getComputedLetter(keyView.data.popup[adjustedIndex]), adjustedIndex
+                            keyView.getComputedLetter(keyView.data.popup[adjustedIndex], isForDisplay = true), adjustedIndex
                         )
                     }
                 }

--- a/app/src/main/res/values/strings_dont_translate.xml
+++ b/app/src/main/res/values/strings_dont_translate.xml
@@ -13,6 +13,7 @@
     <string name="key__view_symbols2" translatable="false">=\\&lt;</string>
     <string name="key__view_half_space" translatable="false">&#8626;</string>
     <string name="key__view_keshida" translatable="false">"یــــ"</string>
+    <string name="key__dotted_circle" translatable="false">&#9676;</string>
 
     <!-- Media strings -->
     <string name="media__tab__emoticons_label" translatable="false">;-)</string>


### PR DESCRIPTION
This PR adds support for proper display of [Combining Diacritical Marks](https://en.wikipedia.org/wiki/Combining_Diacritical_Marks) by adding a dotted circle as the base character while rendered on a key. Done to support keyboard layouts like the IPA (#560).

![Screenshot_20210405-193530](https://user-images.githubusercontent.com/19412843/113606353-2d7e5d80-9648-11eb-94b7-a362812f85f2.jpg)
