### PR TITLE
Add support for Android 11's Autofill API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
 
 plugins {
-    id("com.android.application") version "4.2.0"
+    id("com.android.application") version "4.2.1"
     kotlin("android") version "1.5.0"
     kotlin("kapt") version "1.5.0"
     kotlin("plugin.serialization") version "1.5.0"
@@ -62,6 +62,9 @@ android {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
 
+            isDebuggable = true
+            isJniDebuggable = true
+
             resValue("mipmap", "floris_app_icon", "@mipmap/ic_app_icon_debug")
             resValue("mipmap", "floris_app_icon_round", "@mipmap/ic_app_icon_debug_round")
             resValue("string", "floris_app_name", "FlorisBoard Debug")
@@ -102,6 +105,7 @@ android {
 dependencies {
     implementation("androidx.activity", "activity-ktx", "1.2.1")
     implementation("androidx.appcompat", "appcompat", "1.2.0")
+    implementation("androidx.autofill", "autofill", "1.1.0")
     implementation("androidx.core", "core-ktx", "1.3.2")
     implementation("androidx.fragment", "fragment-ktx", "1.3.0")
     implementation("androidx.preference", "preference-ktx", "1.1.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,13 +34,10 @@
             android:name="dev.patrickgold.florisboard.ime.core.FlorisBoard"
             android:label="@string/floris_app_name"
             android:permission="android.permission.BIND_INPUT_METHOD">
-            <meta-data
-                android:name="android.view.im"
-                android:resource="@xml/method"/>
-
             <intent-filter>
                 <action android:name="android.view.InputMethod"/>
             </intent-filter>
+            <meta-data android:name="android.view.im" android:resource="@xml/method"/>
         </service>
 
         <!-- Settings Activity -->

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -49,8 +49,6 @@ import android.widget.FrameLayout
 import android.widget.inline.InlinePresentationSpec
 import androidx.annotation.RequiresApi
 import androidx.annotation.StyleRes
-import androidx.autofill.inline.UiVersions
-import androidx.autofill.inline.v1.InlineSuggestionUi
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.lifecycle.*
@@ -413,48 +411,11 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardManager
 
     @RequiresApi(Build.VERSION_CODES.R)
     override fun onCreateInlineSuggestionsRequest(uiExtras: Bundle): InlineSuggestionsRequest? {
-        return if (prefs.smartbar.enabled) {
+        return if (prefs.smartbar.enabled && prefs.suggestion.api30InlineSuggestionsEnabled) {
             flogInfo(LogTopic.IMS_EVENTS) {
                 "Creating inline suggestions request because Smartbar and inline suggestions are enabled."
             }
-            val stylesBuilder = UiVersions.newStylesBuilder()
-            /*val style: UiVersions.Style = InlineSuggestionUi.newStyleBuilder()
-                .setSingleIconChipStyle(
-                    ViewStyle.Builder()
-                        .setBackground(
-                            Icon.createWithResource(this, R.drawable.chip_background)
-                        )
-                        .setPadding(0, 0, 0, 0)
-                        .build()
-                )
-                .setChipStyle(
-                    ViewStyle.Builder()
-                        .setBackground(
-                            Icon.createWithResource(this, R.drawable.chip_background)
-                        )
-                        .setPadding(toPixel(5 + 8), 0, toPixel(5 + 8), 0)
-                        .build()
-                )
-                .setStartIconStyle(ImageViewStyle.Builder().setLayoutMargin(0, 0, 0, 0).build())
-                .setTitleStyle(
-                    TextViewStyle.Builder()
-                        .setLayoutMargin(toPixel(4), 0, toPixel(4), 0)
-                        .setTextColor(Color.parseColor("#FF202124"))
-                        .setTextSize(16f)
-                        .build()
-                )
-                .setSubtitleStyle(
-                    TextViewStyle.Builder()
-                        .setLayoutMargin(0, 0, toPixel(4), 0)
-                        .setTextColor(Color.parseColor("#99202124")) // 60% opacity
-                        .setTextSize(14f)
-                        .build()
-                )
-                .setEndIconStyle(ImageViewStyle.Builder().setLayoutMargin(0, 0, 0, 0).build())
-                .build()*/
-            stylesBuilder.addStyle(InlineSuggestionUi.newStyleBuilder().build())
-            val stylesBundle: Bundle = stylesBuilder.build()
-
+            val stylesBundle = themeManager.createInlineSuggestionUiStyleBundle(themeContext)
             InlinePresentationSpec.Builder(
                 Size(
                     inputView?.desiredInlineSuggestionsMinWidth ?: 0,

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputView.kt
@@ -22,9 +22,11 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Typeface
+import android.os.Build
 import android.text.TextPaint
 import android.util.AttributeSet
 import android.util.DisplayMetrics
+import android.util.Size
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ViewFlipper
@@ -54,6 +56,15 @@ class InputView : LinearLayout {
     var heightFactor: Float = 1.0f
         private set
     var shouldGiveAdditionalSpace: Boolean = false
+        private set
+
+    var desiredInlineSuggestionsMinWidth: Int = 0
+        private set
+    var desiredInlineSuggestionsMinHeight: Int = 0
+        private set
+    var desiredInlineSuggestionsMaxWidth: Int = 0
+        private set
+    var desiredInlineSuggestionsMaxHeight: Int = 0
         private set
 
     var mainViewFlipper: ViewFlipper? = null
@@ -142,6 +153,14 @@ class InputView : LinearLayout {
             },
             context
         )
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val width = MeasureSpec.getSize(widthMeasureSpec)
+            desiredInlineSuggestionsMinWidth = width / 3
+            desiredInlineSuggestionsMinHeight = desiredSmartbarHeight.toInt()
+            desiredInlineSuggestionsMaxWidth = (width / 1.5).toInt()
+            desiredInlineSuggestionsMaxHeight = desiredSmartbarHeight.toInt()
+        }
 
         super.onMeasure(widthMeasureSpec, MeasureSpec.makeMeasureSpec(baseHeight.roundToInt(), MeasureSpec.EXACTLY))
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
@@ -531,14 +531,18 @@ class Preferences(
      */
     class Suggestion(private val prefs: Preferences) {
         companion object {
-            const val BLOCK_POSSIBLY_OFFENSIVE =    "suggestion__block_possibly_offensive"
-            const val CLIPBOARD_CONTENT_ENABLED =   "suggestion__clipboard_content_enabled"
-            const val CLIPBOARD_CONTENT_TIMEOUT =   "suggestion__clipboard_content_timeout"
-            const val DISPLAY_MODE =                "suggestion__display_mode"
-            const val ENABLED =                     "suggestion__enabled"
-            const val USE_PREV_WORDS =              "suggestion__use_prev_words"
+            const val API30_INLINE_SUGGESTIONS_ENABLED =    "suggestion__api30_inline_suggestions_enabled"
+            const val BLOCK_POSSIBLY_OFFENSIVE =            "suggestion__block_possibly_offensive"
+            const val CLIPBOARD_CONTENT_ENABLED =           "suggestion__clipboard_content_enabled"
+            const val CLIPBOARD_CONTENT_TIMEOUT =           "suggestion__clipboard_content_timeout"
+            const val DISPLAY_MODE =                        "suggestion__display_mode"
+            const val ENABLED =                             "suggestion__enabled"
+            const val USE_PREV_WORDS =                      "suggestion__use_prev_words"
         }
 
+        var api30InlineSuggestionsEnabled: Boolean
+            get() =  prefs.getPref(API30_INLINE_SUGGESTIONS_ENABLED, true)
+            set(v) = prefs.setPref(API30_INLINE_SUGGESTIONS_ENABLED, v)
         var blockPossiblyOffensive: Boolean
             get() =  prefs.getPref(BLOCK_POSSIBLY_OFFENSIVE, true)
             set(v) = prefs.setPref(BLOCK_POSSIBLY_OFFENSIVE, v)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -246,25 +246,20 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
                     KeyboardMode.EDITING -> R.id.back_button
                     else -> R.id.quick_action_toggle
                 },
-                mainAreaId = if (isShowingInlineSuggestions) {
-                    R.id.inline_suggestions
-                } else {
-                    when (florisboard.textInputManager.keyVariation) {
-                        KeyVariation.PASSWORD -> R.id.number_row
-                        else -> when (isQuickActionsVisible) {
-                            true -> R.id.quick_actions
-                            else -> when (florisboard.textInputManager.getActiveKeyboardMode()) {
-                                KeyboardMode.EDITING -> null
-                                KeyboardMode.NUMERIC,
-                                KeyboardMode.PHONE,
-                                KeyboardMode.PHONE2 -> R.id.clipboard_cursor_row
-                                else -> when {
-                                    florisboard.activeEditorInstance.isComposingEnabled &&
-                                        florisboard.activeEditorInstance.selection.isCursorMode
-                                    -> R.id.candidates
-                                    else -> R.id.clipboard_cursor_row
-                                }
-                            }
+                mainAreaId = when {
+                    isQuickActionsVisible -> R.id.quick_actions
+                    isShowingInlineSuggestions -> R.id.inline_suggestions
+                    florisboard.textInputManager.keyVariation == KeyVariation.PASSWORD -> R.id.number_row
+                    else -> when (florisboard.textInputManager.getActiveKeyboardMode()) {
+                        KeyboardMode.EDITING -> null
+                        KeyboardMode.NUMERIC,
+                        KeyboardMode.PHONE,
+                        KeyboardMode.PHONE2 -> R.id.clipboard_cursor_row
+                        else -> when {
+                            florisboard.activeEditorInstance.isComposingEnabled &&
+                                florisboard.activeEditorInstance.selection.isCursorMode
+                            -> R.id.candidates
+                            else -> R.id.clipboard_cursor_row
                         }
                     }
                 },
@@ -331,7 +326,7 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
     @RequiresApi(Build.VERSION_CODES.R)
     private fun updateInlineSuggestionStrip(suggestionViews: Collection<InlineContentView?>) {
         flogDebug { "Updating the inline suggestion strip with ${suggestionViews.size} items" }
-        binding.inlineSuggestionsInner.removeAllViews()
+        binding.inlineSuggestionsStrip.removeAllViews()
         if (suggestionViews.isEmpty()) {
             isShowingInlineSuggestions = false
             return
@@ -340,7 +335,7 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
                 if (suggestionView == null) {
                     continue
                 }
-                binding.inlineSuggestionsInner.addView(suggestionView)
+                binding.inlineSuggestionsStrip.addView(suggestionView)
             }
             isShowingInlineSuggestions = true
         }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -295,11 +295,20 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
         //
     }
 
+    /**
+     * Clears the inline suggestions and triggers thw Smartbar update cycle.
+     */
     @RequiresApi(Build.VERSION_CODES.R)
     fun clearInlineSuggestions() {
         updateInlineSuggestionStrip(listOf())
     }
 
+    /**
+     * Inflates the given inline suggestions. Once all provided views are ready, the suggestions
+     * strip is updated and the Smartbar update cycle is triggered.
+     *
+     * @param inlineSuggestions A collection of inline suggestions to be inflated and shown.
+     */
     @RequiresApi(Build.VERSION_CODES.R)
     fun showInlineSuggestions(inlineSuggestions: Collection<InlineSuggestion>) {
         if (inlineSuggestions.isEmpty()) {
@@ -323,6 +332,12 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
         }
     }
 
+    /**
+     * Updates the suggestion strip with given inline content views and triggers the Smartbar
+     * update cycle.
+     *
+     * @param suggestionViews A collection of inline content views to show.
+     */
     @RequiresApi(Build.VERSION_CODES.R)
     private fun updateInlineSuggestionStrip(suggestionViews: Collection<InlineContentView?>) {
         flogDebug { "Updating the inline suggestion strip with ${suggestionViews.size} items" }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/smartbar/SmartbarView.kt
@@ -17,13 +17,19 @@
 package dev.patrickgold.florisboard.ime.text.smartbar
 
 import android.content.Context
+import android.os.Build
 import android.util.AttributeSet
+import android.util.Size
 import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.InlineSuggestion
 import androidx.annotation.IdRes
+import androidx.annotation.RequiresApi
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.children
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.databinding.SmartbarBinding
+import dev.patrickgold.florisboard.debug.*
 import dev.patrickgold.florisboard.ime.clip.provider.ClipboardItem
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.Preferences
@@ -65,6 +71,7 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
             binding.quickActionToggle.rotation = if (v) 180.0f else 0.0f
             field = v
         }
+    private var isShowingInlineSuggestions: Boolean = false
 
     private lateinit var binding: SmartbarBinding
     private var indexedActionStartArea: MutableList<Int> = mutableListOf()
@@ -237,20 +244,24 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
                     KeyboardMode.EDITING -> R.id.back_button
                     else -> R.id.quick_action_toggle
                 },
-                mainAreaId = when (florisboard.textInputManager.keyVariation) {
-                    KeyVariation.PASSWORD -> R.id.number_row
-                    else -> when (isQuickActionsVisible) {
-                        true -> R.id.quick_actions
-                        else -> when (florisboard.textInputManager.getActiveKeyboardMode()) {
-                            KeyboardMode.EDITING -> null
-                            KeyboardMode.NUMERIC,
-                            KeyboardMode.PHONE,
-                            KeyboardMode.PHONE2 -> R.id.clipboard_cursor_row
-                            else -> when {
-                                florisboard.activeEditorInstance.isComposingEnabled &&
+                mainAreaId = if (isShowingInlineSuggestions) {
+                    R.id.inline_suggestions
+                } else {
+                    when (florisboard.textInputManager.keyVariation) {
+                        KeyVariation.PASSWORD -> R.id.number_row
+                        else -> when (isQuickActionsVisible) {
+                            true -> R.id.quick_actions
+                            else -> when (florisboard.textInputManager.getActiveKeyboardMode()) {
+                                KeyboardMode.EDITING -> null
+                                KeyboardMode.NUMERIC,
+                                KeyboardMode.PHONE,
+                                KeyboardMode.PHONE2 -> R.id.clipboard_cursor_row
+                                else -> when {
+                                    florisboard.activeEditorInstance.isComposingEnabled &&
                                         florisboard.activeEditorInstance.selection.isCursorMode
                                     -> R.id.candidates
-                                else -> R.id.clipboard_cursor_row
+                                    else -> R.id.clipboard_cursor_row
+                                }
                             }
                         }
                     }
@@ -285,6 +296,38 @@ class SmartbarView : ConstraintLayout, ThemeManager.OnThemeUpdatedListener {
 
     fun updateCandidateSuggestionCapsState() {
         //
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    fun setInlineSuggestions(list: List<InlineSuggestion>?) {
+        if (list == null) {
+            flogDebug { "Removing inline suggestions" }
+            isShowingInlineSuggestions = false
+            binding.inlineSuggestionsInner.removeAllViews()
+        } else if (list.isNotEmpty()) {
+            flogDebug { "Adding inline suggestions (${list.size})" }
+            isShowingInlineSuggestions = true
+            binding.inlineSuggestionsInner.let {
+                for (inlineSuggestion in list) {
+                    try {
+                        inlineSuggestion.inflate(
+                            context,
+                            Size(ViewGroup.LayoutParams.WRAP_CONTENT, florisboard?.inputView?.desiredInlineSuggestionsMaxHeight ?: 0),
+                            context.mainExecutor
+                        ) { view ->
+                            if (view != null) {
+                                flogDebug { "Adding inline suggestion view" }
+                                it.addView(view)
+                            } else {
+                                flogDebug { "Inline suggestion view is null" }
+                            }
+                        }
+                    } catch (e: Throwable) {
+                        flogWarning { "Failed to inflate inline suggestion: $e" }
+                    }
+                }
+            }
+        }
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
@@ -16,14 +16,26 @@
 
 package dev.patrickgold.florisboard.ime.theme
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Color
+import android.graphics.drawable.Icon
 import android.net.Uri
+import android.os.Build
+import android.os.Bundle
 import android.util.TypedValue
 import androidx.annotation.AttrRes
+import androidx.annotation.RequiresApi
+import androidx.autofill.inline.UiVersions
+import androidx.autofill.inline.common.ImageViewStyle
+import androidx.autofill.inline.common.TextViewStyle
+import androidx.autofill.inline.common.ViewStyle
+import androidx.autofill.inline.v1.InlineSuggestionUi
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.ColorUtils
+import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.Preferences
 import dev.patrickgold.florisboard.ime.extension.AssetManager
 import dev.patrickgold.florisboard.ime.extension.AssetRef
@@ -303,6 +315,74 @@ class ThemeManager private constructor(
         }.onFailure {
             Timber.e(it.toString())
         }
+    }
+
+    @SuppressLint("RestrictedApi")
+    @RequiresApi(Build.VERSION_CODES.R)
+    fun createInlineSuggestionUiStyleBundle(context: Context, theme: Theme = activeTheme): Bundle {
+        val bgColor = theme.getAttr(Theme.Attr.SMARTBAR_BUTTON_BACKGROUND).toSolidColor().color
+        val fgColor = theme.getAttr(Theme.Attr.SMARTBAR_BUTTON_FOREGROUND).toSolidColor().color
+        val bgDrawableId = R.drawable.chip_background
+        val stylesBuilder = UiVersions.newStylesBuilder()
+        val style = InlineSuggestionUi.newStyleBuilder()
+            .setSingleIconChipStyle(
+                ViewStyle.Builder()
+                    .setBackground(
+                        Icon.createWithResource(context, bgDrawableId).setTint(bgColor)
+                    )
+                    .setPadding(0, 0, 0, 0)
+                    .build()
+            )
+            .setChipStyle(
+                ViewStyle.Builder()
+                    .setBackground(
+                        Icon.createWithResource(context, bgDrawableId).setTint(bgColor)
+                    )
+                    .setPadding(
+                        context.resources.getDimension(R.dimen.suggestion_chip_bg_padding_start).toInt(),
+                        context.resources.getDimension(R.dimen.suggestion_chip_bg_padding_top).toInt(),
+                        context.resources.getDimension(R.dimen.suggestion_chip_bg_padding_end).toInt(),
+                        context.resources.getDimension(R.dimen.suggestion_chip_bg_padding_bottom).toInt(),
+                    )
+                    .build()
+            )
+            .setStartIconStyle(
+                ImageViewStyle.Builder()
+                    .setLayoutMargin(0, 0, 0, 0)
+                    .build()
+            )
+            .setTitleStyle(
+                TextViewStyle.Builder()
+                    .setLayoutMargin(
+                        context.resources.getDimension(R.dimen.suggestion_chip_fg_title_margin_start).toInt(),
+                        context.resources.getDimension(R.dimen.suggestion_chip_fg_title_margin_top).toInt(),
+                        context.resources.getDimension(R.dimen.suggestion_chip_fg_title_margin_end).toInt(),
+                        context.resources.getDimension(R.dimen.suggestion_chip_fg_title_margin_bottom).toInt(),
+                    )
+                    .setTextColor(fgColor)
+                    .setTextSize(16f)
+                    .build()
+            )
+            .setSubtitleStyle(
+                TextViewStyle.Builder()
+                    .setLayoutMargin(
+                        context.resources.getDimension(R.dimen.suggestion_chip_fg_subtitle_margin_start).toInt(),
+                        context.resources.getDimension(R.dimen.suggestion_chip_fg_subtitle_margin_top).toInt(),
+                        context.resources.getDimension(R.dimen.suggestion_chip_fg_subtitle_margin_end).toInt(),
+                        context.resources.getDimension(R.dimen.suggestion_chip_fg_subtitle_margin_bottom).toInt(),
+                    )
+                    .setTextColor(ColorUtils.setAlphaComponent(fgColor, 150))
+                    .setTextSize(14f)
+                    .build()
+            )
+            .setEndIconStyle(
+                ImageViewStyle.Builder()
+                    .setLayoutMargin(0, 0, 0, 0)
+                    .build()
+            )
+            .build()
+        stylesBuilder.addStyle(style)
+        return stylesBuilder.build()
     }
 
     data class RemoteColors(

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
@@ -317,6 +317,14 @@ class ThemeManager private constructor(
         }
     }
 
+    /**
+     * Creates a new inline suggestion UI bundle based on the attributes of the given [theme].
+     *
+     * @param context The context of the parent view/controller.
+     * @param theme The theme from which the color attributes should be fetched. Defaults to [activeTheme].
+     *
+     * @return A bundle containing all necessary attributes for the inline suggestion views to properly display.
+     */
     @SuppressLint("RestrictedApi")
     @RequiresApi(Build.VERSION_CODES.R)
     fun createInlineSuggestionUiStyleBundle(context: Context, theme: Theme = activeTheme): Bundle {

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/fragments/TypingInnerFragment.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/fragments/TypingInnerFragment.kt
@@ -17,6 +17,7 @@
 package dev.patrickgold.florisboard.settings.fragments
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -27,6 +28,9 @@ import dev.patrickgold.florisboard.settings.UdmActivity
 class TypingInnerFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.prefs_typing)
+        findPreference<Preference>(Preferences.Suggestion.API30_INLINE_SUGGESTIONS_ENABLED)?.let {
+            it.isVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+        }
     }
 
     override fun onPreferenceTreeClick(preference: Preference?): Boolean {

--- a/app/src/main/res/drawable/chip_background.xml
+++ b/app/src/main/res/drawable/chip_background.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2020 The Android Open Source Project
+  ~ Copyright (C) 2021 Patrick Goldinger
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#20000000">
+    <item
+        android:bottom="4dp"
+        android:left="4dp"
+        android:right="4dp"
+        android:shape="rectangle"
+        android:top="4dp">
+        <shape>
+            <corners android:radius="32dp" />
+            <solid android:color="#1F000000" />
+        </shape>
+    </item>
+    <item
+        android:bottom="5dp"
+        android:left="5dp"
+        android:right="5dp"
+        android:shape="rectangle"
+        android:top="5dp">
+        <shape>
+            <corners android:radius="32dp" />
+            <solid android:color="#FFFFFFFF" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/layout/smartbar.xml
+++ b/app/src/main/res/layout/smartbar.xml
@@ -48,7 +48,7 @@
             style="@style/SmartbarContainer">
 
             <LinearLayout
-                android:id="@+id/inline_suggestions_inner"
+                android:id="@+id/inline_suggestions_strip"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:orientation="horizontal"/>

--- a/app/src/main/res/layout/smartbar.xml
+++ b/app/src/main/res/layout/smartbar.xml
@@ -43,6 +43,18 @@
             android:id="@+id/candidates"
             style="@style/SmartbarContainer"/>
 
+        <HorizontalScrollView
+            android:id="@+id/inline_suggestions"
+            style="@style/SmartbarContainer">
+
+            <LinearLayout
+                android:id="@+id/inline_suggestions_inner"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="horizontal"/>
+
+        </HorizontalScrollView>
+
         <LinearLayout
             android:id="@+id/quick_actions"
             style="@style/SmartbarContainer">

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -56,6 +56,21 @@
 
     <dimen name="fab_margin">16dp</dimen>
 
+    <dimen name="suggestion_chip_bg_padding_start">13dp</dimen>
+    <dimen name="suggestion_chip_bg_padding_top">0dp</dimen>
+    <dimen name="suggestion_chip_bg_padding_end">13dp</dimen>
+    <dimen name="suggestion_chip_bg_padding_bottom">0dp</dimen>
+
+    <dimen name="suggestion_chip_fg_title_margin_start">4dp</dimen>
+    <dimen name="suggestion_chip_fg_title_margin_top">0dp</dimen>
+    <dimen name="suggestion_chip_fg_title_margin_end">4dp</dimen>
+    <dimen name="suggestion_chip_fg_title_margin_bottom">0dp</dimen>
+
+    <dimen name="suggestion_chip_fg_subtitle_margin_start">4dp</dimen>
+    <dimen name="suggestion_chip_fg_subtitle_margin_top">0dp</dimen>
+    <dimen name="suggestion_chip_fg_subtitle_margin_end">4dp</dimen>
+    <dimen name="suggestion_chip_fg_subtitle_margin_bottom">0dp</dimen>
+
     <dimen name="gesture_distance_threshold_very_short">24dp</dimen>
     <dimen name="gesture_distance_threshold_short">28dp</dimen>
     <dimen name="gesture_distance_threshold_normal">32dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,8 @@
     <string name="pref__smartbar__enabled__label" comment="Preference title">Enable Smartbar</string>
     <string name="pref__smartbar__enabled__summary" comment="Preference summary">Will show on top of the keyboard</string>
     <string name="pref__suggestion__title" comment="Preference group title">Suggestions</string>
+    <string translatable="false" name="pref__suggestion__api30_inline_suggestions_enabled__label" comment="Preference title">Inline suggestions</string>
+    <string translatable="false" name="pref__suggestion__api30_inline_suggestions_enabled__summary" comment="Preference summary">Show inline suggestions provided by autofill services (password managers, ...)</string>
     <string translatable="false" name="pref__suggestion__enabled__label" comment="Preference title">[EXPERIMENTAL] Display suggestions while you type</string>
     <string translatable="false" name="pref__suggestion__enabled__summary" comment="Preference summary">Will show in the Smartbar, currently regardless of the selected subtype the dictionary language is English (US)</string>
     <string translatable="false" name="pref__suggestion__use_pref_words__label" comment="Preference title">[NOT YET INCLUDED] Next-word suggestions</string>

--- a/app/src/main/res/xml-v30/method.xml
+++ b/app/src/main/res/xml-v30/method.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
     android:settingsActivity="dev.patrickgold.florisboard.settings.SettingsMainActivity"
+    android:supportsInlineSuggestions="true"
     android:supportsSwitchingToNextInputMethod="true"/>

--- a/app/src/main/res/xml/prefs_typing.xml
+++ b/app/src/main/res/xml/prefs_typing.xml
@@ -14,6 +14,14 @@
         app:title="@string/pref__suggestion__title">
 
         <SwitchPreferenceCompat
+            android:defaultValue="true"
+            app:dependency="smartbar__enabled"
+            app:key="suggestion__api30_inline_suggestions_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__suggestion__api30_inline_suggestions_enabled__label"
+            app:summary="@string/pref__suggestion__api30_inline_suggestions_enabled__summary"/>
+
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:dependency="smartbar__enabled"
             app:key="suggestion__enabled"


### PR DESCRIPTION
This PR is a working draft to add support for Android 11's Autofill API. Inline-suggestions works well in "normal" apps like Twitter but bugs out a bit in Firefox (Gboard bugs out too though so not 100% sure if I can do something against this). Closes #163.

Additionally the Language&Input settings bug has also finally been resolved by me (frickin `https` instead of the (sadly) correct `http` in the android schema tag was the issue in `method.xml`). Closes #366. Closes #890.