### PR TITLE
Keyboard data logic rework

### DIFF
--- a/app/src/main/assets/ime/text/characters/extended_popups/tr.json
+++ b/app/src/main/assets/ime/text/characters/extended_popups/tr.json
@@ -29,7 +29,10 @@
         "main": { "$": "auto_text_key", "code":  287, "label": "ğ" }
       },
       "i": {
-        "main": { "$": "auto_text_key", "code":  305, "label": "ı" },
+        "main": { "$": "case_selector",
+          "lower": { "code":  305, "label": "ı" },
+          "upper": { "code":   73, "label": "I" }
+        },
         "relevant": [
           { "$": "auto_text_key", "code":  303, "label": "į" },
           { "$": "auto_text_key", "code":  236, "label": "ì" },
@@ -40,7 +43,10 @@
         ]
       },
       "ı": {
-        "main": { "$": "auto_text_key", "code":  105, "label": "i" },
+        "main": { "$": "case_selector",
+          "lower": { "code":  105, "label": "i" },
+          "upper": { "code":  304, "label": "İ" }
+        },
         "relevant": [
           { "$": "auto_text_key", "code":  303, "label": "į" },
           { "$": "auto_text_key", "code":  236, "label": "ì" },

--- a/app/src/main/assets/ime/text/characters/turkish_f.json
+++ b/app/src/main/assets/ime/text/characters/turkish_f.json
@@ -9,7 +9,10 @@
       { "$": "auto_text_key", "code":  102, "label": "f" },
       { "$": "auto_text_key", "code":  103, "label": "g" },
       { "$": "auto_text_key", "code":  287, "label": "ğ" },
-      { "$": "auto_text_key", "code":  305, "label": "ı" },
+      { "$": "case_selector",
+        "lower": { "code":  305, "label": "ı" },
+        "upper": { "code":   73, "label": "I" }
+      },
       { "$": "auto_text_key", "code":  111, "label": "o" },
       { "$": "auto_text_key", "code":  100, "label": "d" },
       { "$": "auto_text_key", "code":  114, "label": "r" },
@@ -21,7 +24,10 @@
     ],
     [
       { "$": "auto_text_key", "code":  117, "label": "u" },
-      { "$": "auto_text_key", "code":  105, "label": "i" },
+      { "$": "case_selector",
+        "lower": { "code":  105, "label": "i" },
+        "upper": { "code":  304, "label": "İ" }
+      },
       { "$": "auto_text_key", "code":  101, "label": "e" },
       { "$": "auto_text_key", "code":   97, "label": "a" },
       { "$": "auto_text_key", "code":  252, "label": "ü" },

--- a/app/src/main/assets/ime/text/characters/turkish_q.json
+++ b/app/src/main/assets/ime/text/characters/turkish_q.json
@@ -13,7 +13,10 @@
       { "$": "auto_text_key", "code":  116, "label": "t" },
       { "$": "auto_text_key", "code":  121, "label": "y" },
       { "$": "auto_text_key", "code":  117, "label": "u" },
-      { "$": "auto_text_key", "code":  305, "label": "ı" },
+      { "$": "case_selector",
+        "lower": { "code":  305, "label": "ı" },
+        "upper": { "code":   73, "label": "I" }
+      },
       { "$": "auto_text_key", "code":  111, "label": "o" },
       { "$": "auto_text_key", "code":  112, "label": "p" },
       { "$": "auto_text_key", "code":  287, "label": "ğ" },
@@ -30,7 +33,10 @@
       { "$": "auto_text_key", "code":  107, "label": "k" },
       { "$": "auto_text_key", "code":  108, "label": "l" },
       { "$": "auto_text_key", "code":  351, "label": "ş" },
-      { "$": "auto_text_key", "code":  105, "label": "i" }
+      { "$": "case_selector",
+        "lower": { "code":  105, "label": "i" },
+        "upper": { "code":  304, "label": "İ" }
+      }
     ],
     [
       { "$": "auto_text_key", "code":  122, "label": "z" },

--- a/app/src/main/java/dev/patrickgold/florisboard/common/StringBuilder.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/common/StringBuilder.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.common
+
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+inline fun stringBuilder(builder: StringBuilder.() -> Any?): String {
+    contract {
+        callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
+    }
+    val sb = StringBuilder()
+    builder(sb)
+    return sb.toString()
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/ClipboardInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/ClipboardInputManager.kt
@@ -12,7 +12,7 @@ import dev.patrickgold.florisboard.ime.clip.provider.ClipboardItem
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.InputKeyEvent
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
-import dev.patrickgold.florisboard.ime.text.keyboard.BasicTextKeyData
+import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import kotlinx.coroutines.*
 import kotlin.math.pow
 
@@ -128,8 +128,8 @@ class ClipboardInputManager private constructor() : CoroutineScope by MainScope(
         event ?: return false
 
         val data = when (view.id) {
-            R.id.back_to_keyboard_button -> BasicTextKeyData(code = KeyCode.SWITCH_TO_TEXT_CONTEXT)
-            R.id.clear_clipboard_history -> BasicTextKeyData(code = KeyCode.CLEAR_CLIPBOARD_HISTORY)
+            R.id.back_to_keyboard_button -> TextKeyData(code = KeyCode.SWITCH_TO_TEXT_CONTEXT)
+            R.id.clear_clipboard_history -> TextKeyData(code = KeyCode.CLEAR_CLIPBOARD_HISTORY)
             else -> null
         } ?: return false
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputEventDispatcher.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/InputEventDispatcher.kt
@@ -21,8 +21,8 @@ import android.util.SparseArray
 import androidx.core.util.forEach
 import androidx.core.util.set
 import dev.patrickgold.florisboard.BuildConfig
+import dev.patrickgold.florisboard.ime.keyboard.KeyData
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
-import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import timber.log.Timber
@@ -210,7 +210,7 @@ class InputEventDispatcher private constructor(
 data class InputKeyEvent(
     val eventTime: Long,
     val action: Action,
-    val data: TextKeyData,
+    val data: KeyData,
     val count: Int
 ) {
     companion object {
@@ -221,7 +221,7 @@ data class InputKeyEvent(
          *
          * @return The created input key event.
          */
-        fun down(keyData: TextKeyData): InputKeyEvent {
+        fun down(keyData: KeyData): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
                 action = Action.DOWN,
@@ -238,7 +238,7 @@ data class InputKeyEvent(
          *
          * @return The created input key event.
          */
-        fun downUp(keyData: TextKeyData, count: Int = 1): InputKeyEvent {
+        fun downUp(keyData: KeyData, count: Int = 1): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
                 action = Action.DOWN_UP,
@@ -254,7 +254,7 @@ data class InputKeyEvent(
          *
          * @return The created input key event.
          */
-        fun up(keyData: TextKeyData): InputKeyEvent {
+        fun up(keyData: KeyData): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
                 action = Action.UP,
@@ -271,7 +271,7 @@ data class InputKeyEvent(
          *
          * @return The created input key event.
          */
-        fun repeat(keyData: TextKeyData, count: Int = 1): InputKeyEvent {
+        fun repeat(keyData: KeyData, count: Int = 1): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
                 action = Action.REPEAT,
@@ -287,7 +287,7 @@ data class InputKeyEvent(
          *
          * @return The created input key event.
          */
-        fun cancel(keyData: TextKeyData): InputKeyEvent {
+        fun cancel(keyData: KeyData): InputKeyEvent {
             return InputKeyEvent(
                 eventTime = SystemClock.uptimeMillis(),
                 action = Action.CANCEL,

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
@@ -14,47 +14,47 @@
  * limitations under the License.
  */
 
-package dev.patrickgold.florisboard.ime.text.keyboard
+package dev.patrickgold.florisboard.ime.keyboard
 
 import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.text.key.*
 
-interface TextComputingEvaluator {
+interface ComputingEvaluator {
     fun evaluateCaps(): Boolean
 
-    fun evaluateCaps(data: TextKeyData): Boolean
+    fun evaluateCaps(data: KeyData): Boolean
 
-    fun evaluateEnabled(data: TextKeyData): Boolean
+    fun evaluateEnabled(data: KeyData): Boolean
 
-    fun evaluateVisible(data: TextKeyData): Boolean
+    fun evaluateVisible(data: KeyData): Boolean
 
     fun getActiveSubtype(): Subtype
 
     fun getKeyVariation(): KeyVariation
 
-    fun getKeyboard(): TextKeyboard
+    fun getKeyboard(): Keyboard
 
-    fun isSlot(data: TextKeyData): Boolean
+    fun isSlot(data: KeyData): Boolean
 
-    fun getSlotData(data: TextKeyData): TextKeyData?
+    fun getSlotData(data: KeyData): KeyData?
 }
 
-object DefaultTextComputingEvaluator : TextComputingEvaluator {
+object DefaultComputingEvaluator : ComputingEvaluator {
     override fun evaluateCaps(): Boolean = false
 
-    override fun evaluateCaps(data: TextKeyData): Boolean = false
+    override fun evaluateCaps(data: KeyData): Boolean = false
 
-    override fun evaluateEnabled(data: TextKeyData): Boolean = true
+    override fun evaluateEnabled(data: KeyData): Boolean = true
 
-    override fun evaluateVisible(data: TextKeyData): Boolean = true
+    override fun evaluateVisible(data: KeyData): Boolean = true
 
     override fun getActiveSubtype(): Subtype = Subtype.DEFAULT
 
     override fun getKeyVariation(): KeyVariation = KeyVariation.NORMAL
 
-    override fun getKeyboard(): TextKeyboard = throw NotImplementedError()
+    override fun getKeyboard(): Keyboard = throw NotImplementedError()
 
-    override fun isSlot(data: TextKeyData): Boolean = false
+    override fun isSlot(data: KeyData): Boolean = false
 
-    override fun getSlotData(data: TextKeyData): TextKeyData? = null
+    override fun getSlotData(data: KeyData): KeyData? = null
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/keyboard/Key.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/keyboard/Key.kt
@@ -28,7 +28,7 @@ import android.graphics.Rect
  * @property data The base key data this key represents.This can be anything - from a basic text key to an emoji key
  *  to a complex selector.
  */
-abstract class Key(open val data: KeyData) {
+abstract class Key(open val data: AbstractKeyData) {
     /**
      * Specifies whether this key is enabled or not.
      */

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKey.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKey.kt
@@ -23,7 +23,7 @@ import dev.patrickgold.florisboard.ime.popup.PopupSet
 class EmojiKey(override val data: KeyData) : Key(data) {
     var computedData: EmojiKeyData = EmojiKeyData(listOf())
         private set
-    var computedPopups: PopupSet<EmojiKeyData> = PopupSet()
+    var computedPopups: PopupSet<KeyData> = PopupSet()
         private set
 
     companion object {
@@ -32,6 +32,6 @@ class EmojiKey(override val data: KeyData) : Key(data) {
 
     fun dummyCompute() {
         computedData = data as? EmojiKeyData ?: computedData
-        computedPopups = PopupSet(relevant = (data as? EmojiKeyData)?.popup ?: listOf())
+        computedPopups = PopupSet(relevant = (data as? EmojiKeyData)?.popupList ?: listOf())
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyData.kt
@@ -16,11 +16,16 @@
 
 package dev.patrickgold.florisboard.ime.media.emoji
 
+import dev.patrickgold.florisboard.ime.keyboard.AbstractKeyData
+import dev.patrickgold.florisboard.ime.keyboard.ComputingEvaluator
 import dev.patrickgold.florisboard.ime.keyboard.KeyData
-import dev.patrickgold.florisboard.ime.text.keyboard.TextComputingEvaluator
+import dev.patrickgold.florisboard.ime.popup.PopupSet
+import dev.patrickgold.florisboard.ime.text.key.KeyCode
+import dev.patrickgold.florisboard.ime.text.key.KeyType
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * Data class for a single emoji (with possible emoji variants in [popup]). The JSON class identifier for this selector
@@ -34,10 +39,15 @@ import kotlinx.serialization.Serializable
 @SerialName("emoji_key")
 class EmojiKeyData(
     val codePoints: List<Int>,
-    val label: String = "",
-    val popup: MutableList<EmojiKeyData> = mutableListOf()
+    override val label: String = "",
+    val popupList: MutableList<EmojiKeyData> = mutableListOf()
 ) : KeyData {
-    override fun computeTextKeyData(evaluator: TextComputingEvaluator): TextKeyData? {
+    @Transient override val type: KeyType = KeyType.CHARACTER
+    @Transient override val code: Int = KeyCode.UNSPECIFIED
+    @Transient override val groupId: Int = KeyData.GROUP_DEFAULT
+    @Transient override val popup: PopupSet<AbstractKeyData> = PopupSet()
+
+    override fun compute(evaluator: ComputingEvaluator): TextKeyData? {
         return null
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
@@ -137,7 +137,7 @@ class EmojiKeyView(
                         florisboard?.keyPressVibrate()
                         florisboard?.keyPressSound()
                     }
-                    florisboard?.mediaInputManager?.sendEmojiKeyPress(retData)
+                    (retData as? EmojiKeyData)?.let { florisboard?.mediaInputManager?.sendEmojiKeyPress(it) }
                     performClick()
                 }
                 if (event.actionMasked == MotionEvent.ACTION_CANCEL) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiLayoutData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiLayoutData.kt
@@ -151,7 +151,7 @@ fun parseRawEmojiSpecsFile(
                                         WHITE_HAIR,
                                         BALD -> {
                                             // Emoji is extension, add it as popup to last one
-                                            lastKey?.popup?.add(key)
+                                            lastKey?.popupList?.add(key)
                                         }
                                         else -> {
                                             // Emoji is standalone

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupExtension.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupExtension.kt
@@ -16,16 +16,16 @@
 
 package dev.patrickgold.florisboard.ime.popup
 
+import dev.patrickgold.florisboard.ime.keyboard.AbstractKeyData
 import dev.patrickgold.florisboard.res.Asset
 import dev.patrickgold.florisboard.ime.text.key.KeyVariation
-import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import kotlinx.serialization.Serializable
 
 /**
  * An object which maps each base key to its extended popups. This can be done for each
  * key variation. [KeyVariation.ALL] is always the fallback for each key.
  */
-typealias PopupMapping = Map<KeyVariation, Map<String, PopupSet<TextKeyData>>>
+typealias PopupMapping = Map<KeyVariation, Map<String, PopupSet<AbstractKeyData>>>
 
 /**
  * Class which contains an extended popup mapping to use for adding popups subtype based on the

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupLayerView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupLayerView.kt
@@ -21,12 +21,10 @@ import android.content.Context
 import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.MotionEvent
-import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import dev.patrickgold.florisboard.ime.clip.ClipboardPopupManager
 import dev.patrickgold.florisboard.ime.clip.ClipboardPopupView
-import timber.log.Timber
 
 /**
  * Basic helper view class which acts as a non-interactive layer view, which sits above the whole

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupManager.kt
@@ -23,6 +23,7 @@ import android.view.View
 import androidx.core.content.ContextCompat.getDrawable
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.keyboard.Key
+import dev.patrickgold.florisboard.ime.keyboard.KeyData
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiKey
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiKeyData
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiKeyboardView
@@ -496,7 +497,7 @@ class PopupManager<V : View>(
      * @param keyHintConfiguration The key hint configuration to be used.
      * @return The [TextKeyData] object of the currently active key or null.
      */
-    fun getActiveKeyData(key: Key, keyHintConfiguration: KeyHintConfiguration): TextKeyData? {
+    fun getActiveKeyData(key: Key, keyHintConfiguration: KeyHintConfiguration): KeyData? {
         return if (key is TextKey) {
             val element = popupViewExt.properties.getElementOrNull()
             if (element != null) {
@@ -516,7 +517,7 @@ class PopupManager<V : View>(
      * @param key Reference to the key currently controlling the popup.
      * @return The [EmojiKeyData] object of the currently active key or null.
      */
-    fun getActiveEmojiKeyData(key: Key): EmojiKeyData? {
+    fun getActiveEmojiKeyData(key: Key): KeyData? {
         return if (key is EmojiKey) {
             val element = popupViewExt.properties.getElementOrNull()
             if (element != null) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupSet.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/popup/PopupSet.kt
@@ -16,11 +16,10 @@
 
 package dev.patrickgold.florisboard.ime.popup
 
-import dev.patrickgold.florisboard.ime.keyboard.KeyData
+import dev.patrickgold.florisboard.ime.keyboard.AbstractKeyData
+import dev.patrickgold.florisboard.ime.keyboard.ComputingEvaluator
 import dev.patrickgold.florisboard.ime.text.key.KeyHintConfiguration
 import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
-import dev.patrickgold.florisboard.ime.text.keyboard.BasicTextKeyData
-import dev.patrickgold.florisboard.ime.text.keyboard.TextComputingEvaluator
 import kotlinx.serialization.Serializable
 
 /**
@@ -32,7 +31,7 @@ import kotlinx.serialization.Serializable
  * The order in which these defined popups will be shown depends on the current [KeyHintConfiguration].
  */
 @Serializable
-open class PopupSet<T : KeyData>(
+open class PopupSet<T : AbstractKeyData>(
     open val main: T? = null,
     open val relevant: List<T> = listOf()
 ) {
@@ -46,7 +45,7 @@ open class PopupSet<T : KeyData>(
 }
 
 @Suppress("UNCHECKED_CAST")
-class MutablePopupSet<T : KeyData>(
+class MutablePopupSet<T : AbstractKeyData>(
     override var main: T? = null,
     override val relevant: ArrayList<T> = arrayListOf(),
     var symbolHint: T? = null,
@@ -143,27 +142,27 @@ class MutablePopupSet<T : KeyData>(
         }
     }
 
-    fun merge(other: PopupSet<T>, evaluator: TextComputingEvaluator) {
+    fun merge(other: PopupSet<AbstractKeyData>, evaluator: ComputingEvaluator) {
         mergeInternal(other, evaluator, relevant, true)
     }
 
-    fun mergeSymbolHint(hintPopups: PopupSet<T>, evaluator: TextComputingEvaluator) {
+    fun mergeSymbolHint(hintPopups: PopupSet<AbstractKeyData>, evaluator: ComputingEvaluator) {
         mergeInternal(hintPopups, evaluator, symbolPopups)
     }
 
-    fun mergeNumberHint(hintPopups: PopupSet<T>, evaluator: TextComputingEvaluator) {
+    fun mergeNumberHint(hintPopups: PopupSet<AbstractKeyData>, evaluator: ComputingEvaluator) {
         mergeInternal(hintPopups, evaluator, numberPopups)
     }
 
-    private fun mergeInternal(other: PopupSet<T>, evaluator: TextComputingEvaluator, targetList: MutableList<T>, useMain: Boolean = false) {
+    private fun mergeInternal(other: PopupSet<AbstractKeyData>, evaluator: ComputingEvaluator, targetList: MutableList<T>, useMain: Boolean = false) {
         other.relevant.forEach {
-            val data = it.computeTextKeyData(evaluator) as? T
+            val data = it.compute(evaluator) as? T
             if (data != null) {
                 targetList.add(data)
             }
         }
         other.main?.let {
-            val data = it.computeTextKeyData(evaluator) as? T
+            val data = it.compute(evaluator) as? T
             if (data != null) {
                 if (useMain && main == null) {
                     main = data

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -26,11 +26,14 @@ import dev.patrickgold.florisboard.debug.*
 import dev.patrickgold.florisboard.ime.clip.provider.ClipboardItem
 import dev.patrickgold.florisboard.ime.core.*
 import dev.patrickgold.florisboard.ime.dictionary.DictionaryManager
+import dev.patrickgold.florisboard.ime.keyboard.ComputingEvaluator
 import dev.patrickgold.florisboard.res.AssetManager
 import dev.patrickgold.florisboard.res.AssetRef
 import dev.patrickgold.florisboard.res.AssetSource
 import dev.patrickgold.florisboard.ime.keyboard.ImeOptions
 import dev.patrickgold.florisboard.ime.keyboard.InputAttributes
+import dev.patrickgold.florisboard.ime.keyboard.KeyData
+import dev.patrickgold.florisboard.ime.keyboard.Keyboard
 import dev.patrickgold.florisboard.ime.keyboard.KeyboardState
 import dev.patrickgold.florisboard.ime.keyboard.updateKeyboardState
 import dev.patrickgold.florisboard.ime.text.gestures.GlideTypingManager
@@ -112,16 +115,16 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
         this.symbolsWithSpaceAfter = List(json.length()){ json.getString(it) }
     }
 
-    val evaluator = object : TextComputingEvaluator {
+    val evaluator = object : ComputingEvaluator {
         override fun evaluateCaps(): Boolean {
             return activeState.caps || activeState.capsLock
         }
 
-        override fun evaluateCaps(data: TextKeyData): Boolean {
+        override fun evaluateCaps(data: KeyData): Boolean {
             return evaluateCaps() && data.code >= KeyCode.SPACE
         }
 
-        override fun evaluateEnabled(data: TextKeyData): Boolean {
+        override fun evaluateEnabled(data: KeyData): Boolean {
             return when (data.code) {
                 KeyCode.CLIPBOARD_COPY,
                 KeyCode.CLIPBOARD_CUT -> {
@@ -145,7 +148,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
             }
         }
 
-        override fun evaluateVisible(data: TextKeyData): Boolean {
+        override fun evaluateVisible(data: KeyData): Boolean {
             return when (data.code) {
                 KeyCode.SWITCH_TO_TEXT_CONTEXT,
                 KeyCode.SWITCH_TO_MEDIA_CONTEXT -> {
@@ -187,15 +190,15 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
             return activeState.keyVariation
         }
 
-        override fun getKeyboard(): TextKeyboard {
+        override fun getKeyboard(): Keyboard {
             throw NotImplementedError() // Correct value must be inserted by the TextKeyboardView
         }
 
-        override fun isSlot(data: TextKeyData): Boolean {
+        override fun isSlot(data: KeyData): Boolean {
             return CurrencySet.isCurrencySlot(data.code)
         }
 
-        override fun getSlotData(data: TextKeyData): TextKeyData? {
+        override fun getSlotData(data: KeyData): KeyData? {
             return florisboard.subtypeManager.getCurrencySet(getActiveSubtype()).getSlot(data.code)
         }
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/CurrencySet.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/key/CurrencySet.kt
@@ -16,7 +16,6 @@
 
 package dev.patrickgold.florisboard.ime.text.key
 
-import dev.patrickgold.florisboard.ime.text.keyboard.BasicTextKeyData
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import kotlinx.serialization.Serializable
 import kotlin.math.abs
@@ -44,12 +43,12 @@ class CurrencySet(
             name = "\$default",
             label = "Default",
             slots = listOf(
-                BasicTextKeyData(code =   36, label = "$"),
-                BasicTextKeyData(code =  162, label = "¢"),
-                BasicTextKeyData(code = 8364, label = "€"),
-                BasicTextKeyData(code =  163, label = "£"),
-                BasicTextKeyData(code =  165, label = "¥"),
-                BasicTextKeyData(code = 8369, label = "₱")
+                TextKeyData(code =   36, label = "$"),
+                TextKeyData(code =  162, label = "¢"),
+                TextKeyData(code = 8364, label = "€"),
+                TextKeyData(code =  163, label = "£"),
+                TextKeyData(code =  165, label = "¥"),
+                TextKeyData(code = 8369, label = "₱")
             )
         )
     }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
@@ -16,283 +16,15 @@
 
 package dev.patrickgold.florisboard.ime.text.keyboard
 
+import dev.patrickgold.florisboard.common.stringBuilder
+import dev.patrickgold.florisboard.ime.keyboard.AbstractKeyData
+import dev.patrickgold.florisboard.ime.keyboard.ComputingEvaluator
 import dev.patrickgold.florisboard.ime.keyboard.KeyData
 import dev.patrickgold.florisboard.ime.popup.PopupSet
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyType
 import kotlinx.serialization.*
 import java.util.*
-
-interface TextKeyData : KeyData {
-    val type: KeyType
-    val code: Int
-    val label: String
-    val groupId: Int
-
-    override fun asString(isForDisplay: Boolean): String {
-        return StringBuilder().run {
-            if (!isForDisplay && code == KeyCode.MULTIPLE_CODE_POINTS) {
-                if (this@TextKeyData is MultiTextKeyData) {
-                    for (codePoint in codePoints) {
-                        if (Character.isBmpCodePoint(codePoint)) {
-                            append(codePoint.toChar())
-                        } else {
-                            try {
-                                append(Character.toChars(codePoint))
-                            } catch (_: Throwable) {
-                            }
-                        }
-                    }
-                }
-            } else if (isForDisplay || code == KeyCode.URI_COMPONENT_TLD || code < KeyCode.SPACE) {
-                // Combining Diacritical Marks
-                // See: https://en.wikipedia.org/wiki/Combining_Diacritical_Marks
-                if (code in 0x0300..0x036F) {
-                    append("◌")
-                }
-                append(label)
-            } else {
-                if (Character.isBmpCodePoint(code)) {
-                    append(code.toChar())
-                } else {
-                    try {
-                        append(Character.toChars(code))
-                    } catch (_: Throwable) {
-                    }
-                }
-            }
-            toString()
-        }
-    }
-
-    companion object {
-        /** Predefined key data for [KeyCode.ARROW_DOWN] */
-        val ARROW_DOWN = BasicTextKeyData(
-            type = KeyType.NAVIGATION,
-            code = KeyCode.ARROW_DOWN,
-            label = "arrow_down"
-        )
-
-        /** Predefined key data for [KeyCode.ARROW_LEFT] */
-        val ARROW_LEFT = BasicTextKeyData(
-            type = KeyType.NAVIGATION,
-            code = KeyCode.ARROW_LEFT,
-            label = "arrow_left"
-        )
-
-        /** Predefined key data for [KeyCode.ARROW_RIGHT] */
-        val ARROW_RIGHT = BasicTextKeyData(
-            type = KeyType.NAVIGATION,
-            code = KeyCode.ARROW_RIGHT,
-            label = "arrow_right"
-        )
-
-        /** Predefined key data for [KeyCode.ARROW_UP] */
-        val ARROW_UP = BasicTextKeyData(
-            type = KeyType.NAVIGATION,
-            code = KeyCode.ARROW_UP,
-            label = "arrow_up"
-        )
-
-        /** Predefined key data for [KeyCode.CLIPBOARD_COPY] */
-        val CLIPBOARD_COPY = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.CLIPBOARD_COPY,
-            label = "clipboard_copy"
-        )
-
-        /** Predefined key data for [KeyCode.CLIPBOARD_CUT] */
-        val CLIPBOARD_CUT = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.CLIPBOARD_CUT,
-            label = "clipboard_cut"
-        )
-
-        /** Predefined key data for [KeyCode.CLIPBOARD_PASTE] */
-        val CLIPBOARD_PASTE = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.CLIPBOARD_PASTE,
-            label = "clipboard_paste"
-        )
-
-        /** Predefined key data for [KeyCode.CLIPBOARD_SELECT] */
-        val CLIPBOARD_SELECT = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.CLIPBOARD_SELECT,
-            label = "clipboard_select"
-        )
-
-        /** Predefined key data for [KeyCode.CLIPBOARD_SELECT_ALL] */
-        val CLIPBOARD_SELECT_ALL = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.CLIPBOARD_SELECT_ALL,
-            label = "clipboard_select_all"
-        )
-
-        /** Predefined key data for [KeyCode.DELETE] */
-        val DELETE = BasicTextKeyData(
-            type = KeyType.ENTER_EDITING,
-            code = KeyCode.DELETE,
-            label = "delete"
-        )
-
-        /** Predefined key data for [KeyCode.DELETE_WORD] */
-        val DELETE_WORD = BasicTextKeyData(
-            type = KeyType.ENTER_EDITING,
-            code = KeyCode.DELETE_WORD,
-            label = "delete_word"
-        )
-
-        /** Predefined key data for [KeyCode.INTERNAL_BATCH_EDIT] */
-        val INTERNAL_BATCH_EDIT = BasicTextKeyData(
-            type = KeyType.FUNCTION,
-            code = KeyCode.INTERNAL_BATCH_EDIT,
-            label = "internal_batch_edit"
-        )
-
-        /** Predefined key data for [KeyCode.MOVE_START_OF_LINE] */
-        val MOVE_START_OF_LINE = BasicTextKeyData(
-            type = KeyType.NAVIGATION,
-            code = KeyCode.MOVE_START_OF_LINE,
-            label = "move_start_of_line"
-        )
-
-        /** Predefined key data for [KeyCode.MOVE_END_OF_LINE] */
-        val MOVE_END_OF_LINE = BasicTextKeyData(
-            type = KeyType.NAVIGATION,
-            code = KeyCode.MOVE_END_OF_LINE,
-            label = "move_end_of_line"
-        )
-
-        /** Predefined key data for [KeyCode.MOVE_START_OF_PAGE] */
-        val MOVE_START_OF_PAGE = BasicTextKeyData(
-            type = KeyType.NAVIGATION,
-            code = KeyCode.MOVE_START_OF_PAGE,
-            label = "move_start_of_page"
-        )
-
-        /** Predefined key data for [KeyCode.MOVE_END_OF_PAGE] */
-        val MOVE_END_OF_PAGE = BasicTextKeyData(
-            type = KeyType.NAVIGATION,
-            code = KeyCode.MOVE_END_OF_PAGE,
-            label = "move_end_of_page"
-        )
-
-        /** Predefined key data for [KeyCode.REDO] */
-        val REDO = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.REDO,
-            label = "redo"
-        )
-
-        /** Predefined key data for [KeyCode.SHOW_INPUT_METHOD_PICKER] */
-        val SHOW_INPUT_METHOD_PICKER = BasicTextKeyData(
-            type = KeyType.FUNCTION,
-            code = KeyCode.SHOW_INPUT_METHOD_PICKER,
-            label = "show_input_method_picker"
-        )
-
-        /** Predefined key data for [KeyCode.SWITCH_TO_TEXT_CONTEXT] */
-        val SWITCH_TO_TEXT_CONTEXT = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.SWITCH_TO_TEXT_CONTEXT,
-            label = "switch_to_text_context"
-        )
-        /** Predefined key data for [KeyCode.SWITCH_TO_CLIPBOARD_CONTEXT] */
-        val SWITCH_TO_CLIPBOARD_CONTEXT = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.SWITCH_TO_CLIPBOARD_CONTEXT,
-            label = "switch_to_clipboard_context"
-        )
-
-        /** Predefined key data for [KeyCode.SHIFT] */
-        val SHIFT = BasicTextKeyData(
-            type = KeyType.MODIFIER,
-            code = KeyCode.SHIFT,
-            label = "shift"
-        )
-
-        /** Predefined key data for [KeyCode.SHIFT_LOCK] */
-        val SHIFT_LOCK = BasicTextKeyData(
-            type = KeyType.MODIFIER,
-            code = KeyCode.SHIFT_LOCK,
-            label = "shift_lock"
-        )
-
-        /** Predefined key data for [KeyCode.SPACE] */
-        val SPACE = BasicTextKeyData(
-            type = KeyType.CHARACTER,
-            code = KeyCode.SPACE,
-            label = "space"
-        )
-
-        /** Predefined key data for [KeyCode.UNDO] */
-        val UNDO = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.UNDO,
-            label = "undo"
-        )
-
-        /** Predefined key data for [KeyCode.UNSPECIFIED] */
-        val UNSPECIFIED = BasicTextKeyData(
-            type = KeyType.UNSPECIFIED,
-            code = KeyCode.UNSPECIFIED,
-            label = "unspecified"
-        )
-
-        /** Predefined key data for [KeyCode.VIEW_CHARACTERS] */
-        val VIEW_CHARACTERS = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.VIEW_CHARACTERS,
-            label = "view_characters"
-        )
-
-        /** Predefined key data for [KeyCode.VIEW_SYMBOLS] */
-        val VIEW_SYMBOLS = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.VIEW_SYMBOLS,
-            label = "view_symbols"
-        )
-
-        /** Predefined key data for [KeyCode.VIEW_SYMBOLS2] */
-        val VIEW_SYMBOLS2 = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.VIEW_SYMBOLS2,
-            label = "view_symbols2"
-        )
-
-        /** Predefined key data for [KeyCode.VIEW_NUMERIC_ADVANCED] */
-        val VIEW_NUMERIC_ADVANCED = BasicTextKeyData(
-            type = KeyType.SYSTEM_GUI,
-            code = KeyCode.VIEW_NUMERIC_ADVANCED,
-            label = "view_numeric_advanced"
-        )
-
-        /**
-         * Constant for the default group. If not otherwise specified, any key is automatically
-         * assigned to this group.
-         */
-        const val GROUP_DEFAULT: Int = 0
-
-        /**
-         * Constant for the Left modifier key group. Any key belonging to this group will get the
-         * popups specified for "~left" in the popup mapping.
-         */
-        const val GROUP_LEFT: Int = 1
-
-        /**
-         * Constant for the right modifier key group. Any key belonging to this group will get the
-         * popups specified for "~right" in the popup mapping.
-         */
-        const val GROUP_RIGHT: Int = 2
-
-        /**
-         * Constant for the enter modifier key group. Any key belonging to this group will get the
-         * popups specified for "~enter" in the popup mapping.
-         */
-        const val GROUP_ENTER: Int = 3
-    }
-}
 
 /**
  * Data class which describes a single key and its attributes.
@@ -307,28 +39,242 @@ interface TextKeyData : KeyData {
  */
 @Serializable
 @SerialName("text_key")
-class BasicTextKeyData(
+class TextKeyData(
     override val type: KeyType = KeyType.CHARACTER,
     override val code: Int = KeyCode.UNSPECIFIED,
     override val label: String = "",
-    override val groupId: Int = TextKeyData.GROUP_DEFAULT,
-    val popup: PopupSet<TextKeyData>? = null
-) : TextKeyData {
-    override fun computeTextKeyData(evaluator: TextComputingEvaluator): TextKeyData? {
+    override val groupId: Int = KeyData.GROUP_DEFAULT,
+    override val popup: PopupSet<AbstractKeyData>? = null
+) : KeyData {
+    override fun compute(evaluator: ComputingEvaluator): KeyData? {
         return if (evaluator.isSlot(this)) {
-            val slotData = evaluator.getSlotData(this)
-            if (slotData != null) {
-                BasicTextKeyData(slotData.type, slotData.code, slotData.label, slotData.groupId, popup)
-            } else {
-                null
-            }
+            evaluator.getSlotData(this)
         } else {
             this
         }
     }
 
+    override fun asString(isForDisplay: Boolean): String {
+        return stringBuilder {
+            if (isForDisplay || code == KeyCode.URI_COMPONENT_TLD || code < KeyCode.SPACE) {
+                // Combining Diacritical Marks
+                // See: https://en.wikipedia.org/wiki/Combining_Diacritical_Marks
+                if (code in 0x0300..0x036F) {
+                    append("◌")
+                }
+                append(label)
+            } else {
+                try { appendCodePoint(code) } catch (_: Throwable) { }
+            }
+        }
+    }
+
     override fun toString(): String {
-        return "${BasicTextKeyData::class.simpleName} { type=$type code=$code label=\"$label\" groupId=$groupId }"
+        return "${TextKeyData::class.simpleName} { type=$type code=$code label=\"$label\" groupId=$groupId }"
+    }
+
+    companion object {
+        /** Predefined key data for [KeyCode.ARROW_DOWN] */
+        val ARROW_DOWN = TextKeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.ARROW_DOWN,
+            label = "arrow_down"
+        )
+
+        /** Predefined key data for [KeyCode.ARROW_LEFT] */
+        val ARROW_LEFT = TextKeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.ARROW_LEFT,
+            label = "arrow_left"
+        )
+
+        /** Predefined key data for [KeyCode.ARROW_RIGHT] */
+        val ARROW_RIGHT = TextKeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.ARROW_RIGHT,
+            label = "arrow_right"
+        )
+
+        /** Predefined key data for [KeyCode.ARROW_UP] */
+        val ARROW_UP = TextKeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.ARROW_UP,
+            label = "arrow_up"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_COPY] */
+        val CLIPBOARD_COPY = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_COPY,
+            label = "clipboard_copy"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_CUT] */
+        val CLIPBOARD_CUT = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_CUT,
+            label = "clipboard_cut"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_PASTE] */
+        val CLIPBOARD_PASTE = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_PASTE,
+            label = "clipboard_paste"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_SELECT] */
+        val CLIPBOARD_SELECT = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_SELECT,
+            label = "clipboard_select"
+        )
+
+        /** Predefined key data for [KeyCode.CLIPBOARD_SELECT_ALL] */
+        val CLIPBOARD_SELECT_ALL = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.CLIPBOARD_SELECT_ALL,
+            label = "clipboard_select_all"
+        )
+
+        /** Predefined key data for [KeyCode.DELETE] */
+        val DELETE = TextKeyData(
+            type = KeyType.ENTER_EDITING,
+            code = KeyCode.DELETE,
+            label = "delete"
+        )
+
+        /** Predefined key data for [KeyCode.DELETE_WORD] */
+        val DELETE_WORD = TextKeyData(
+            type = KeyType.ENTER_EDITING,
+            code = KeyCode.DELETE_WORD,
+            label = "delete_word"
+        )
+
+        /** Predefined key data for [KeyCode.INTERNAL_BATCH_EDIT] */
+        val INTERNAL_BATCH_EDIT = TextKeyData(
+            type = KeyType.FUNCTION,
+            code = KeyCode.INTERNAL_BATCH_EDIT,
+            label = "internal_batch_edit"
+        )
+
+        /** Predefined key data for [KeyCode.MOVE_START_OF_LINE] */
+        val MOVE_START_OF_LINE = TextKeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.MOVE_START_OF_LINE,
+            label = "move_start_of_line"
+        )
+
+        /** Predefined key data for [KeyCode.MOVE_END_OF_LINE] */
+        val MOVE_END_OF_LINE = TextKeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.MOVE_END_OF_LINE,
+            label = "move_end_of_line"
+        )
+
+        /** Predefined key data for [KeyCode.MOVE_START_OF_PAGE] */
+        val MOVE_START_OF_PAGE = TextKeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.MOVE_START_OF_PAGE,
+            label = "move_start_of_page"
+        )
+
+        /** Predefined key data for [KeyCode.MOVE_END_OF_PAGE] */
+        val MOVE_END_OF_PAGE = TextKeyData(
+            type = KeyType.NAVIGATION,
+            code = KeyCode.MOVE_END_OF_PAGE,
+            label = "move_end_of_page"
+        )
+
+        /** Predefined key data for [KeyCode.REDO] */
+        val REDO = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.REDO,
+            label = "redo"
+        )
+
+        /** Predefined key data for [KeyCode.SHOW_INPUT_METHOD_PICKER] */
+        val SHOW_INPUT_METHOD_PICKER = TextKeyData(
+            type = KeyType.FUNCTION,
+            code = KeyCode.SHOW_INPUT_METHOD_PICKER,
+            label = "show_input_method_picker"
+        )
+
+        /** Predefined key data for [KeyCode.SWITCH_TO_TEXT_CONTEXT] */
+        val SWITCH_TO_TEXT_CONTEXT = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.SWITCH_TO_TEXT_CONTEXT,
+            label = "switch_to_text_context"
+        )
+        /** Predefined key data for [KeyCode.SWITCH_TO_CLIPBOARD_CONTEXT] */
+        val SWITCH_TO_CLIPBOARD_CONTEXT = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.SWITCH_TO_CLIPBOARD_CONTEXT,
+            label = "switch_to_clipboard_context"
+        )
+
+        /** Predefined key data for [KeyCode.SHIFT] */
+        val SHIFT = TextKeyData(
+            type = KeyType.MODIFIER,
+            code = KeyCode.SHIFT,
+            label = "shift"
+        )
+
+        /** Predefined key data for [KeyCode.SHIFT_LOCK] */
+        val SHIFT_LOCK = TextKeyData(
+            type = KeyType.MODIFIER,
+            code = KeyCode.SHIFT_LOCK,
+            label = "shift_lock"
+        )
+
+        /** Predefined key data for [KeyCode.SPACE] */
+        val SPACE = TextKeyData(
+            type = KeyType.CHARACTER,
+            code = KeyCode.SPACE,
+            label = "space"
+        )
+
+        /** Predefined key data for [KeyCode.UNDO] */
+        val UNDO = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.UNDO,
+            label = "undo"
+        )
+
+        /** Predefined key data for [KeyCode.UNSPECIFIED] */
+        val UNSPECIFIED = TextKeyData(
+            type = KeyType.UNSPECIFIED,
+            code = KeyCode.UNSPECIFIED,
+            label = "unspecified"
+        )
+
+        /** Predefined key data for [KeyCode.VIEW_CHARACTERS] */
+        val VIEW_CHARACTERS = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.VIEW_CHARACTERS,
+            label = "view_characters"
+        )
+
+        /** Predefined key data for [KeyCode.VIEW_SYMBOLS] */
+        val VIEW_SYMBOLS = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.VIEW_SYMBOLS,
+            label = "view_symbols"
+        )
+
+        /** Predefined key data for [KeyCode.VIEW_SYMBOLS2] */
+        val VIEW_SYMBOLS2 = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.VIEW_SYMBOLS2,
+            label = "view_symbols2"
+        )
+
+        /** Predefined key data for [KeyCode.VIEW_NUMERIC_ADVANCED] */
+        val VIEW_NUMERIC_ADVANCED = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.VIEW_NUMERIC_ADVANCED,
+            label = "view_numeric_advanced"
+        )
     }
 }
 
@@ -338,24 +284,34 @@ class AutoTextKeyData(
     override val type: KeyType = KeyType.CHARACTER,
     override val code: Int = KeyCode.UNSPECIFIED,
     override val label: String = "",
-    override val groupId: Int = TextKeyData.GROUP_DEFAULT,
-    val popup: PopupSet<TextKeyData>? = null
-) : TextKeyData {
-    @Transient private val lower: BasicTextKeyData =
-        BasicTextKeyData(type, Character.toLowerCase(code), label.lowercase(Locale.getDefault()), groupId, popup)
-    @Transient private val upper: BasicTextKeyData =
-        BasicTextKeyData(type, Character.toUpperCase(code), label.uppercase(Locale.getDefault()), groupId, popup)
+    override val groupId: Int = KeyData.GROUP_DEFAULT,
+    override val popup: PopupSet<AbstractKeyData>? = null
+) : KeyData {
+    @Transient private val lower: TextKeyData =
+        TextKeyData(type, Character.toLowerCase(code), label.lowercase(Locale.getDefault()), groupId, popup)
+    @Transient private val upper: TextKeyData =
+        TextKeyData(type, Character.toUpperCase(code), label.uppercase(Locale.getDefault()), groupId, popup)
 
-    override fun computeTextKeyData(evaluator: TextComputingEvaluator): TextKeyData? {
+    override fun compute(evaluator: ComputingEvaluator): KeyData? {
         return if (evaluator.isSlot(this)) {
-            val slotData = evaluator.getSlotData(this)
-            if (slotData != null) {
-                BasicTextKeyData(slotData.type, slotData.code, slotData.label, slotData.groupId, popup)
-            } else {
-                null
-            }
+            evaluator.getSlotData(this)
         } else {
             if (evaluator.evaluateCaps(this)) { upper } else { lower }
+        }
+    }
+
+    override fun asString(isForDisplay: Boolean): String {
+        return stringBuilder {
+            if (isForDisplay || code == KeyCode.URI_COMPONENT_TLD || code < KeyCode.SPACE) {
+                // Combining Diacritical Marks
+                // See: https://en.wikipedia.org/wiki/Combining_Diacritical_Marks
+                if (code in 0x0300..0x036F) {
+                    append("◌")
+                }
+                append(label)
+            } else {
+                try { appendCodePoint(code) } catch (_: Throwable) { }
+            }
         }
     }
 
@@ -370,16 +326,28 @@ class MultiTextKeyData(
     override val type: KeyType = KeyType.CHARACTER,
     val codePoints: IntArray = intArrayOf(),
     override val label: String = "",
-    override val groupId: Int = TextKeyData.GROUP_DEFAULT,
-    val popup: PopupSet<TextKeyData>? = null
-) : TextKeyData {
+    override val groupId: Int = KeyData.GROUP_DEFAULT,
+    override val popup: PopupSet<AbstractKeyData>? = null
+) : KeyData {
     @Transient override val code: Int = KeyCode.MULTIPLE_CODE_POINTS
 
-    override fun computeTextKeyData(evaluator: TextComputingEvaluator): TextKeyData {
+    override fun compute(evaluator: ComputingEvaluator): KeyData {
         return this
     }
 
+    override fun asString(isForDisplay: Boolean): String {
+        return stringBuilder {
+            if (isForDisplay) {
+                append(label)
+            } else {
+                for (codePoint in codePoints) {
+                    try { appendCodePoint(codePoint) } catch (_: Throwable) { }
+                }
+            }
+        }
+    }
+
     override fun toString(): String {
-        return "${AutoTextKeyData::class.simpleName} { type=$type code=$code label=\"$label\" groupId=$groupId }"
+        return "${MultiTextKeyData::class.simpleName} { type=$type code=$code label=\"$label\" groupId=$groupId }"
     }
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
@@ -59,7 +59,7 @@ class TextKeyData(
             if (isForDisplay || code == KeyCode.URI_COMPONENT_TLD || code < KeyCode.SPACE) {
                 // Combining Diacritical Marks
                 // See: https://en.wikipedia.org/wiki/Combining_Diacritical_Marks
-                if (code in 0x0300..0x036F) {
+                if (code in 0x0300..0x036F && !label.startsWith("◌")) {
                     append("◌")
                 }
                 append(label)
@@ -305,7 +305,7 @@ class AutoTextKeyData(
             if (isForDisplay || code == KeyCode.URI_COMPONENT_TLD || code < KeyCode.SPACE) {
                 // Combining Diacritical Marks
                 // See: https://en.wikipedia.org/wiki/Combining_Diacritical_Marks
-                if (code in 0x0300..0x036F) {
+                if (code in 0x0300..0x036F && !label.startsWith("◌")) {
                     append("◌")
                 }
                 append(label)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
@@ -30,7 +30,11 @@ import dev.patrickgold.florisboard.common.PointerMap
 import dev.patrickgold.florisboard.common.ViewUtils
 import dev.patrickgold.florisboard.debug.*
 import dev.patrickgold.florisboard.ime.core.*
+import dev.patrickgold.florisboard.ime.keyboard.ComputingEvaluator
+import dev.patrickgold.florisboard.ime.keyboard.DefaultComputingEvaluator
 import dev.patrickgold.florisboard.ime.keyboard.ImeOptions
+import dev.patrickgold.florisboard.ime.keyboard.KeyData
+import dev.patrickgold.florisboard.ime.keyboard.Keyboard
 import dev.patrickgold.florisboard.ime.keyboard.KeyboardState
 import dev.patrickgold.florisboard.ime.keyboard.KeyboardView
 import dev.patrickgold.florisboard.ime.popup.PopupManager
@@ -62,51 +66,51 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
     private var cachedTheme: Theme? = null
     private var cachedState: KeyboardState = KeyboardState.new(maskOfInterest = KeyboardState.INTEREST_TEXT)
 
-    private var externalComputingEvaluator: TextComputingEvaluator? = null
-    private val internalComputingEvaluator = object : TextComputingEvaluator {
+    private var externalComputingEvaluator: ComputingEvaluator? = null
+    private val internalComputingEvaluator = object : ComputingEvaluator {
         override fun evaluateCaps(): Boolean {
             return externalComputingEvaluator?.evaluateCaps()
-                ?: DefaultTextComputingEvaluator.evaluateCaps()
+                ?: DefaultComputingEvaluator.evaluateCaps()
         }
 
-        override fun evaluateCaps(data: TextKeyData): Boolean {
+        override fun evaluateCaps(data: KeyData): Boolean {
             return externalComputingEvaluator?.evaluateCaps(data)
-                ?: DefaultTextComputingEvaluator.evaluateCaps(data)
+                ?: DefaultComputingEvaluator.evaluateCaps(data)
         }
 
-        override fun evaluateEnabled(data: TextKeyData): Boolean {
+        override fun evaluateEnabled(data: KeyData): Boolean {
             return externalComputingEvaluator?.evaluateEnabled(data)
-                ?: DefaultTextComputingEvaluator.evaluateEnabled(data)
+                ?: DefaultComputingEvaluator.evaluateEnabled(data)
         }
 
-        override fun evaluateVisible(data: TextKeyData): Boolean {
+        override fun evaluateVisible(data: KeyData): Boolean {
             return externalComputingEvaluator?.evaluateVisible(data)
-                ?: DefaultTextComputingEvaluator.evaluateVisible(data)
+                ?: DefaultComputingEvaluator.evaluateVisible(data)
         }
 
         override fun getActiveSubtype(): Subtype {
             return externalComputingEvaluator?.getActiveSubtype()
-                ?: DefaultTextComputingEvaluator.getActiveSubtype()
+                ?: DefaultComputingEvaluator.getActiveSubtype()
         }
 
         override fun getKeyVariation(): KeyVariation {
             return externalComputingEvaluator?.getKeyVariation()
-                ?: DefaultTextComputingEvaluator.getKeyVariation()
+                ?: DefaultComputingEvaluator.getKeyVariation()
         }
 
-        override fun getKeyboard(): TextKeyboard {
+        override fun getKeyboard(): Keyboard {
             return computedKeyboard // Purposely not calling the external evaluator!
-                ?: DefaultTextComputingEvaluator.getKeyboard()
+                ?: DefaultComputingEvaluator.getKeyboard()
         }
 
-        override fun isSlot(data: TextKeyData): Boolean {
+        override fun isSlot(data: KeyData): Boolean {
             return externalComputingEvaluator?.isSlot(data)
-                ?: DefaultTextComputingEvaluator.isSlot(data)
+                ?: DefaultComputingEvaluator.isSlot(data)
         }
 
-        override fun getSlotData(data: TextKeyData): TextKeyData? {
+        override fun getSlotData(data: KeyData): KeyData? {
             return externalComputingEvaluator?.getSlotData(data)
-                ?: DefaultTextComputingEvaluator.getSlotData(data)
+                ?: DefaultComputingEvaluator.getSlotData(data)
         }
     }
 
@@ -173,7 +177,7 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
         setWillNotDraw(false)
     }
 
-    fun setComputingEvaluator(evaluator: TextComputingEvaluator?) {
+    fun setComputingEvaluator(evaluator: ComputingEvaluator?) {
         externalComputingEvaluator = evaluator
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/Layout.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/Layout.kt
@@ -16,10 +16,10 @@
 
 package dev.patrickgold.florisboard.ime.text.layout
 
+import dev.patrickgold.florisboard.ime.keyboard.AbstractKeyData
 import dev.patrickgold.florisboard.res.Asset
-import dev.patrickgold.florisboard.ime.keyboard.KeyData
 import dev.patrickgold.florisboard.ime.text.key.*
-import dev.patrickgold.florisboard.ime.text.keyboard.BasicTextKeyData
+import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -30,7 +30,7 @@ data class Layout(
     override val authors: List<String>,
     val direction: String,
     val modifier: String? = null,
-    val arrangement: List<List<KeyData>> = listOf()
+    val arrangement: List<List<AbstractKeyData>> = listOf()
 ) : Asset {
     companion object {
         val PRE_GENERATED_LOADING_KEYBOARD = Layout(
@@ -41,46 +41,46 @@ data class Layout(
             direction = "ltr",
             arrangement = listOf(
                 listOf(
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0)
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0)
                 ),
                 listOf(
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0)
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0)
                 ),
                 listOf(
-                    BasicTextKeyData(code = KeyCode.SHIFT, type = KeyType.MODIFIER, label = "shift"),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = KeyCode.DELETE, type = KeyType.ENTER_EDITING, label = "delete")
+                    TextKeyData(code = KeyCode.SHIFT, type = KeyType.MODIFIER, label = "shift"),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = KeyCode.DELETE, type = KeyType.ENTER_EDITING, label = "delete")
                 ),
                 listOf(
-                    BasicTextKeyData(code = KeyCode.VIEW_SYMBOLS, type = KeyType.SYSTEM_GUI, label = "view_symbols"),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = KeyCode.SPACE, label = "space"),
-                    BasicTextKeyData(code = 0),
-                    BasicTextKeyData(code = KeyCode.ENTER, type = KeyType.ENTER_EDITING, label = "enter")
+                    TextKeyData(code = KeyCode.VIEW_SYMBOLS, type = KeyType.SYSTEM_GUI, label = "view_symbols"),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = KeyCode.SPACE, label = "space"),
+                    TextKeyData(code = 0),
+                    TextKeyData(code = KeyCode.ENTER, type = KeyType.ENTER_EDITING, label = "enter")
                 )
             )
         )

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/layout/LayoutManager.kt
@@ -21,6 +21,7 @@ import dev.patrickgold.florisboard.debug.flogDebug
 import dev.patrickgold.florisboard.debug.flogWarning
 import dev.patrickgold.florisboard.ime.core.Preferences
 import dev.patrickgold.florisboard.ime.core.Subtype
+import dev.patrickgold.florisboard.ime.keyboard.DefaultComputingEvaluator
 import dev.patrickgold.florisboard.res.AssetManager
 import dev.patrickgold.florisboard.res.AssetRef
 import dev.patrickgold.florisboard.res.AssetSource
@@ -252,7 +253,7 @@ class LayoutManager {
 
     private fun addRowHints(main: Array<TextKey>, hint: Array<TextKey>, hintType: KeyType) {
         for ((k,key) in main.withIndex()) {
-            val hintKey = hint.getOrNull(k)?.data?.computeTextKeyData(DefaultTextComputingEvaluator)
+            val hintKey = hint.getOrNull(k)?.data?.compute(DefaultComputingEvaluator)
             if (hintKey?.type != hintType) {
                 continue
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/res/Asset.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/res/Asset.kt
@@ -20,10 +20,6 @@ package dev.patrickgold.florisboard.res
  * Interface for an Asset to use within FlorisBoard. An asset is everything from a dictionary to a
  * keyboard layout to a extended popup mapping, etc. Assets are very important for the splitting
  * FlorisBoard's resources into assets.
- *
- * NOTE: At the current state, this is only a simple implementation idea and only PopupMappingAsset
- * partly uses it. This package and it's classes are expected to grow and gain more importance over
- * time.
  */
 interface Asset {
     /**

--- a/app/src/main/java/dev/patrickgold/florisboard/res/AssetManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/res/AssetManager.kt
@@ -19,6 +19,7 @@ package dev.patrickgold.florisboard.res
 import android.content.Context
 import android.net.Uri
 import dev.patrickgold.florisboard.debug.flogError
+import dev.patrickgold.florisboard.ime.keyboard.AbstractKeyData
 import dev.patrickgold.florisboard.ime.keyboard.CaseSelector
 import dev.patrickgold.florisboard.ime.keyboard.KeyData
 import dev.patrickgold.florisboard.ime.keyboard.VariationSelector
@@ -50,20 +51,21 @@ class AssetManager private constructor(val applicationContext: Context) {
         ignoreUnknownKeys = true
         isLenient = true
         serializersModule = SerializersModule {
-            polymorphic(KeyData::class) {
-                subclass(BasicTextKeyData::class, BasicTextKeyData.serializer())
+            polymorphic(AbstractKeyData::class) {
+                subclass(TextKeyData::class, TextKeyData.serializer())
                 subclass(AutoTextKeyData::class, AutoTextKeyData.serializer())
                 subclass(MultiTextKeyData::class, MultiTextKeyData.serializer())
                 subclass(EmojiKeyData::class, EmojiKeyData.serializer())
                 subclass(CaseSelector::class, CaseSelector.serializer())
                 subclass(VariationSelector::class, VariationSelector.serializer())
-                default { BasicTextKeyData.serializer() }
+                default { TextKeyData.serializer() }
             }
-            polymorphic(TextKeyData::class) {
-                subclass(BasicTextKeyData::class, BasicTextKeyData.serializer())
+            polymorphic(KeyData::class) {
+                subclass(TextKeyData::class, TextKeyData.serializer())
                 subclass(AutoTextKeyData::class, AutoTextKeyData.serializer())
                 subclass(MultiTextKeyData::class, MultiTextKeyData.serializer())
-                default { BasicTextKeyData.serializer() }
+                subclass(EmojiKeyData::class, EmojiKeyData.serializer())
+                default { TextKeyData.serializer() }
             }
             polymorphic(Composer::class) {
                 subclass(Appender::class, Appender.serializer())

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/ThemeManagerActivity.kt
@@ -46,6 +46,9 @@ import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import dev.patrickgold.florisboard.ime.theme.ThemeMetaOnly
 import dev.patrickgold.florisboard.common.ViewUtils
+import dev.patrickgold.florisboard.ime.keyboard.ComputingEvaluator
+import dev.patrickgold.florisboard.ime.keyboard.DefaultComputingEvaluator
+import dev.patrickgold.florisboard.ime.keyboard.KeyData
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -55,17 +58,17 @@ class ThemeManagerActivity : FlorisActivity<ThemeManagerActivityBinding>() {
     private val assetManager: AssetManager get() = AssetManager.default()
 
     private lateinit var textKeyboardIconSet: TextKeyboardIconSet
-    private val textComputingEvaluator = object : TextComputingEvaluator by DefaultTextComputingEvaluator {
-        override fun evaluateVisible(data: TextKeyData): Boolean {
+    private val textComputingEvaluator = object : ComputingEvaluator by DefaultComputingEvaluator {
+        override fun evaluateVisible(data: KeyData): Boolean {
             return data.code != KeyCode.SWITCH_TO_MEDIA_CONTEXT
         }
 
-        override fun isSlot(data: TextKeyData): Boolean {
+        override fun isSlot(data: KeyData): Boolean {
             return CurrencySet.isCurrencySlot(data.code)
         }
 
-        override fun getSlotData(data: TextKeyData): TextKeyData {
-            return BasicTextKeyData(label = "$")
+        override fun getSlotData(data: KeyData): KeyData {
+            return TextKeyData(label = "$")
         }
     }
 


### PR DESCRIPTION
This PR reworks the KeyData logic so popups can also fully use variation and case selectors. This is required to fully implement the Turkish layout, but also may be needed in the future. This rework also allows for a more general use of the KeyData interface and unifies the text and emoji data base (kinda).

Additionally fixes #1045 and fixes #1089