### PR TITLE
Merge hints more flexibly

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
@@ -26,6 +26,7 @@ import dev.patrickgold.florisboard.ime.onehanded.OneHandedMode
 import dev.patrickgold.florisboard.ime.text.gestures.DistanceThreshold
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.gestures.VelocityThreshold
+import dev.patrickgold.florisboard.ime.text.key.KeyHintConfiguration
 import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
 import dev.patrickgold.florisboard.ime.text.key.UtilityKeyAction
 import dev.patrickgold.florisboard.ime.text.smartbar.CandidateView
@@ -397,6 +398,7 @@ class Preferences(
             const val KEY_SPACING_VERTICAL =                "keyboard__key_spacing_vertical"
             const val LANDSCAPE_INPUT_UI_MODE =             "keyboard__landscape_input_ui_mode"
             const val LONG_PRESS_DELAY =                    "keyboard__long_press_delay"
+            const val MERGE_HINT_POPUPS_ENABLED =           "keyboard__merge_hint_popups_enabled"
             const val NUMBER_ROW =                          "keyboard__number_row"
             const val ONE_HANDED_MODE =                     "keyboard__one_handed_mode"
             const val ONE_HANDED_MODE_SCALE_FACTOR =        "keyboard__one_handed_mode_scale_factor"
@@ -447,6 +449,9 @@ class Preferences(
         var longPressDelay: Int = 0
             get() = prefs.getPref(LONG_PRESS_DELAY, 300)
             private set
+        var mergeHintPopupsEnabled: Boolean
+            get() =  prefs.getPref(MERGE_HINT_POPUPS_ENABLED, false)
+            set(v) = prefs.setPref(MERGE_HINT_POPUPS_ENABLED, v)
         var numberRow: Boolean
             get() =  prefs.getPref(NUMBER_ROW, false)
             set(v) = prefs.setPref(NUMBER_ROW, v)
@@ -485,6 +490,10 @@ class Preferences(
         var vibrationStrength: Int = 0
             get() = prefs.getPref(VIBRATION_STRENGTH, -1)
             private set
+
+        fun getKeyHintConfiguration(): KeyHintConfiguration {
+            return KeyHintConfiguration(hintedSymbolsMode, hintedNumberRowMode, mergeHintPopupsEnabled)
+        }
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
@@ -28,7 +28,8 @@ import androidx.recyclerview.widget.RecyclerView
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.Preferences
-import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
+import dev.patrickgold.florisboard.ime.text.key.HINTS_DISABLED
+import dev.patrickgold.florisboard.ime.text.key.KeyHintConfiguration
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import kotlinx.coroutines.CoroutineScope
@@ -39,8 +40,7 @@ import kotlinx.coroutines.MainScope
  *
  * @property florisboard Reference to instance of core class [FlorisBoard].
  * @property emojiKeyboardView Reference to the parent [EmojiKeyboardView].
- * @property data The data the current key represents. Is used to determine rendering and possible
- *  behaviour when events occur.
+ * @property key The current key. Is used to determine rendering and possible behaviour when events occur.
  */
 @SuppressLint("ViewConstructor")
 class EmojiKeyView(
@@ -104,8 +104,8 @@ class EmojiKeyView(
                     (parent as RecyclerView)
                         .requestDisallowInterceptTouchEvent(true)
                     emojiKeyboardView.isScrollBlocked = true
-                    emojiKeyboardView.popupManager.show(key, KeyHintMode.DISABLED)
-                    emojiKeyboardView.popupManager.extend(key, KeyHintMode.DISABLED)
+                    emojiKeyboardView.popupManager.show(key, HINTS_DISABLED)
+                    emojiKeyboardView.popupManager.extend(key, HINTS_DISABLED)
                     florisboard?.keyPressVibrate()
                     florisboard?.keyPressSound()
                 }, delayMillis.toLong())
@@ -174,7 +174,7 @@ class EmojiKeyView(
 
         canvas ?: return
 
-        if (key.computedPopups.isNotEmpty()) {
+        if (key.computedPopups.getPopupKeys(HINTS_DISABLED).isNotEmpty()) {
             triangleDrawable?.draw(canvas)
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyHintConfiguration.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyHintConfiguration.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 ostrya
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.text.key
+
+data class KeyHintConfiguration(
+    val symbolHintMode: KeyHintMode,
+    val numberHintMode: KeyHintMode,
+    val mergeHintPopups: Boolean
+)
+
+val HINTS_DISABLED: KeyHintConfiguration = KeyHintConfiguration(KeyHintMode.DISABLED, KeyHintMode.DISABLED, false)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
@@ -26,7 +26,8 @@ class TextKey(override val data: KeyData) : Key(data) {
     var computedData: TextKeyData = TextKeyData.UNSPECIFIED
         private set
     val computedPopups: MutablePopupSet<TextKeyData> = MutablePopupSet()
-    var computedHint: TextKeyData? = null
+    var computedSymbolHint: TextKeyData? = null
+    var computedNumericHint: TextKeyData? = null
 
     fun compute(evaluator: TextComputingEvaluator) {
         val keyboardMode = evaluator.getKeyboard().mode
@@ -44,7 +45,8 @@ class TextKey(override val data: KeyData) : Key(data) {
         } else {
             computedData = computed
             computedPopups.clear()
-            computedPopups.hint = computedHint?.computeTextKeyData(evaluator)
+            computedPopups.hint = computedSymbolHint?.computeTextKeyData(evaluator)
+            computedPopups.merge(PopupSet(hint = computedNumericHint?.computeTextKeyData(evaluator)))
             if (computed is BasicTextKeyData && computed.popup != null) {
                 computedPopups.merge(computed.popup, evaluator)
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
@@ -27,7 +27,7 @@ class TextKey(override val data: KeyData) : Key(data) {
         private set
     val computedPopups: MutablePopupSet<TextKeyData> = MutablePopupSet()
     var computedSymbolHint: TextKeyData? = null
-    var computedNumericHint: TextKeyData? = null
+    var computedNumberHint: TextKeyData? = null
 
     fun compute(evaluator: TextComputingEvaluator) {
         val keyboardMode = evaluator.getKeyboard().mode
@@ -45,19 +45,7 @@ class TextKey(override val data: KeyData) : Key(data) {
         } else {
             computedData = computed
             computedPopups.clear()
-            val symbolHint = computedSymbolHint
-            val numericHint = computedNumericHint
-            if (symbolHint != null && numericHint != null) {
-                computedPopups.hint = symbolHint.computeTextKeyData(evaluator)
-                numericHint.computeTextKeyData(evaluator)?.let { computedPopups.relevant.add(it) }
-            } else if (symbolHint != null) {
-                computedPopups.hint = symbolHint.computeTextKeyData(evaluator)
-            } else if (numericHint != null) {
-                computedPopups.hint = numericHint.computeTextKeyData(evaluator)
-            }
-            if (computed is BasicTextKeyData && computed.popup != null) {
-                computedPopups.merge(computed.popup, evaluator)
-            }
+            mergePopups(computed, evaluator, computedPopups::merge)
             if (keyboardMode == KeyboardMode.CHARACTERS || keyboardMode == KeyboardMode.NUMERIC_ADVANCED ||
                 keyboardMode == KeyboardMode.SYMBOLS || keyboardMode == KeyboardMode.SYMBOLS2) {
                 val extLabel = when (computed.groupId) {
@@ -106,6 +94,24 @@ class TextKey(override val data: KeyData) : Key(data) {
                 computedPopups.apply {
                     keySpecificPopupSet?.let { merge(it, evaluator) }
                     popupSet?.let { merge(it, evaluator) }
+                }
+                val symbolHint = computedSymbolHint
+                if (symbolHint != null) {
+                    val evaluatedSymbolHint = symbolHint.computeTextKeyData(evaluator)
+                    computedPopups.symbolHint = evaluatedSymbolHint
+                    mergePopups(evaluatedSymbolHint, evaluator, computedPopups::mergeSymbolHint)
+                    val hintSpecificPopupSet = extendedPopups?.get(KeyVariation.ALL)?.get(symbolHint.label) ?:
+                            extendedPopupsDefault?.get(KeyVariation.ALL)?.get(symbolHint.label)
+                    hintSpecificPopupSet?.let { computedPopups.mergeSymbolHint(it, evaluator) }
+                }
+                val numericHint = computedNumberHint
+                if (numericHint != null) {
+                    val evaluatedNumberHint = numericHint.computeTextKeyData(evaluator)
+                    computedPopups.numberHint = evaluatedNumberHint
+                    mergePopups(evaluatedNumberHint, evaluator, computedPopups::mergeNumberHint)
+                    val hintSpecificPopupSet = extendedPopups?.get(KeyVariation.ALL)?.get(numericHint.label) ?:
+                    extendedPopupsDefault?.get(KeyVariation.ALL)?.get(numericHint.label)
+                    hintSpecificPopupSet?.let { computedPopups.mergeNumberHint(it, evaluator) }
                 }
             }
             isEnabled = evaluator.evaluateEnabled(computed)
@@ -158,6 +164,16 @@ class TextKey(override val data: KeyData) : Key(data) {
                     else -> 1.00
                 }
             }
+        }
+    }
+
+    private fun mergePopups(
+        keyData: TextKeyData?,
+        evaluator: TextComputingEvaluator,
+        merge: (popups: PopupSet<TextKeyData>, evaluator: TextComputingEvaluator) -> Unit
+    ) {
+        if (keyData is BasicTextKeyData && keyData.popup != null) {
+            merge(keyData.popup, evaluator)
         }
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
@@ -45,8 +45,16 @@ class TextKey(override val data: KeyData) : Key(data) {
         } else {
             computedData = computed
             computedPopups.clear()
-            computedPopups.hint = computedSymbolHint?.computeTextKeyData(evaluator)
-            computedPopups.merge(PopupSet(hint = computedNumericHint?.computeTextKeyData(evaluator)))
+            val symbolHint = computedSymbolHint
+            val numericHint = computedNumericHint
+            if (symbolHint != null && numericHint != null) {
+                computedPopups.hint = symbolHint.computeTextKeyData(evaluator)
+                numericHint.computeTextKeyData(evaluator)?.let { computedPopups.relevant.add(it) }
+            } else if (symbolHint != null) {
+                computedPopups.hint = symbolHint.computeTextKeyData(evaluator)
+            } else if (numericHint != null) {
+                computedPopups.hint = numericHint.computeTextKeyData(evaluator)
+            }
             if (computed is BasicTextKeyData && computed.popup != null) {
                 computedPopups.merge(computed.popup, evaluator)
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
@@ -26,6 +26,7 @@ import dev.patrickgold.florisboard.ime.extension.AssetRef
 import dev.patrickgold.florisboard.ime.extension.AssetSource
 import dev.patrickgold.florisboard.ime.popup.PopupExtension
 import dev.patrickgold.florisboard.ime.popup.PopupManager
+import dev.patrickgold.florisboard.ime.popup.PopupSet
 import dev.patrickgold.florisboard.ime.text.key.*
 import dev.patrickgold.florisboard.ime.text.keyboard.*
 import kotlinx.coroutines.*
@@ -207,22 +208,21 @@ class LayoutManager {
         // Add hints to keys
         if (keyboardMode == KeyboardMode.CHARACTERS) {
             val symbolsComputedArrangement = computeKeyboardAsync(KeyboardMode.SYMBOLS, subtype).await().arrangement
-            val minRow = if (prefs.keyboard.numberRow) { 1 } else { 0 }
+            // number row hint always happens on first row
+            if (prefs.keyboard.hintedNumberRowMode != KeyHintMode.DISABLED) {
+                val row = computedArrangement[0]
+                val symbolRow = symbolsComputedArrangement[0]
+                addRowHints(row, symbolRow, KeyType.NUMERIC)
+            }
+            // all other symbols are added bottom-aligned
+            val rOffset = computedArrangement.size - symbolsComputedArrangement.size
             for ((r, row) in computedArrangement.withIndex()) {
-                if (r >= (3 + minRow) || r < minRow) {
+                if (r < rOffset) {
                     continue
                 }
-                val symbolRow = symbolsComputedArrangement.getOrNull(r - minRow)
+                val symbolRow = symbolsComputedArrangement.getOrNull(r - rOffset)
                 if (symbolRow != null) {
-                    for ((k, key) in row.withIndex()) {
-                        val symbol = symbolRow.getOrNull(k)?.data?.computeTextKeyData(DefaultTextComputingEvaluator)
-                        val type = (key.data as? TextKeyData)?.type ?: KeyType.UNSPECIFIED
-                        if (r == minRow && type == KeyType.CHARACTER && symbol?.type == KeyType.NUMERIC) {
-                            key.computedHint = symbol
-                        } else if (r > minRow && type == KeyType.CHARACTER && symbol?.type == KeyType.CHARACTER) {
-                            key.computedHint = symbol
-                        }
-                    }
+                    addRowHints(row, symbolRow, KeyType.CHARACTER)
                 }
             }
         }
@@ -238,6 +238,35 @@ class LayoutManager {
                 flogWarning(LogTopic.LAYOUT_MANAGER) { it.toString() }
             }.getOrNull()?.mapping
         )
+    }
+
+    private fun addRowHints(main: Array<TextKey>, hint: Array<TextKey>, hintType: KeyType) {
+        for ((k,key) in main.withIndex()) {
+            val keyData = (key.data as? TextKeyData)
+            if (keyData?.type != KeyType.CHARACTER) {
+                continue
+            }
+            val hintKey = hint.getOrNull(k)?.data?.computeTextKeyData(DefaultTextComputingEvaluator)
+            if (hintKey?.type != hintType) {
+                continue
+            }
+
+            // if hint key is identical to main key, no merging is needed
+            if (hintKey.code == keyData.code) {
+                continue
+            }
+            when (hintType) {
+                KeyType.CHARACTER -> {
+                    key.computedSymbolHint = hintKey
+                }
+                KeyType.NUMERIC -> {
+                    key.computedNumericHint = hintKey
+                }
+                else -> {
+                    // do nothing
+                }
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
@@ -26,7 +26,6 @@ import dev.patrickgold.florisboard.ime.extension.AssetRef
 import dev.patrickgold.florisboard.ime.extension.AssetSource
 import dev.patrickgold.florisboard.ime.popup.PopupExtension
 import dev.patrickgold.florisboard.ime.popup.PopupManager
-import dev.patrickgold.florisboard.ime.popup.PopupSet
 import dev.patrickgold.florisboard.ime.text.key.*
 import dev.patrickgold.florisboard.ime.text.keyboard.*
 import kotlinx.coroutines.*
@@ -260,7 +259,7 @@ class LayoutManager {
                     key.computedSymbolHint = hintKey
                 }
                 KeyType.NUMERIC -> {
-                    key.computedNumericHint = hintKey
+                    key.computedNumberHint = hintKey
                 }
                 else -> {
                     // do nothing

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -169,6 +169,8 @@
     <string name="pref__keyboard__utility_key_action__switch_language" comment="Preference value">Sprache wechseln</string>
     <string name="pref__keyboard__utility_key_action__switch_keyboard_app" comment="Preference value">Tastatur-App wechseln</string>
     <string name="pref__keyboard__utility_key_action__dynamic_switch_language_emojis" comment="Preference value">Dynamisch: Zu Emojis / Sprache wechseln</string>
+    <string name="pref__keyboard__merge_hint_popups_enabled__label">Auch Symbol-Pop-Ups anzeigen</string>
+    <string name="pref__keyboard_merge_hint_popups_enabled__summary">Die Symbol-Pop-Ups zum Standardlayout hinzufügen</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Schriftgröße anpassen (Hochformat)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Schriftgröße anpassen (Querformat)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Layout</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,8 @@
     <string name="pref__keyboard__utility_key_action__switch_language" comment="Preference value">Switch language</string>
     <string name="pref__keyboard__utility_key_action__switch_keyboard_app" comment="Preference value">Switch keyboard app</string>
     <string name="pref__keyboard__utility_key_action__dynamic_switch_language_emojis" comment="Preference value">Dynamic: Switch to emojis / Switch language</string>
+    <string name="pref__keyboard__merge_hint_popups_enabled__label">Also show symbol popups</string>
+    <string name="pref__keyboard_merge_hint_popups_enabled__summary">Add the symbol popups to the default layout</string>
     <string name="pref__keyboard__font_size_multiplier_portrait__label" comment="Preference title">Font size multiplier (portrait)</string>
     <string name="pref__keyboard__font_size_multiplier_landscape__label" comment="Preference title">Font size multiplier (landscape)</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Layout</string>

--- a/app/src/main/res/xml/prefs_keyboard.xml
+++ b/app/src/main/res/xml/prefs_keyboard.xml
@@ -47,6 +47,13 @@
             app:title="@string/pref__keyboard__utility_key_action__label"
             app:useSimpleSummaryProvider="true"/>
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="keyboard__merge_hint_popups_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__keyboard__merge_hint_popups_enabled__label"
+            android:summary="@string/pref__keyboard_merge_hint_popups_enabled__summary"/>
+
         <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
             app:allowDividerAbove="false"
             android:defaultValue="100"


### PR DESCRIPTION
As discussed, I extracted my proposal for adding hints to the character layout in a more general fashion into a separate PR.

To allow symbol layouts with the same or more rows as the character
layout to be hinted more consistently, the hinting of the numeric row
is split from the rest of the symbol layout.

The numeric row hinting is always done in the first row. If the numeric
row is actually enabled, no additional hints will be shown (as hints
are only added to character type keys).

The symbol hinting is now bottom-aligned: hints from the last symbol
row are shown in the last character row.

Overall, only keys matching the expected type (numeric for numeric
row, character elsewhere) are iterated over. This allows also the
bottom row with the layout switch keys to be hinted.

Closes #618