### PR TITLE
Add support for Colemak-DHm layout

### DIFF
--- a/app/src/main/assets/ime/text/characters/colemak-dhm.json
+++ b/app/src/main/assets/ime/text/characters/colemak-dhm.json
@@ -1,0 +1,46 @@
+{
+  "type": "characters",
+  "name": "colemak-dhm",
+  "label": "Colemak-DHm",
+  "authors": [ "SteveP" ],
+  "direction": "ltr",
+  "arrangement": [
+    [
+      { "code":  113, "label": "q" },
+      { "code":  119, "label": "w" },
+      { "code":  102, "label": "f" },
+      { "code":  112, "label": "p" },
+      { "code":   98, "label": "b" },
+      { "code":  106, "label": "j" },
+      { "code":  108, "label": "l" },
+      { "code":  117, "label": "u" },
+      { "code":  121, "label": "y" },
+      { "code":   59, "label": ";", "popup": {
+        "relevant": [
+          { "code":   58, "label": ":" }
+        ]
+      }, "shift": { "code":   58, "label": ":" } }
+    ],
+    [
+      { "code":   97, "label": "a" },
+      { "code":  114, "label": "r" },
+      { "code":  115, "label": "s" },
+      { "code":  116, "label": "t" },
+      { "code":  103, "label": "g" },
+      { "code":  109, "label": "m" },
+      { "code":  110, "label": "n" },
+      { "code":  101, "label": "e" },
+      { "code":  105, "label": "i" },
+      { "code":  111, "label": "o" }
+    ],
+    [
+      { "code":  122, "label": "z" },
+      { "code":  120, "label": "x" },
+      { "code":   99, "label": "c" },
+      { "code":  100, "label": "d" },
+      { "code":  118, "label": "v" },
+      { "code":  107, "label": "k" },
+      { "code":  104, "label": "h" }
+    ]
+  ]
+}


### PR DESCRIPTION
I added the Coelmak-DHm layout which is described on this website: https://colemakmods.github.io/mod-dh/

It calls it "Mod DH" but on other sited everybody calls it DHm, so I went with the shorter and more common name. As the author I credited the original author which is also named in above site:

> The original Mod-DH was developed and launched by SteveP in October 2014

Cheers! 👋