### PR TITLE
Code cleanup + some polish

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/ClipboardHistoryItemAdapter.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/ClipboardHistoryItemAdapter.kt
@@ -1,6 +1,10 @@
 package dev.patrickgold.florisboard.ime.clip
 
-import android.graphics.drawable.Drawable
+import android.animation.ValueAnimator
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.GONE
@@ -13,11 +17,16 @@ import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.clip.provider.ClipboardItem
 import dev.patrickgold.florisboard.ime.clip.provider.ItemType
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 class ClipboardHistoryItemAdapter(
-        private val dataSet: ArrayDeque<FlorisClipboardManager.TimedClipData>,
-        private val pins: ArrayDeque<ClipboardItem>
-    ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private val dataSet: ArrayDeque<FlorisClipboardManager.TimedClipData>,
+    private val pins: ArrayDeque<ClipboardItem>
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>(), CoroutineScope by MainScope() {
 
     class ClipboardHistoryTextViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val textView: TextView = view.findViewById(R.id.clipboard_history_item_text)
@@ -35,13 +44,11 @@ class ClipboardHistoryItemAdapter(
         return if (position < pins.size) {
             // is a pin
             pins[position].type.value
-        }else {
+        } else {
             // regular history item
             dataSet[position - pins.size].data.type.value
         }
     }
-
-
 
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
@@ -53,7 +60,7 @@ class ClipboardHistoryItemAdapter(
 
                 ClipboardHistoryImageViewHolder(view)
             }
-            ItemType.TEXT.value  -> {
+            ItemType.TEXT.value -> {
                 val view = LayoutInflater.from(viewGroup.context)
                     .inflate(R.layout.clipboard_history_item_text, viewGroup, false)
 
@@ -73,7 +80,7 @@ class ClipboardHistoryItemAdapter(
                 var text = if (position < pins.size) {
                     (viewHolder.itemView as ClipboardHistoryItemView).setPinned()
                     pins[position].text
-                }else {
+                } else {
                     (viewHolder.itemView as ClipboardHistoryItemView).setUnpinned()
                     dataSet[position - pins.size].data.text
                 }
@@ -87,7 +94,7 @@ class ClipboardHistoryItemAdapter(
                 val uri = if (position < pins.size) {
                     (viewHolder.itemView as ClipboardHistoryItemView).setPinned()
                     pins[position].uri
-                }else {
+                } else {
                     (viewHolder.itemView as ClipboardHistoryItemView).setUnpinned()
                     dataSet[position - pins.size].data.uri
                 }
@@ -95,20 +102,73 @@ class ClipboardHistoryItemAdapter(
 
                 viewHolder.imgView.clipToOutline = true
                 viewHolder.imgView.visibility = GONE
-                // For very large images, this can take a bit
-                FlorisClipboardManager.getInstance().executor.execute {
-                    val resolver = FlorisBoard.getInstance().contentResolver
-                    val inputStream = resolver.openInputStream(uri!!)
 
-                    val drawable = Drawable.createFromStream(inputStream, "clipboard URI")
+                // The code looks like a mess because we're jumping across threads so much :(
+                // read dimensions (IO) -> set dimensions (UI) -> read bitmap (IO) -> set bitmap (UI)
+                launch(Dispatchers.IO) {
+                    val resolver = FlorisBoard.getInstance().contentResolver
+                    val (imgWidth, imgHeight) = getImageDimensions(resolver, uri!!)
                     viewHolder.itemView.post {
-                        viewHolder.imgView.setImageDrawable(drawable)
-                        viewHolder.imgView.visibility = VISIBLE
+                        val width = viewHolder.itemView.width
+                        val sampleSize = calcSampleSize(imgWidth, width)
+                        val params = viewHolder.itemView.layoutParams.apply {
+                            height = (width * (imgHeight.toFloat() / imgWidth)).roundToInt() + 30
+                        }
+                        viewHolder.itemView.layoutParams = params
+                        this@ClipboardHistoryItemAdapter.launch(Dispatchers.IO) {
+                            val bitmap = loadSampledBitmap(resolver, uri, sampleSize)
+                            bitmap?.let {
+                                viewHolder.itemView.post {
+                                    viewHolder.imgView.visibility = VISIBLE
+                                    val animator = ValueAnimator.ofFloat(0f, 1f)
+                                    animator.duration = 150
+                                    animator.addUpdateListener {
+                                        viewHolder.imgView.alpha = it.animatedValue as Float
+                                    }
+                                    animator.start()
+                                    viewHolder.imgView.setImageBitmap(bitmap)
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
     }
+
     override fun getItemCount() = pins.size + dataSet.size
+
+    // returns (width, height)
+    private fun getImageDimensions(resolver: ContentResolver, uri: Uri): Pair<Int, Int> {
+        return BitmapFactory.Options().run {
+            inJustDecodeBounds = true
+            val stream = resolver.openInputStream(uri)
+            BitmapFactory.decodeStream(stream, null, this)
+
+            Pair(outWidth, outHeight)
+        }
+    }
+
+    private fun calcSampleSize(imgWidth: Int, reqWidth: Int): Int {
+        var inSampleSize = 2
+        while (imgWidth / inSampleSize > reqWidth) {
+            inSampleSize *= 2
+        }
+        return inSampleSize / 2
+    }
+
+    private fun loadSampledBitmap(resolver: ContentResolver, uri: Uri, inSampleSize: Int): Bitmap? {
+        return BitmapFactory.Options().run {
+            // Calculate inSampleSize
+            this.inSampleSize = inSampleSize
+
+            // Decode bitmap with inSampleSize set
+            inJustDecodeBounds = false
+            val stream2 = resolver.openInputStream(uri)
+            BitmapFactory.decodeStream(stream2, null, this)
+        }
+
+    }
+
 
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/FlorisClipboardManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/FlorisClipboardManager.kt
@@ -3,17 +3,17 @@ package dev.patrickgold.florisboard.ime.clip
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Context.CLIPBOARD_SERVICE
-import android.os.Handler
-import android.os.Looper
 import dev.patrickgold.florisboard.ime.clip.provider.*
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.Preferences
-import dev.patrickgold.florisboard.util.cancelAll
-import dev.patrickgold.florisboard.util.postAtScheduledRate
-import timber.log.Timber
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.io.Closeable
 import java.util.*
-import java.util.concurrent.ExecutorService
 import kotlin.collections.ArrayDeque
 
 /**
@@ -37,9 +37,9 @@ import kotlin.collections.ArrayDeque
  *
  * [ClipboardPopupView] is the view representing a popup displayed when long pressing on a clipboard history item.
  */
-class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryClipChangedListener, Closeable {
+class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryClipChangedListener, Closeable,
+    CoroutineScope by MainScope() {
     private lateinit var pinsDao: PinnedClipboardItemDao
-    lateinit var executor: ExecutorService
 
     // Using ArrayDeque because it's "technically" the correct data structure (I think).
     // Newest stored first, oldest stored last.
@@ -48,8 +48,8 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
     private var current: ClipboardItem? = null
     private var onPrimaryClipChangedListeners: ArrayList<OnPrimaryClipChangedListener> = arrayListOf()
     private lateinit var systemClipboardManager: ClipboardManager
-    private lateinit var handler: Handler
     private val prefs get() = Preferences.default()
+    private lateinit var cleanUpJob: Job
 
     data class TimedClipData(val data: ClipboardItem, val timeUTC: Long)
 
@@ -195,7 +195,8 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
         val systemPrimaryClip = systemClipboardManager.primaryClip
 
         if (systemPrimaryClip?.getItemAt(0)?.text == null &&
-            systemPrimaryClip?.getItemAt(0)?.uri == null) {
+            systemPrimaryClip?.getItemAt(0)?.uri == null
+        ) {
             return
         }
 
@@ -231,7 +232,7 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
      */
     override fun close() {
         systemClipboardManager.removePrimaryClipChangedListener(this)
-        handler.cancelAll()
+        cleanUpJob.cancel()
         instance = null
     }
 
@@ -268,13 +269,17 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
             ClipboardInputManager.getInstance().notifyItemRangeRemoved(pins.size + history.size, numToPop)
         }
         FlorisBoard.getInstance().clipInputManager.initClipboard(this.history, this.pins)
-        handler = Handler(Looper.getMainLooper())
         prefs
-        handler.postAtScheduledRate(0, INTERVAL, cleanUpClipboard)
-        executor = FlorisBoard.getInstance().asyncExecutor
-        executor.execute {
+        cleanUpJob = launch(Dispatchers.Main) {
+
+            while (true) {
+                cleanUpClipboard.run()
+                delay(INTERVAL)
+            }
+        }
+        launch(Dispatchers.IO) {
             pinsDao = PinnedItemsDatabase.getInstance().clipboardItemDao()
-            pinsDao.getAll().toCollection(this.pins)
+            pinsDao.getAll().toCollection(pins)
             FlorisContentProvider.getInstance().initIfNotAlready()
         }
     }
@@ -284,16 +289,17 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
      */
     fun clearHistoryWithAnimation() {
         val clipInputManager = FlorisBoard.getInstance().clipInputManager
-        val delay = clipInputManager.clearClipboardWithAnimation(pins.size, history.size)
+        val animationDelay = clipInputManager.clearClipboardWithAnimation(pins.size, history.size)
 
-        handler.postDelayed({
+        launch(Dispatchers.Main) {
+            delay(animationDelay)
             val size = history.size
             for (item in history) {
                 item.data.close()
             }
             history.clear()
             clipInputManager.notifyItemRangeRemoved(pins.size, size)
-        }, delay)
+        }
     }
 
     fun pinClip(adapterPos: Int) {
@@ -303,7 +309,7 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
         clipInputManager.notifyItemMoved(adapterPos, 0)
         clipInputManager.notifyItemChanged(0)
 
-        executor.execute {
+        launch(Dispatchers.IO) {
             val uid = pinsDao.insert(pin.data)
             pin.data.uid = uid
         }
@@ -347,7 +353,7 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
         clipInputManager.notifyItemMoved(adapterPos, pins.size)
         clipInputManager.notifyItemChanged(pins.size)
 
-        executor.execute {
+        launch(Dispatchers.IO) {
             pinsDao.delete(item)
         }
     }
@@ -356,8 +362,7 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
         when {
             pos < pins.size -> {
                 val item = pins.removeAt(pos)
-                executor.execute {
-                    Timber.d("removing pin")
+                launch(Dispatchers.IO) {
                     pinsDao.delete(item)
                 }
                 item.close()
@@ -386,7 +391,9 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
             clipItem.mimeTypes.any { clipType ->
                 if (editorType != null) {
                     compareMimeTypes(clipType, editorType)
-                }else { false }
+                } else {
+                    false
+                }
             }
         } == true
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/FlorisBoard.kt
@@ -91,8 +91,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 
 /**
  * Variable which holds the current [FlorisBoard] instance. To get this instance from another
@@ -186,8 +184,6 @@ open class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardMa
         }
     }
 
-    lateinit var asyncExecutor: ExecutorService
-
     companion object {
         @Synchronized
         fun getInstance(): FlorisBoard {
@@ -238,7 +234,6 @@ open class FlorisBoard : InputMethodService(), LifecycleOwner, FlorisClipboardMa
 
                 AppVersionUtils.updateVersionOnInstallAndLastUse(this, prefs)
 
-                asyncExecutor = Executors.newSingleThreadExecutor()
                 florisClipboardManager = FlorisClipboardManager.getInstance().also {
                     it.initialize(this)
                     it.addPrimaryClipChangedListener(this)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
@@ -334,7 +334,6 @@ class Preferences(
             const val TRAIL_DURATION =              "glide__trail_fade_duration"
             const val SHOW_PREVIEW =                "glide__show_preview"
             const val PREVIEW_REFRESH_DELAY =       "glide__preview_refresh_delay"
-            const val MAX_TRAIL_LENGTH  =           "glide__trail_max_length"
         }
 
         var enabled: Boolean
@@ -352,9 +351,6 @@ class Preferences(
         var previewRefreshDelay: Int
             get() = prefs.getPref(PREVIEW_REFRESH_DELAY, 150)
             set(v) = prefs.setPref(PREVIEW_REFRESH_DELAY, v)
-        var trailMaxLength: Int
-            get() = prefs.getPref(MAX_TRAIL_LENGTH, 150)
-            set(v) = prefs.setPref(MAX_TRAIL_LENGTH, v)
     }
 
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/StatisticalGlideTypingClassifier.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/StatisticalGlideTypingClassifier.kt
@@ -9,6 +9,7 @@ import dev.patrickgold.florisboard.ime.text.keyboard.TextKey
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import java.text.Normalizer
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.HashMap
 import kotlin.math.*
 
@@ -328,13 +329,18 @@ class StatisticalGlideTypingClassifier : GlideTypingClassifier {
             for (word in words) {
                 val idealGestures = Gesture.generateIdealGestures(word, keysByCharacter)
                 for (idealGesture in idealGestures) {
-                    val wordIdealLength = idealGesture.getLength()
+                    val wordIdealLength = getCachedIdealLength(word, idealGesture)
                     if (abs(userLength - wordIdealLength) < lengthThreshold * radius) {
                         remainingWords.add(word)
                     }
                 }
             }
             return remainingWords
+        }
+
+        val cachedIdealLength = ConcurrentHashMap<String, Float>()
+        private fun getCachedIdealLength(word: String, idealGesture: Gesture): Float {
+            return cachedIdealLength.getOrPut(word, { idealGesture.getLength() })
         }
 
         companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -460,6 +460,5 @@
     <string name="pref__glide_trail_fade_duration">Glide trail fade time</string>
     <string name="pref__glide_preview_refresh_delay">Preview refresh delay</string>
     <string name="pref__glide__show_preview">Show preview while glide typing</string>
-    <string name="pref__glide_trail_max_length">Maximum glide trail length</string>
 
 </resources>

--- a/app/src/main/res/xml/prefs_gestures.xml
+++ b/app/src/main/res/xml/prefs_gestures.xml
@@ -24,18 +24,6 @@
 
         <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
             app:allowDividerAbove="false"
-            android:defaultValue="150"
-            app:dependency="glide__show_trail"
-            app:key="glide__trail_max_length"
-            app:min="25"
-            app:max="1000"
-            app:iconSpaceReserved="false"
-            app:title="@string/pref__glide_trail_max_length"
-            app:seekBarIncrement="25"
-            app:unit=" points"/>
-
-        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
-            app:allowDividerAbove="false"
             android:defaultValue="200"
             app:dependency="glide__show_trail"
             app:key="glide__trail_fade_duration"


### PR DESCRIPTION
Firstly I just wanted to make all the old clipboard code I wrote which used `Executor` and `Handler` use Kotlin coroutines, to make it consistent with the rest of the project.

I also have improved bitmap loading in the clipboard manager a lot -- loading smaller samples in the preview and preventing jerking while the images are loading. Scrolling should be much smoother. 

I have also taken Etienne's advice and cached the ideal word lengths, this should be a decent performance improvement. 

Finally I wanted to make the glide trail fade based on time, not based on how far the pointer travels. It's a much needed bit of polish that makes glide typing look much smoother, while also getting rid of the fairly pointless max length preference.