### PR TITLE
Stop glide suggestions disappearing and remove the redundant first suggestion

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -445,7 +445,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
         }
         smartbarView?.updateSmartbarState()
         flogInfo(LogTopic.IMS_EVENTS) { "current word: ${activeEditorInstance.cachedInput.currentWord.text}" }
-        if (activeEditorInstance.isComposingEnabled && !inputEventDispatcher.isPressed(KeyCode.DELETE)) {
+        if (activeEditorInstance.isComposingEnabled && !inputEventDispatcher.isPressed(KeyCode.DELETE) && !isGlidePostEffect) {
             if (activeEditorInstance.shouldReevaluateComposingSuggestions) {
                 activeEditorInstance.shouldReevaluateComposingSuggestions = false
                 activeDictionary?.let {


### PR DESCRIPTION
No idea how I didn't notice it before but after glide typing a word, the suggestions are immediately replaced with the regular suggestions instead of showing the glide typing suggestions.

Another issue I noticded is that somewhat redundantly, the committed word shows as the first suggesion. I changed it to show the second best guess instead.