### PR TITLE
OutOfMemory: Fix 1

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/debug/LogTopic.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/debug/LogTopic.kt
@@ -33,5 +33,7 @@ object LogTopic {
 
     const val IMS_EVENTS: FlogTopic =           1u
     const val KEY_EVENTS: FlogTopic =           2u
+    const val GLIDE: FlogTopic =                512u
+    const val CLIPBOARD: FlogTopic =            1024u
     const val CRASH_UTILITY: FlogTopic =        2048u
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/ClipboardHistoryItemAdapter.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/ClipboardHistoryItemAdapter.kt
@@ -97,7 +97,7 @@ class ClipboardHistoryItemAdapter(
                 viewHolder.imgView.visibility = GONE
                 // For very large images, this can take a bit
                 FlorisClipboardManager.getInstance().executor.execute {
-                    val resolver = FlorisBoard.getInstance().context.contentResolver
+                    val resolver = FlorisBoard.getInstance().contentResolver
                     val inputStream = resolver.openInputStream(uri!!)
 
                     val drawable = Drawable.createFromStream(inputStream, "clipboard URI")

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FileStorage.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FileStorage.kt
@@ -1,45 +1,39 @@
 package dev.patrickgold.florisboard.ime.clip.provider
 
 import android.net.Uri
+import dev.patrickgold.florisboard.debug.*
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
-import timber.log.Timber
 import java.io.File
+import java.io.InputStream
 
 /**
- * Backend class which is used by [FlorisContentProvider] to serve content.
+ * Backend helper object which is used by [FlorisContentProvider] to serve content.
  */
-class FileStorage private constructor() {
-
-
-    companion object {
-        private const val BUF_SIZE = 1024 * 8
-        private var instance: FileStorage? = null
-        private var offset = 0
-
-
-        fun getInstance() : FileStorage {
-            if (this.instance == null){
-                this.instance = FileStorage()
-            }
-            return instance!!
-        }
-
-    }
-
+object FileStorage {
+    private const val BUF_SIZE = 1024 * 8
+    private var offset = 0
 
     /**
      * Clones a content URI to internal storage.
+     *
      * @param uri The URI
-     * @return  the file's name which is a unique long
+     * @return The file's name which is a unique long
      */
     @Synchronized
-    fun cloneURI(uri: Uri) : Long {
-        val context = FlorisBoard.getInstance().context
+    fun cloneURI(uri: Uri): Result<Long> {
+        val context = FlorisBoard.getInstance()
         // nanoTime + the number of items created so that it's unique.
         val name = (System.nanoTime() + offset)
 
         // Just a normal copy from input stream to output stream.
-        val source = context.contentResolver.openInputStream(uri)!!
+        val source: InputStream
+        try {
+            source = context.contentResolver.openInputStream(uri) ?: return Result.failure(
+                NullPointerException("Input stream for given URI '$uri' is null!")
+            )
+        } catch (e: Exception) {
+            return Result.failure(e)
+        }
         val sink = File(context.filesDir, name.toString()).outputStream()
         var nread = 0L
         val buf = ByteArray(BUF_SIZE)
@@ -52,14 +46,14 @@ class FileStorage private constructor() {
         source.close()
         sink.close()
 
-        return name
+        return Result.success(name)
     }
 
     /**
      * Deletes the file corresponding to an id.
      */
     fun deleteById(id: Long) {
-        Timber.d("Cleaning up $id")
+        flogDebug(LogTopic.CLIPBOARD) { "Cleaning up $id" }
         val file = File(FlorisBoard.getInstance().filesDir, id.toString())
         file.delete()
     }
@@ -70,6 +64,4 @@ class FileStorage private constructor() {
     fun getAddress(id: Long): String {
         return FlorisBoard.getInstance().filesDir.toString() + "/$id"
     }
-
-
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisContentProvider.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisContentProvider.kt
@@ -6,10 +6,13 @@ import android.net.Uri
 import android.os.ParcelFileDescriptor
 import androidx.room.Room
 import dev.patrickgold.florisboard.BuildConfig
-import dev.patrickgold.florisboard.ime.core.FlorisBoard
+import dev.patrickgold.florisboard.debug.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.File
-import java.util.concurrent.ExecutorService
 
 /**
  * Allows apps to access images on the clipboard.
@@ -20,7 +23,27 @@ import java.util.concurrent.ExecutorService
 class FlorisContentProvider : ContentProvider() {
     private lateinit var fileUriDao: FileUriDao
     private val mimeTypes: HashMap<Long, Array<String>> = hashMapOf()
-    private lateinit var executor: ExecutorService
+    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    companion object {
+        const val AUTHORITY = "${BuildConfig.APPLICATION_ID}.provider.clip"
+        val CONTENT_URI: Uri = Uri.parse("content://$AUTHORITY")
+        val CLIPS_URI: Uri = Uri.parse("content://$AUTHORITY/clips")
+
+        private var instance: FlorisContentProvider? = null
+
+        fun getInstance(): FlorisContentProvider {
+            return instance!!
+        }
+
+        private const val CLIPS_TABLE = 1
+        private const val CLIP_ITEM = 0
+
+        val matcher: UriMatcher = UriMatcher(UriMatcher.NO_MATCH).apply {
+            addURI(AUTHORITY, "clips/#", CLIP_ITEM)
+            addURI(AUTHORITY, "clips", CLIPS_TABLE)
+        }
+    }
 
     override fun onCreate(): Boolean {
         instance = this
@@ -32,13 +55,11 @@ class FlorisContentProvider : ContentProvider() {
             return
         }
 
-
         fileUriDao = Room.databaseBuilder(
             context!!,
             FileUriDatabase::class.java, "fileuridb"
         ).build().fileUriDao()
 
-        executor = FlorisBoard.getInstance().asyncExecutor
         for (fileUri in fileUriDao.getAll()) {
             mimeTypes[fileUri.fileName] = fileUri.mimeTypes
         }
@@ -65,7 +86,7 @@ class FlorisContentProvider : ContentProvider() {
 
     override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor {
         val id = ContentUris.parseId(uri)
-        val path = File(FileStorage.getInstance().getAddress(id))
+        val path = File(FileStorage.getAddress(id))
 
         // Nothing has permission to write anyway.
         return ParcelFileDescriptor.open(path, ParcelFileDescriptor.MODE_READ_ONLY)
@@ -74,16 +95,18 @@ class FlorisContentProvider : ContentProvider() {
     override fun insert(uri: Uri, values: ContentValues?): Uri {
         when (matcher.match(uri)){
             CLIPS_TABLE -> {
-                val id = FileStorage.getInstance().cloneURI(Uri.parse(values?.getAsString("uri")))
+                val id = FileStorage.cloneURI(Uri.parse(values?.getAsString("uri"))).getOrElse {
+                    flogError(LogTopic.CLIPBOARD) { it.toString() }
+                    return uri.buildUpon().appendPath("0").build()
+                }
                 val mimes =  values?.getAsString("mimetypes")?.split(",")?.toTypedArray()
                 mimes?.let {
                     mimeTypes[id] = mimes
-                    executor.execute {
+                    ioScope.launch {
                         Timber.d("Inserted file uri $id")
                         fileUriDao.insert(FileUri(id, mimes))
                     }
                 }
-
                 return ContentUris.withAppendedId(CLIPS_URI, id)
             }
             else -> throw IllegalArgumentException("Don't know what this is $uri")
@@ -94,10 +117,10 @@ class FlorisContentProvider : ContentProvider() {
         when (matcher.match(uri)){
             CLIP_ITEM -> {
                 val id = ContentUris.parseId(uri)
-                FileStorage.getInstance().deleteById(id)
+                FileStorage.deleteById(id)
                 mimeTypes.remove(id)
                 context?.revokeUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                executor.execute {
+                ioScope.launch {
                     fileUriDao.delete(id)
                 }
                 return 1
@@ -108,24 +131,5 @@ class FlorisContentProvider : ContentProvider() {
 
     override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String>?): Int {
         throw IllegalArgumentException("This ContentProvider does not support update.")
-    }
-
-    companion object {
-        private var instance: FlorisContentProvider? = null
-        const val AUTHORITY = "${BuildConfig.APPLICATION_ID}.provider.clip"
-        val CONTENT_URI: Uri = Uri.parse("content://$AUTHORITY")
-        val CLIPS_URI: Uri = Uri.parse("content://$AUTHORITY/clips")
-
-        fun getInstance(): FlorisContentProvider {
-            return instance!!
-        }
-
-        private const val CLIPS_TABLE = 1
-        private const val CLIP_ITEM = 0
-
-        val matcher: UriMatcher = UriMatcher(UriMatcher.NO_MATCH).apply {
-            addURI(AUTHORITY, "clips/#", CLIP_ITEM)
-            addURI(AUTHORITY, "clips", CLIPS_TABLE)
-        }
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
@@ -8,7 +8,6 @@ import androidx.room.*
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import java.io.Closeable
 
-
 enum class ItemType(val value: Int) {
     TEXT(1),
     IMAGE(2);
@@ -19,7 +18,6 @@ enum class ItemType(val value: Int) {
         }
     }
 }
-
 
 /**
  * Represents an item on the clipboard.
@@ -43,7 +41,7 @@ data class ClipboardItem(
     fun toClipData(): ClipData {
         return when (type) {
             ItemType.IMAGE -> {
-                ClipData.newUri(FlorisBoard.getInstance().context.contentResolver, "Clipboard data", uri)
+                ClipData.newUri(FlorisBoard.getInstance().contentResolver, "Clipboard data", uri)
             }
             ItemType.TEXT -> {
                 ClipData.newPlainText("Clipboard data", text)
@@ -56,7 +54,7 @@ data class ClipboardItem(
      */
     override fun close() {
         if (type == ItemType.IMAGE) {
-            FlorisBoard.getInstance().context.contentResolver.delete(this.uri!!, null, null)
+            FlorisBoard.getInstance().contentResolver.delete(this.uri!!, null, null)
         }
     }
 
@@ -120,7 +118,7 @@ data class ClipboardItem(
                             put("uri", data.getItemAt(0).uri.toString())
                             put("mimetypes", data.description.filterMimeTypes("*/*").joinToString(","))
                         }
-                        FlorisBoard.getInstance().context.contentResolver.insert(FlorisContentProvider.CLIPS_URI, values)
+                        FlorisBoard.getInstance().contentResolver.insert(FlorisContentProvider.CLIPS_URI, values)
                     }
             } else { null }
 
@@ -174,7 +172,6 @@ class Converters {
     }
 }
 
-
 @Dao
 interface PinnedClipboardItemDao {
     @Query("SELECT * FROM pins")
@@ -199,7 +196,7 @@ abstract class PinnedItemsDatabase : RoomDatabase() {
 
             if (instance == null) {
                 instance = Room.databaseBuilder(
-                    FlorisBoard.getInstance().context,
+                    FlorisBoard.getInstance(),
                     PinnedItemsDatabase::class.java,
                     "pins").build()
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -262,7 +262,7 @@ class EditorInstance private constructor(
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
                     flags = flags or InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION
                 } else {
-                    FlorisBoard.getInstance().context.grantUriPermission(
+                    FlorisBoard.getInstance().grantUriPermission(
                         editorInfo.packageName,
                         item.uri,
                         Intent.FLAG_GRANT_READ_URI_PERMISSION
@@ -275,7 +275,6 @@ class EditorInstance private constructor(
             }
         }
     }
-
 
     /**
      * Executes a backward delete on this editor's text. If a text selection is active, all

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
@@ -162,8 +162,8 @@ class MediaInputManager private constructor() : CoroutineScope by MainScope(),
     private fun createTabViewFor(tab: Tab): LinearLayout {
         return when (tab) {
             Tab.EMOJI -> EmojiKeyboardView(florisboard)
-            Tab.EMOTICON -> EmoticonKeyboardView(florisboard.context)
-            else -> LinearLayout(florisboard.context).apply {
+            Tab.EMOTICON -> EmoticonKeyboardView(florisboard)
+            else -> LinearLayout(florisboard).apply {
                 addView(TextView(context).apply {
                     text = "not yet implemented"
                 })

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -79,7 +79,6 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
     private val dictionaryManager: DictionaryManager = DictionaryManager.default()
     private var activeDictionary: Dictionary<String, Int>? = null
     val inputEventDispatcher: InputEventDispatcher = InputEventDispatcher.new(
-        parentScope = this,
         repeatableKeyCodes = intArrayOf(
             KeyCode.ARROW_DOWN,
             KeyCode.ARROW_LEFT,
@@ -146,11 +145,15 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
     }
 
     override fun onCreateInputView() {
-        keyboardViews.clear()
+        flogInfo(LogTopic.IMS_EVENTS) { "onCreateInputView()" }
+
+        if (keyboardViews.isNotEmpty()) {
+            keyboardViews.clear()
+        }
     }
 
     private suspend fun addKeyboardView(mode: KeyboardMode) {
-        val keyboardView = KeyboardView(florisboard.context)
+        val keyboardView = KeyboardView(florisboard)
         keyboardView.computedLayout = layoutManager.fetchComputedLayoutAsync(mode, florisboard.activeSubtype, florisboard.prefs, florisboard.subtypeManager.getCurrencySet(florisboard.activeSubtype)).await()
         keyboardViews[mode] = keyboardView
         textViewFlipper?.addView(keyboardView)
@@ -342,7 +345,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
                     }
                 }
             }
-            if (PrefHelper.getDefaultInstance(florisboard.context).glide.enabled) {
+            if (PrefHelper.getDefaultInstance(florisboard).glide.enabled) {
                 GlideTypingManager.getInstance().setWordData(newSubtype)
             }
             // TODO: heavy load on main thread
@@ -471,7 +474,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
     }
 
     override fun onSmartbarPrivateModeButtonClicked() {
-        Toast.makeText(florisboard.context, R.string.private_mode_dialog__title, Toast.LENGTH_LONG).show()
+        Toast.makeText(florisboard, R.string.private_mode_dialog__title, Toast.LENGTH_LONG).show()
     }
 
     override fun onSmartbarQuickActionPressed(quickActionId: Int) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/GlideTypingManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/GlideTypingManager.kt
@@ -29,7 +29,7 @@ class GlideTypingManager : GlideTypingGesture.Listener, CoroutineScope by MainSc
         fun getInstance(): GlideTypingManager {
             if (!this::glideTypingManager.isInitialized) {
                 glideTypingManager = GlideTypingManager()
-                glideTypingManager.prefHelper = PrefHelper.getDefaultInstance(FlorisBoard.getInstance().context)
+                glideTypingManager.prefHelper = FlorisBoard.getInstance().prefs
             }
             return glideTypingManager
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/KeyboardView.kt
@@ -240,7 +240,7 @@ class KeyboardView : FlexboxLayout, FlorisBoard.EventListener, SwipeGesture.List
                 activeKeyViews.remove(pointerId)
             }
             invalidate()
-            this.gesturing = true
+            gesturing = true
             return true
         }
 
@@ -473,10 +473,10 @@ class KeyboardView : FlexboxLayout, FlorisBoard.EventListener, SwipeGesture.List
             }
         }
         if (theme.getAttr(Theme.Attr.GLIDE_TRAIL_COLOR).toSolidColor().color == 0) {
-            this.glideTrailPaint.color = theme.getAttr(Theme.Attr.WINDOW_COLOR_PRIMARY).toSolidColor().color
-            this.glideTrailPaint.alpha = 32
+            glideTrailPaint.color = theme.getAttr(Theme.Attr.WINDOW_COLOR_PRIMARY).toSolidColor().color
+            glideTrailPaint.alpha = 32
         } else {
-            this.glideTrailPaint.color = theme.getAttr(Theme.Attr.GLIDE_TRAIL_COLOR).toSolidColor().color
+            glideTrailPaint.color = theme.getAttr(Theme.Attr.GLIDE_TRAIL_COLOR).toSolidColor().color
         }
     }
 
@@ -580,30 +580,26 @@ class KeyboardView : FlexboxLayout, FlorisBoard.EventListener, SwipeGesture.List
     }
 
     override fun onGestureAdd(point: GlideTypingGesture.Detector.Position) {
-        val initialRadius = 25f
-        val gestureData = this.gestureDataForDrawing
-        val targetDist = 5f
-        val maxLength = 1000f
         if (prefs.glide.enabled) {
-            this.gestureDataForDrawing.add(point)
+            gestureDataForDrawing.add(point)
         }
     }
 
     override fun onGestureCancelled() {
         if (prefs.glide.showTrail) {
-            this.fadingGesture.clear()
-            this.fadingGesture.addAll(gestureDataForDrawing)
+            fadingGesture.clear()
+            fadingGesture.addAll(gestureDataForDrawing)
 
             val animator = ValueAnimator.ofFloat(20f, 0f)
             animator.interpolator = AccelerateInterpolator()
             animator.duration = prefs.glide.trailDuration.toLong()
             animator.addUpdateListener {
-                this.fadingGestureRadius = it.animatedValue as Float
-                this.invalidate()
+                fadingGestureRadius = it.animatedValue as Float
+                invalidate()
             }
             animator.start()
 
-            this.gestureDataForDrawing.clear()
+            gestureDataForDrawing.clear()
             gesturing = false
             invalidate()
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/util/summarize_utils.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/util/summarize_utils.kt
@@ -22,23 +22,25 @@ import android.view.inputmethod.EditorInfo
 import kotlin.reflect.KClass
 
 fun EditorInfo.debugSummarize(): String {
-    var summary = this::class.qualifiedName + "\r\n"
-    summary += "imeOptions: " + this.imeOptions.debugSummarize(EditorInfo::class) + "\r\n"
-    summary += "initialCapsMode: " + this.initialCapsMode.debugSummarize(TextUtils::class) + "\r\n"
-    summary += "initialSelStart: " + this.initialSelStart + "\r\n"
-    summary += "initialSelEnd: " + this.initialSelEnd + "\r\n"
-    summary += "inputType: " + this.inputType.debugSummarize(InputType::class) + "\r\n"
-    summary += "packageName: " + this.packageName
-    return summary
+    return StringBuilder().let {
+        it.appendLine(this::class.qualifiedName)
+        it.append("imeOptions: ").appendLine(this.imeOptions.debugSummarize(EditorInfo::class))
+        it.append("initialCapsMode: ").appendLine(this.initialCapsMode.debugSummarize(TextUtils::class))
+        it.append("initialSelStart: ").appendLine(this.initialSelStart)
+        it.append("initialSelEnd: ").appendLine(this.initialSelEnd)
+        it.append("inputType: ").appendLine(this.inputType.debugSummarize(InputType::class))
+        it.append("packageName: ").appendLine(this.packageName)
+        it.toString()
+    }
 }
 
 fun <T: Any> Int.debugSummarize(type: KClass<T>): String {
-    var summary = ""
+    val summary = StringBuilder()
     when (type) {
         EditorInfo::class -> {
             when (this) {
                 EditorInfo.IME_NULL -> {
-                    summary += "IME_NULL"
+                    summary.append("IME_NULL")
                 }
                 else -> {
                     val tAction = when (this and EditorInfo.IME_MASK_ACTION) {
@@ -52,50 +54,50 @@ fun <T: Any> Int.debugSummarize(type: KClass<T>): String {
                         EditorInfo.IME_ACTION_UNSPECIFIED -> "IME_ACTION_UNSPECIFIED"
                         else -> String.format("0x%08x", this and EditorInfo.IME_MASK_ACTION)
                     }
-                    var tFlags = ""
+                    val tFlags = StringBuilder()
                     if (this and EditorInfo.IME_FLAG_FORCE_ASCII > 0) {
-                        tFlags += "IME_FLAG_FORCE_ASCII|"
+                        tFlags.append("IME_FLAG_FORCE_ASCII|")
                     }
                     if (this and EditorInfo.IME_FLAG_NAVIGATE_NEXT > 0) {
-                        tFlags += "IME_FLAG_NAVIGATE_NEXT|"
+                        tFlags.append("IME_FLAG_NAVIGATE_NEXT|")
                     }
                     if (this and EditorInfo.IME_FLAG_NAVIGATE_PREVIOUS > 0) {
-                        tFlags += "IME_FLAG_NAVIGATE_PREVIOUS|"
+                        tFlags.append("IME_FLAG_NAVIGATE_PREVIOUS|")
                     }
                     if (this and EditorInfo.IME_FLAG_NO_ACCESSORY_ACTION > 0) {
-                        tFlags += "IME_FLAG_NO_ACCESSORY_ACTION|"
+                        tFlags.append("IME_FLAG_NO_ACCESSORY_ACTION|")
                     }
                     if (this and EditorInfo.IME_FLAG_NO_ENTER_ACTION > 0) {
-                        tFlags += "IME_FLAG_NO_ENTER_ACTION|"
+                        tFlags.append("IME_FLAG_NO_ENTER_ACTION|")
                     }
                     if (this and EditorInfo.IME_FLAG_NO_EXTRACT_UI > 0) {
-                        tFlags += "IME_FLAG_NO_EXTRACT_UI|"
+                        tFlags.append("IME_FLAG_NO_EXTRACT_UI|")
                     }
                     if (this and EditorInfo.IME_FLAG_NO_FULLSCREEN > 0) {
-                        tFlags += "IME_FLAG_NO_FULLSCREEN|"
+                        tFlags.append("IME_FLAG_NO_FULLSCREEN|")
                     }
                     if (this and EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING > 0) {
-                        tFlags += "IME_FLAG_NO_PERSONALIZED_LEARNING|"
+                        tFlags.append("IME_FLAG_NO_PERSONALIZED_LEARNING|")
                     }
                     if (tFlags.isEmpty()) {
-                        tFlags = "(none)"
+                        tFlags.append("(none)")
                     }
                     if (tFlags.endsWith("|")) {
-                        tFlags = tFlags.substring(0, tFlags.length - 1)
+                        tFlags.deleteAt(tFlags.length - 1)
                     }
-                    summary += "action=$tAction flags=$tFlags"
+                    summary.append("action=$tAction flags=$tFlags")
                 }
             }
         }
         InputType::class -> {
             when (this) {
                 InputType.TYPE_NULL -> {
-                    summary += "TYPE_NULL"
+                    summary.append("TYPE_NULL")
                 }
                 else -> {
                     val tClass: String
                     val tVariation: String
-                    var tFlags = ""
+                    val tFlags = StringBuilder()
                     when (this and InputType.TYPE_MASK_CLASS) {
                         InputType.TYPE_CLASS_DATETIME -> {
                             tClass = "TYPE_CLASS_DATETIME"
@@ -114,10 +116,10 @@ fun <T: Any> Int.debugSummarize(type: KClass<T>): String {
                                 else -> String.format("0x%08x", this and InputType.TYPE_MASK_VARIATION)
                             }
                             if (this and InputType.TYPE_NUMBER_FLAG_DECIMAL > 0) {
-                                tFlags += "TYPE_NUMBER_FLAG_DECIMAL|"
+                                tFlags.append("TYPE_NUMBER_FLAG_DECIMAL|")
                             }
                             if (this and InputType.TYPE_NUMBER_FLAG_SIGNED > 0) {
-                                tFlags += "TYPE_NUMBER_FLAG_SIGNED|"
+                                tFlags.append("TYPE_NUMBER_FLAG_SIGNED|")
                             }
                         }
                         InputType.TYPE_CLASS_PHONE -> {
@@ -145,28 +147,28 @@ fun <T: Any> Int.debugSummarize(type: KClass<T>): String {
                                 else -> String.format("0x%08x", this and InputType.TYPE_MASK_VARIATION)
                             }
                             if (this and InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE > 0) {
-                                tFlags += "TYPE_TEXT_FLAG_AUTO_COMPLETE|"
+                                tFlags.append("TYPE_TEXT_FLAG_AUTO_COMPLETE|")
                             }
                             if (this and InputType.TYPE_TEXT_FLAG_AUTO_CORRECT > 0) {
-                                tFlags += "TYPE_TEXT_FLAG_AUTO_CORRECT|"
+                                tFlags.append("TYPE_TEXT_FLAG_AUTO_CORRECT|")
                             }
                             if (this and InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS > 0) {
-                                tFlags += "TYPE_TEXT_FLAG_CAP_CHARACTERS|"
+                                tFlags.append("TYPE_TEXT_FLAG_CAP_CHARACTERS|")
                             }
                             if (this and InputType.TYPE_TEXT_FLAG_CAP_SENTENCES > 0) {
-                                tFlags += "TYPE_TEXT_FLAG_CAP_SENTENCES|"
+                                tFlags.append("TYPE_TEXT_FLAG_CAP_SENTENCES|")
                             }
                             if (this and InputType.TYPE_TEXT_FLAG_CAP_WORDS > 0) {
-                                tFlags += "TYPE_TEXT_FLAG_CAP_WORDS|"
+                                tFlags.append("TYPE_TEXT_FLAG_CAP_WORDS|")
                             }
                             if (this and InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE > 0) {
-                                tFlags += "TYPE_TEXT_FLAG_IME_MULTI_LINE|"
+                                tFlags.append("TYPE_TEXT_FLAG_IME_MULTI_LINE|")
                             }
                             if (this and InputType.TYPE_TEXT_FLAG_MULTI_LINE > 0) {
-                                tFlags += "TYPE_TEXT_FLAG_MULTI_LINE|"
+                                tFlags.append("TYPE_TEXT_FLAG_MULTI_LINE|")
                             }
                             if (this and InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS > 0) {
-                                tFlags += "TYPE_TEXT_FLAG_NO_SUGGESTIONS|"
+                                tFlags.append("TYPE_TEXT_FLAG_NO_SUGGESTIONS|")
                             }
                         }
                         else -> {
@@ -175,43 +177,43 @@ fun <T: Any> Int.debugSummarize(type: KClass<T>): String {
                         }
                     }
                     if (tFlags.isEmpty()) {
-                        tFlags = "(none)"
+                        tFlags.append("(none)")
                     }
                     if (tFlags.endsWith("|")) {
-                        tFlags = tFlags.substring(0, tFlags.length - 1)
+                        tFlags.deleteAt(tFlags.length - 1)
                     }
-                    summary += "class=$tClass variation=$tVariation flags=$tFlags"
+                    summary.append("class=$tClass variation=$tVariation flags=$tFlags")
                 }
             }
         }
         TextUtils::class -> {
-            var tFlags = ""
+            val tFlags = StringBuilder()
             if (this and TextUtils.CAP_MODE_CHARACTERS > 0) {
-                tFlags += "CAP_MODE_CHARACTERS|"
+                tFlags.append("CAP_MODE_CHARACTERS|")
             }
             if (this and TextUtils.CAP_MODE_SENTENCES > 0) {
-                tFlags += "CAP_MODE_SENTENCES|"
+                tFlags.append("CAP_MODE_SENTENCES|")
             }
             if (this and TextUtils.CAP_MODE_WORDS > 0) {
-                tFlags += "CAP_MODE_WORDS|"
+                tFlags.append("CAP_MODE_WORDS|")
             }
             if (this and TextUtils.SAFE_STRING_FLAG_FIRST_LINE > 0) {
-                tFlags += "SAFE_STRING_FLAG_FIRST_LINE|"
+                tFlags.append("SAFE_STRING_FLAG_FIRST_LINE|")
             }
             if (this and TextUtils.SAFE_STRING_FLAG_SINGLE_LINE > 0) {
-                tFlags += "SAFE_STRING_FLAG_SINGLE_LINE|"
+                tFlags.append("SAFE_STRING_FLAG_SINGLE_LINE|")
             }
             if (this and TextUtils.SAFE_STRING_FLAG_TRIM > 0) {
-                tFlags += "SAFE_STRING_FLAG_TRIM|"
+                tFlags.append("SAFE_STRING_FLAG_TRIM|")
             }
             if (tFlags.isEmpty()) {
-                tFlags = "(none)"
+                tFlags.append("(none)")
             }
             if (tFlags.endsWith("|")) {
-                tFlags = tFlags.substring(0, tFlags.length - 1)
+                tFlags.deleteAt(tFlags.length - 1)
             }
-            summary += "flags=$tFlags"
+            summary.append("flags=$tFlags")
         }
     }
-    return summary
+    return summary.toString()
 }


### PR DESCRIPTION
This PR is an initial attempt at reducing the memory strain and improving the codebase. This PR alone will not introduce noticeable changes for the crashes (I think). You are of course free to try the debug APK out and see if anything regarding the OOM issues have changed. Note that this PR assumes you have glide typing and suggestions disabled (will be addressed by future PRs).

During inspections of memory allocations, a few things could be seen by me:
- The average memory consumption over a larger timeframe is increasing very slowly, which means in general the GC is able to pick up and remove unused objects and the number of memory leaks is low.
- When typing a lot in a relatively short timeframe, a lot of memory allocations are done, which leads to enormous spikes in memory usage. This can easily lead to hitting the max. RAM usage limit before the GC has the ability to get rid of the objects, which then throws the infamous OOM exceptions. The primary goal in the next `oom-fix2` PR will be to remove the need to allocate so many new objects and also experiment with moving memory-intensive objects such as the layout and event objects to native code (C++). This should remove a lot of unneeded overhead for objects in the JVM and is especially useful for objects which exists in hundreds, if not thousands, such as KeyData and InputKeyEvent.

Additionally this PR cleans up quite some code (removing/adding spaces, new lines, etc., which I noticed during reading through the code).

---

Related #677 

---

Fix #699 