### PR TITLE
Recycle EmojiKeyViews to reduce memory usage

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKey.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKey.kt
@@ -26,6 +26,10 @@ class EmojiKey(override val data: KeyData) : Key(data) {
     var computedPopups: PopupSet<EmojiKeyData> = PopupSet()
         private set
 
+    companion object {
+        val EMPTY = EmojiKey(EmojiKeyData.EMPTY)
+    }
+
     fun dummyCompute() {
         computedData = data as? EmojiKeyData ?: computedData
         computedPopups = PopupSet(relevant = (data as? EmojiKeyData)?.popup ?: listOf())

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyAdapter.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyAdapter.kt
@@ -1,0 +1,59 @@
+package dev.patrickgold.florisboard.ime.media.emoji
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.flexbox.FlexboxLayoutManager
+
+
+class EmojiKeyAdapter(
+    private val dataSet: List<EmojiKey>,
+    private val emojiKeyboardView: EmojiKeyboardView,
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    companion object {
+        private const val PLACEHOLDER_EMOJI_COUNT = 24
+    }
+
+    class EmojiKeyViewHolder(view: View) : RecyclerView.ViewHolder(view)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return EmojiKeyViewHolder(EmojiKeyView(emojiKeyboardView, EmojiKey(EmojiKeyData.EMPTY)))
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (position < dataSet.size) {
+            (holder.itemView as EmojiKeyView).key = dataSet[position]
+            holder.itemView.layoutParams = FlexboxLayoutManager.LayoutParams(
+                emojiKeyboardView.emojiKeyWidth, emojiKeyboardView.emojiKeyHeight
+            )
+        } else {
+            (holder.itemView as EmojiKeyView).key = EmojiKey.EMPTY
+            holder.itemView.layoutParams = FlexboxLayoutManager.LayoutParams(
+                emojiKeyboardView.emojiKeyWidth, 0
+            )
+        }
+    }
+
+    override fun getItemCount(): Int {
+        // Add empty placeholder emojis at the end so the grid view. Below is an illustration how
+        // the UI looks with and without an placeholder (e = emoji):
+        //   Without placeholder        With placeholder
+        //     e e e e e e e             e e e e e e e
+        //     .............             .............
+        //     e e e e e e e             e e e e e e e
+        //        e e e e                e e e e
+        //
+        // Based on this SO's answer idea (by La Nube - Luis R. Díaz Muñiz):
+        //  https://stackoverflow.com/a/31478004/6801193
+        //
+        // 24 items are chosen here because that's probably the max items that will be shown per
+        // row, even in landscape mode.
+        return dataSet.size + PLACEHOLDER_EMOJI_COUNT
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return 0
+    }
+}
+

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyData.kt
@@ -41,13 +41,22 @@ class EmojiKeyData(
         return null
     }
 
+    private var string: String? = null
+
     override fun asString(isForDisplay: Boolean): String {
-        return StringBuilder().run {
-            for (codePoint in codePoints) {
-                append(Character.toChars(codePoint))
+        if (string == null) {
+            string = StringBuilder().run {
+                for (codePoint in codePoints) {
+                    append(Character.toChars(codePoint))
+                }
+                toString()
             }
-            toString()
         }
+        return string!!
+    }
+
+    companion object {
+        val EMPTY = EmojiKeyData(listOf())
     }
 
     override fun toString(): String {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
@@ -25,6 +25,7 @@ import android.view.Gravity
 import android.view.MotionEvent
 import android.widget.ScrollView
 import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.PrefHelper
@@ -32,7 +33,9 @@ import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 
 /**
  * View class for managing the rendering and the events of a single emoji keyboard key.
@@ -45,7 +48,7 @@ import kotlinx.coroutines.MainScope
 @SuppressLint("ViewConstructor")
 class EmojiKeyView(
     private val emojiKeyboardView: EmojiKeyboardView,
-    val key: EmojiKey
+    key: EmojiKey
 ) : androidx.appcompat.widget.AppCompatTextView(emojiKeyboardView.context), CoroutineScope by MainScope(),
     FlorisBoard.EventListener, ThemeManager.OnThemeUpdatedListener {
     private val florisboard: FlorisBoard? = FlorisBoard.getInstanceOrNull()
@@ -54,6 +57,12 @@ class EmojiKeyView(
     private var isCancelled: Boolean = false
     private var osHandler: Handler? = null
     private var triangleDrawable: Drawable? = null
+
+    var key: EmojiKey = key
+        set(value) {
+            field = value
+            text = value.data.asString(true)
+        }
 
     init {
         background = null
@@ -95,7 +104,7 @@ class EmojiKeyView(
                     osHandler = Handler()
                 }
                 osHandler?.postDelayed({
-                    (parent.parent as ScrollView)
+                    (parent as RecyclerView)
                         .requestDisallowInterceptTouchEvent(true)
                     emojiKeyboardView.isScrollBlocked = true
                     emojiKeyboardView.popupManager.show(key, KeyHintMode.DISABLED)
@@ -126,7 +135,8 @@ class EmojiKeyView(
                     emojiKeyboardView.popupManager.getActiveEmojiKeyData(key)
                 emojiKeyboardView.popupManager.hide()
                 if (event.actionMasked != MotionEvent.ACTION_CANCEL &&
-                    retData != null && !isCancelled) {
+                    retData != null && !isCancelled
+                ) {
                     if (!emojiKeyboardView.isScrollBlocked) {
                         florisboard?.keyPressVibrate()
                         florisboard?.keyPressSound()


### PR DESCRIPTION
This PR decreases memory usage by using a `RecyclerView` to recycle `EmojiKeyView`s instead of creating one for each emoji. This reduces memory usage by about 15-20% when suggestions and glide typing are disabled (in my somewhat limited short tests)

Let me know if you'd like me to make any changes.

Related: #677 