### PR TITLE
Fix getting composer from name

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -63,6 +63,7 @@ import dev.patrickgold.florisboard.ime.media.MediaInputManager
 import dev.patrickgold.florisboard.ime.onehanded.OneHandedMode
 import dev.patrickgold.florisboard.ime.popup.PopupLayerView
 import dev.patrickgold.florisboard.ime.text.TextInputManager
+import dev.patrickgold.florisboard.ime.text.composing.Appender
 import dev.patrickgold.florisboard.ime.text.composing.Composer
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.key.CurrencySet
@@ -143,7 +144,7 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardManager
     var activeEditorInstance: EditorInstance = EditorInstance.default()
 
     val subtypeManager: SubtypeManager get() = SubtypeManager.default()
-    val composer: Composer get() = subtypeManager.imeConfig.composers[subtypeManager.imeConfig.composerNames.indexOf(activeSubtype.composerName)]
+    val composer: Composer get() = subtypeManager.imeConfig.composerFromName.getValue(activeSubtype.composerName)
     lateinit var activeSubtype: Subtype
     private var currentThemeIsNight: Boolean = false
     private var currentThemeResId: Int = 0
@@ -976,6 +977,7 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardManager
         @Transient var currencySetLabels: List<String> = listOf()
         @Transient var composerNames: List<String> = listOf()
         @Transient var composerLabels: List<String> = listOf()
+        @Transient val composerFromName: Map<String, Composer> = composers.map { it.name to it }.toMap()
         @Transient var defaultSubtypesLanguageCodes: List<String> = listOf()
         @Transient var defaultSubtypesLanguageNames: List<String> = listOf()
 
@@ -984,7 +986,7 @@ class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardManager
             // Sort composer list alphabetically by the label of a composer
             tmpComposerList.sortBy { it.second }
             // Move selected composers to the top of the list
-            for (composerName in listOf("appender")) {
+            for (composerName in listOf(Appender.name)) {
                 val index: Int = tmpComposerList.indexOfFirst { it.first == composerName }
                 if (index > 0) {
                     tmpComposerList.add(0, tmpComposerList.removeAt(index))


### PR DESCRIPTION
The `composers[composerNames.indexOf(activeSubtype.composerName)]` was always a bad idea and I knew it when I wrote it, but I thought "it's stupid but it's probably going to move to a better place anyways and for now it works" so I left it.

Except it doesn't work.

The `composers` list is unsorted, and the `composerNames` list is sorted, so their order is the same by pure chance in the current state of Florisboard, but that line still requires fixing before adding more composers. Otherwise this will happen.
![2021-05-30 10_46_24-FlorisBoard – FlorisBoard kt  FlorisBoard app](https://user-images.githubusercontent.com/7904776/120098678-94dff780-c137-11eb-83a4-ef4c98c28f9f.png)

This commit fixes it by adding a map to read the current composer from its name without sorting being a problem.
(Also it uses the constant Appender.name (that is already available for other purposes) rather than hardcoding "appender" when forcing the position of that composer to the first position in the list.)