### PR TITLE
Add devtool overlay for heap memory usage

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/PrefHelper.kt
@@ -48,7 +48,9 @@ class PrefHelper(
     private val cacheString: HashMap<String, String> = hashMapOf()
 
     val advanced = Advanced(this)
+    val clipboard = Clipboard(this)
     val correction = Correction(this)
+    val devtools = Devtools(this)
     val gestures = Gestures(this)
     val glide = Glide(this)
     val internal = Internal(this)
@@ -57,7 +59,6 @@ class PrefHelper(
     val smartbar = Smartbar(this)
     val suggestion = Suggestion(this)
     val theme = Theme(this)
-    val clipboard = Clipboard(this)
 
     /**
      * Checks the cache if an entry for [key] exists, else calls [getPrefInternal] to retrieve the
@@ -220,6 +221,23 @@ class PrefHelper(
         var rememberCapsLockState: Boolean
             get() =  prefHelper.getPref(REMEMBER_CAPS_LOCK_STATE, false)
             set(v) = prefHelper.setPref(REMEMBER_CAPS_LOCK_STATE, v)
+    }
+
+    /**
+     * Wrapper class for devtools preferences.
+     */
+    class Devtools(private val prefHelper: PrefHelper) {
+        companion object {
+            const val ENABLED =                     "devtools__enabled"
+            const val SHOW_HEAP_MEMORY_STATS =      "devtools__show_heap_memory_stats"
+        }
+
+        var enabled: Boolean
+            get() =  prefHelper.getPref(ENABLED, false)
+            set(v) = prefHelper.setPref(ENABLED, v)
+        var showHeapMemoryStats: Boolean
+            get() =  prefHelper.getPref(SHOW_HEAP_MEMORY_STATS, false)
+            set(v) = prefHelper.setPref(SHOW_HEAP_MEMORY_STATS, v)
     }
 
     /**

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -26,6 +26,7 @@
     <dimen name="key_numeric_textSize">12sp</dimen>
     <dimen name="key_popup_textSize">21sp</dimen>
     <dimen name="emoji_key_textSize">22sp</dimen>
+    <dimen name="devtools_memory_overlay_textSize">8sp</dimen>
 
     <dimen name="landscapeInputUi_padding">8dp</dimen>
     <dimen name="landscapeInputUi_actionButton_cornerRadius">6dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -310,6 +310,10 @@
     <string name="pref__advanced__show_app_icon__label" comment="Label of Show app icon preference in Advanced">Show app icon in launcher</string>
     <string name="pref__advanced__force_private_mode__label" comment="Label of Force private mode preference in Advanced">Force private mode</string>
     <string name="pref__advanced__force_private_mode__summary" comment="Summary of Force private mode preference in Advanced">Will disable any features which have to temporarily work with your input data</string>
+    <string name="pref__devtools__enabled__label" comment="Label of Enable developer tools in Advanced">Enable developer tools</string>
+    <string name="pref__devtools__enabled__summary" comment="Summary of Enable developer tools in Advanced">Tools specifically designed for debugging and troubleshooting</string>
+    <string name="pref__devtools__show_heap_memory_stats__label" comment="Label of Show heap memory stats in Advanced">Show heap memory stats</string>
+    <string name="pref__devtools__show_heap_memory_stats__summary" comment="Summary of Show heap memory stats in Advanced">Overlays the heap memory usage and max size in the top-right corner</string>
 
     <!-- About UI strings -->
     <string name="about__title" comment="Title of About activity">About</string>

--- a/app/src/main/res/xml/prefs_advanced.xml
+++ b/app/src/main/res/xml/prefs_advanced.xml
@@ -26,4 +26,21 @@
         app:summary="@string/pref__advanced__force_private_mode__summary"
         app:useSimpleSummaryProvider="true"/>
 
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        app:key="devtools__enabled"
+        app:iconSpaceReserved="false"
+        app:title="@string/pref__devtools__enabled__label"
+        app:summary="@string/pref__devtools__enabled__summary"
+        app:useSimpleSummaryProvider="true"/>
+
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        app:dependency="devtools__enabled"
+        app:key="devtools__show_heap_memory_stats"
+        app:iconSpaceReserved="false"
+        app:title="@string/pref__devtools__show_heap_memory_stats__label"
+        app:summary="@string/pref__devtools__show_heap_memory_stats__summary"
+        app:useSimpleSummaryProvider="true"/>
+
 </PreferenceScreen>


### PR DESCRIPTION
This PR adds a little overlay display in the top-right corner to show the heap memory usage. Useful for watching how the heap memory size grows and potentially find out what actions leave memory behind what is not de-allocated anymore. Note: the shown memory is only the heap, the native memory usage may be bigger than this and is not included. As most of the OOM errors occur due to a full heap though and it is easier to measure the heap size than the native size, the devtools currently only show the heap size. Defaults to disabled. To enable, go to Settings > Advanced > Enable debug mode > Show heap memory stats

Related #677

---

![devtools-memory-preview](https://user-images.githubusercontent.com/19412843/117020885-1ee29f00-acf7-11eb-8334-fa58bcc7734c.jpeg)
