### PR TITLE
Set main uri ending to .de and add .eu ending

### DIFF
--- a/app/src/main/assets/ime/text/characters/extended_popups/de.json
+++ b/app/src/main/assets/ime/text/characters/extended_popups/de.json
@@ -96,12 +96,13 @@
     },
     "uri": {
       "~right": {
-        "main": { "code": -255, "label": ".com" },
+        "main": { "code": -255, "label": ".de" },
         "relevant": [
           { "code": -255, "label": ".ch" },
-          { "code": -255, "label": ".de" },
           { "code": -255, "label": ".at" },
-          { "code": -255, "label": ".net" }
+          { "code": -255, "label": ".com" },
+          { "code": -255, "label": ".net" },
+          { "code": -255, "label": ".eu" }
         ]
       }
     }


### PR DESCRIPTION
I am wondering why ".com" is the first pop entry for the German layout. Mostly ".de" will be used for normal usage. In addition, this adds the ".eu" ending which is also used more frequently.