### PR TITLE
Improve bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,9 +22,9 @@ Guide to a good bug-report:
 Describe the bug in a short but concise way.
 
 #### Steps to reproduce
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+1. Go to '…'
+2. Click on '…'
+3. Scroll down to '…'
 4. See error
 
 #### Environment information


### PR DESCRIPTION
Make everything use the same number of placeholder-periods (3). Also use "…" instead of three ".". It looks stupid in monospace, but it's nice in a regular font and is less annoying to delete.