### PR TITLE
Fix gesture logic to adapt to screens with different screen densities

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/SwipeGesture.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/gestures/SwipeGesture.kt
@@ -155,8 +155,8 @@ abstract class SwipeGesture {
                 val absDiffX = event.getX(pointer.index) - gesturePointer.firstX
                 val absDiffY = event.getY(pointer.index) - gesturePointer.firstY
                 velocityTracker.computeCurrentVelocity(1000)
-                val velocityX = ViewUtils.dp2px(velocityTracker.getXVelocity(pointer.id))
-                val velocityY = ViewUtils.dp2px(velocityTracker.getYVelocity(pointer.id))
+                val velocityX = ViewUtils.px2dp(velocityTracker.getXVelocity(pointer.id))
+                val velocityY = ViewUtils.px2dp(velocityTracker.getYVelocity(pointer.id))
                 flogDebug(LogTopic.GESTURES) { "Velocity: $velocityX $velocityY dp/s" }
                 pointerMap.removeById(pointer.id)
                 return if ((abs(absDiffX) > thresholdWidth || abs(absDiffY) > thresholdWidth) && (abs(velocityX) > thresholdSpeed || abs(velocityY) > thresholdSpeed)) {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
@@ -578,18 +578,18 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
         val florisboard = florisboard ?: return false
         val pointer = pointerMap.findById(event.pointerId) ?: return false
         val initialKey = pointer.initialKey ?: return false
-        val activeKey = pointer.activeKey ?: return false
+        val activeKey = pointer.activeKey
         flogDebug(LogTopic.TEXT_KEYBOARD_VIEW)
 
         return when (initialKey.computedData.code) {
             KeyCode.DELETE -> handleDeleteSwipe(event)
             KeyCode.SPACE -> handleSpaceSwipe(event)
             else -> when {
-                initialKey.computedData.code == KeyCode.SHIFT && activeKey.computedData.code == KeyCode.SPACE &&
+                initialKey.computedData.code == KeyCode.SHIFT && activeKey?.computedData?.code == KeyCode.SPACE &&
                     event.type == SwipeGesture.Type.TOUCH_MOVE -> handleSpaceSwipe(event)
-                initialKey.computedData.code == KeyCode.SHIFT && activeKey.computedData.code != KeyCode.SHIFT &&
+                initialKey.computedData.code == KeyCode.SHIFT && activeKey?.computedData?.code != KeyCode.SHIFT &&
                     event.type == SwipeGesture.Type.TOUCH_UP -> {
-                    activeKey.let {
+                    activeKey?.let {
                         florisboard.textInputManager.inputEventDispatcher.send(
                             InputKeyEvent.up(popupManager.getActiveKeyData(it, keyHintConfiguration) ?: it.computedData)
                         )

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -80,9 +80,9 @@
     <dimen name="gesture_distance_threshold_long">36dp</dimen>
     <dimen name="gesture_distance_threshold_very_long">40dp</dimen>
 
-    <integer name="gesture_velocity_threshold_very_slow">7000</integer>
-    <integer name="gesture_velocity_threshold_slow">10000</integer>
-    <integer name="gesture_velocity_threshold_normal">13000</integer>
-    <integer name="gesture_velocity_threshold_fast">16000</integer>
-    <integer name="gesture_velocity_threshold_very_fast">19000</integer>
+    <integer name="gesture_velocity_threshold_very_slow">1000</integer>
+    <integer name="gesture_velocity_threshold_slow">1450</integer>
+    <integer name="gesture_velocity_threshold_normal">1900</integer>
+    <integer name="gesture_velocity_threshold_fast">2350</integer>
+    <integer name="gesture_velocity_threshold_very_fast">2800</integer>
 </resources>


### PR DESCRIPTION
This PR attempts to fix the several reported bug that gestures don't activate on some devices. The velocity detection was based on Pixels instead of Display-Independent-Pixels, thus the screen density had a big impact on if a gesture could be detected or not. Now, the velocity is converted to DiP before checking, which should fix the gesture detection bugs.

Closes #1086 
Closes #972
Closes #549