### PR TITLE
Make normalizeBoxSide have a non-zero minimum longestSide

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/StatisticalGlideTypingClassifier.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/StatisticalGlideTypingClassifier.kt
@@ -526,7 +526,7 @@ class StatisticalGlideTypingClassifier : GlideTypingClassifier {
 
             val width = maxX - minX
             val height = maxY - minY
-            val longestSide = max(width, height)
+            val longestSide = max(max(width, height), 0.00001f)
 
             val centroidX = (width / 2 + minX) / longestSide
             val centroidY = (height / 2 + minY) / longestSide


### PR DESCRIPTION
Noticed this issue while testing glide typing. If longestSide is ever zero, as sometimes happens because the dictionary contains "words" like "yyy" and "ggg", it causes NaN issues.