### PR TITLE
Fix glide logic in TextInputManager

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -224,27 +224,6 @@ class EditorInstance private constructor(
                 ic.commitText(" ", 1)
             }
             ic.commitText(text, 1)
-            isPhantomSpaceActive = true
-            wasPhantomSpaceActiveLastUpdate = false
-            ic.endBatchEdit()
-            true
-        }
-    }
-
-    /**
-     * Replaces the previous word with the given [text]. Used to correct gestures.
-     */
-    fun commitGestureCorrection(text: String): Boolean {
-        val ic = inputConnection ?: return false
-        return if (isRawInputEditor) {
-            false
-        } else {
-            ic.beginBatchEdit()
-            markComposingRegion(Region(this, cachedInput.getWordForIndex(-1).start, cachedInput.getWordForIndex(-1).end))
-            ic.commitText(text, 1)
-            markComposingRegion(null)
-            isPhantomSpaceActive = true
-            wasPhantomSpaceActiveLastUpdate = false
             ic.endBatchEdit()
             true
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/GlideTypingManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/GlideTypingManager.kt
@@ -145,8 +145,7 @@ class GlideTypingManager : GlideTypingGesture.Listener, CoroutineScope by MainSc
 
             withContext(Dispatchers.Main) {
                 val textInputManager = TextInputManager.getInstance()
-                textInputManager.glideSuggestionsActive = true
-                textInputManager.hackyGlideSuggestionSkip = false
+                textInputManager.isGlidePostEffect = true
                 textInputManager.smartbarView?.setCandidateSuggestionWords(
                     System.nanoTime(),
                     suggestions.take(maxSuggestionsToShow).map { textInputManager.fixCase(it) }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/KeyView.kt
@@ -355,6 +355,7 @@ class KeyView(
                 longKeyPressHandler.cancelAll()
                 if (hasTriggeredGestureMove && data.code == KeyCode.DELETE) {
                     florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.cancel(data))
+                    florisboard.textInputManager.isGlidePostEffect = false
                     florisboard.activeEditorInstance.apply {
                         if (selection.isSelectionMode) {
                             deleteBackwards()


### PR DESCRIPTION
Fixes #581
Fixes #595
Fixes #604

@X-yl I've investigated into several glide suggestion issues and now changed some parts of the glide suggestion logic in the TextInputManager. Most importantly, I've eliminated the `hackyGlideSuggestionSkip` variable, because it was indeed very hacky :) When a glide word is now typed in, the phantom space flag is purposely not set, this way we can use the suggestion click logic without injecting some extra logic for glide typing. Furthermore, when manual typing in a letter after a glided word, a space is now set (except for characters like !?. etc.). The delete word feature now also resets when either clicking on a provided suggestion or when manual typing in a letter.

Could you check if I didn't accidentally remove a useful feature/functionality for the behavior directly after a glide word was typed in and also check if you can also not reproduce the bugs anymore? This would be very helpful!