### PR TITLE
Fix the default popup for some letters

### DIFF
--- a/app/src/main/assets/ime/text/characters/extended_popups/el.json
+++ b/app/src/main/assets/ime/text/characters/extended_popups/el.json
@@ -20,8 +20,8 @@
         ]
       },
       "ι": {
+        "main": { "$": "auto_text_key", "code":  943, "label": "ί" },
         "relevant": [
-          { "$": "auto_text_key", "code":  943, "label": "ί" },
           { "$": "auto_text_key", "code":  912, "label": "ΐ" },
           { "$": "auto_text_key", "code":  970, "label": "ϊ" }
         ]
@@ -32,8 +32,8 @@
         ]
       },
       "υ": {
+        "main": { "$": "auto_text_key", "code":  973, "label": "ύ" },
         "relevant": [
-          { "$": "auto_text_key", "code":  973, "label": "ύ" },
           { "$": "auto_text_key", "code":  944, "label": "ΰ" },
           { "$": "auto_text_key", "code":  971, "label": "ϋ" }
         ]

--- a/app/src/main/assets/ime/text/characters/extended_popups/el.json
+++ b/app/src/main/assets/ime/text/characters/extended_popups/el.json
@@ -21,9 +21,9 @@
       },
       "ι": {
         "relevant": [
+          { "$": "auto_text_key", "code":  943, "label": "ί" },
           { "$": "auto_text_key", "code":  912, "label": "ΐ" },
-          { "$": "auto_text_key", "code":  970, "label": "ϊ" },
-          { "$": "auto_text_key", "code":  943, "label": "ί" }
+          { "$": "auto_text_key", "code":  970, "label": "ϊ" }
         ]
       },
       "ο": {
@@ -33,9 +33,9 @@
       },
       "υ": {
         "relevant": [
+          { "$": "auto_text_key", "code":  973, "label": "ύ" },
           { "$": "auto_text_key", "code":  944, "label": "ΰ" },
-          { "$": "auto_text_key", "code":  971, "label": "ϋ" },
-          { "$": "auto_text_key", "code":  973, "label": "ύ" }
+          { "$": "auto_text_key", "code":  971, "label": "ϋ" }
         ]
       },
       "ω": {


### PR DESCRIPTION
This pr fixes a recently introduced minor issue with the order of popups for letters "ι" and "υ" in greek layout. I tried it locally and it works as expected. Closes #912 