### PR TITLE
Make sure to clone images in clipboard history

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/FlorisClipboardManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/FlorisClipboardManager.kt
@@ -3,6 +3,7 @@ package dev.patrickgold.florisboard.ime.clip
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Context.CLIPBOARD_SERVICE
+import dev.patrickgold.florisboard.debug.flogDebug
 import dev.patrickgold.florisboard.ime.clip.provider.*
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.Preferences
@@ -236,7 +237,7 @@ class FlorisClipboardManager private constructor() : ClipboardManager.OnPrimaryC
         } else if (prefs.clipboard.enableHistory) {
             // in the event history is enabled, and it should be updated it is updated
             if (shouldUpdateHistory) {
-                updateHistory(ClipboardItem.fromClipData(systemPrimaryClip, false))
+                updateHistory(ClipboardItem.fromClipData(systemPrimaryClip, true))
             } else {
                 shouldUpdateHistory = true
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/provider/FlorisDatabase.kt
@@ -22,7 +22,6 @@ enum class ItemType(val value: Int) {
 
 /**
  * Represents an item on the clipboard.
- * The URI stored belongs to FlorisContentProvider, not whatever app copied the image
  *
  * If type == ItemType.IMAGE there must be a uri set
  * if type == ItemType.TEXT there must be a text set


### PR DESCRIPTION
Looks like I forgot to clone images when the internal clipboard is off but the clipboard history is still on. We have to own the items in the clipboard history since authorization to read them is temporary.

Fixes #1124.
