### PR TITLE
Improve crash_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/crash_report.md
+++ b/.github/ISSUE_TEMPLATE/crash_report.md
@@ -20,9 +20,9 @@ Guide to a good crash-report:
 Describe what you were doing that could've led to the crash.
 
 #### Steps to reproduce
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+1. Go to '…'
+2. Click on '…'
+3. Scroll down to '…'
 4. See crash
 
 <!-- Paste the generated crash log below -->


### PR DESCRIPTION
Make everything use the same number of placeholder-periods (3). Also use "…" instead of three ".". It looks stupid in monospace, but it's nice in a regular font and is less annoying to delete, especially when using a phone.