### PR TITLE
Rework audio and haptic feedback of FlorisBoard

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/clip/ClipboardInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/clip/ClipboardInputManager.kt
@@ -135,8 +135,7 @@ class ClipboardInputManager private constructor() : CoroutineScope by MainScope(
 
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
-                florisboard.keyPressVibrate()
-                florisboard.keyPressSound(data)
+                florisboard.inputFeedbackManager.keyPress(data)
                 florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.down(data))
             }
             MotionEvent.ACTION_UP -> {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
@@ -373,7 +373,7 @@ class Preferences(
             get() =  prefs.getPref(HAPTIC_IGNORE_SYSTEM_SETTINGS, false)
             set(v) = prefs.setPref(HAPTIC_IGNORE_SYSTEM_SETTINGS, v)
         var hapticUseVibrator: Boolean
-            get() =  prefs.getPref(HAPTIC_USE_VIBRATOR, false)
+            get() =  prefs.getPref(HAPTIC_USE_VIBRATOR, true)
             set(v) = prefs.setPref(HAPTIC_USE_VIBRATOR, v)
         var hapticVibrationDuration: Int
             get() =  prefs.getPref(HAPTIC_VIBRATION_DURATION, 50)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/Preferences.kt
@@ -19,7 +19,6 @@ package dev.patrickgold.florisboard.ime.core
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
-import android.provider.Settings
 import androidx.core.os.UserManagerCompat
 import androidx.preference.PreferenceManager
 import dev.patrickgold.florisboard.R
@@ -57,6 +56,7 @@ class Preferences(
     val dictionary = Dictionary(this)
     val gestures = Gestures(this)
     val glide = Glide(this)
+    val inputFeedback = InputFeedback(this)
     val internal = Internal(this)
     val keyboard = Keyboard(this)
     val localization = Localization(this)
@@ -149,21 +149,6 @@ class Preferences(
             }
         } catch (e: Exception) {
             e.fillInStackTrace()
-        }
-    }
-
-    /**
-     * Syncs the system preference values and clears the cache.
-     */
-    fun syncSystemSettings() {
-        applicationContext.get()?.let { context ->
-            val contentResolver = context.contentResolver
-            keyboard.soundEnabledSystem = Settings.System.getInt(
-                contentResolver, Settings.System.SOUND_EFFECTS_ENABLED, 0
-            ) != 0
-            keyboard.vibrationEnabledSystem = Settings.System.getInt(
-                contentResolver, Settings.System.HAPTIC_FEEDBACK_ENABLED, 0
-            ) != 0
         }
     }
 
@@ -333,6 +318,90 @@ class Preferences(
      * Wrapper class for internal preferences. A preference qualifies as an internal pref if the
      * user has no ability to control this preference's value directly (via a UI pref view).
      */
+    class InputFeedback(private val prefs: Preferences) {
+        companion object {
+            const val AUDIO_ENABLED =                       "input_feedback__audio_enabled"
+            const val AUDIO_IGNORE_SYSTEM_SETTINGS =        "input_feedback__audio_ignore_system_settings"
+            const val AUDIO_VOLUME =                        "input_feedback__audio_volume"
+            const val AUDIO_FEAT_KEY_PRESS =                "input_feedback__audio_feat_key_press"
+            const val AUDIO_FEAT_KEY_LONG_PRESS =           "input_feedback__audio_feat_key_long_press"
+            const val AUDIO_FEAT_KEY_REPEATED_ACTION =      "input_feedback__audio_feat_key_repeated_action"
+            const val AUDIO_FEAT_GESTURE_SWIPE =            "input_feedback__audio_feat_gesture_swipe"
+            const val AUDIO_FEAT_GESTURE_MOVING_SWIPE =     "input_feedback__audio_feat_gesture_moving_swipe"
+
+            const val HAPTIC_ENABLED =                      "input_feedback__haptic_enabled"
+            const val HAPTIC_IGNORE_SYSTEM_SETTINGS =       "input_feedback__haptic_ignore_system_settings"
+            const val HAPTIC_USE_VIBRATOR =                 "input_feedback__haptic_use_vibrator"
+            const val HAPTIC_VIBRATION_DURATION =           "input_feedback__haptic_vibration_duration"
+            const val HAPTIC_VIBRATION_STRENGTH =           "input_feedback__haptic_vibration_strength"
+            const val HAPTIC_FEAT_KEY_PRESS =               "input_feedback__haptic_feat_key_press"
+            const val HAPTIC_FEAT_KEY_LONG_PRESS =          "input_feedback__haptic_feat_key_long_press"
+            const val HAPTIC_FEAT_KEY_REPEATED_ACTION =     "input_feedback__haptic_feat_key_repeated_action"
+            const val HAPTIC_FEAT_GESTURE_SWIPE =           "input_feedback__haptic_feat_gesture_swipe"
+            const val HAPTIC_FEAT_GESTURE_MOVING_SWIPE =    "input_feedback__haptic_feat_gesture_moving_swipe"
+        }
+
+        var audioEnabled: Boolean
+            get() =  prefs.getPref(AUDIO_ENABLED, true)
+            set(v) = prefs.setPref(AUDIO_ENABLED, v)
+        var audioIgnoreSystemSettings: Boolean
+            get() =  prefs.getPref(AUDIO_IGNORE_SYSTEM_SETTINGS, false)
+            set(v) = prefs.setPref(AUDIO_IGNORE_SYSTEM_SETTINGS, v)
+        var audioVolume: Int
+            get() =  prefs.getPref(AUDIO_VOLUME, 50)
+            set(v) = prefs.setPref(AUDIO_VOLUME, v)
+        var audioFeatKeyPress: Boolean
+            get() =  prefs.getPref(AUDIO_FEAT_KEY_PRESS, true)
+            set(v) = prefs.setPref(AUDIO_FEAT_KEY_PRESS, v)
+        var audioFeatKeyLongPress: Boolean
+            get() =  prefs.getPref(AUDIO_FEAT_KEY_LONG_PRESS, false)
+            set(v) = prefs.setPref(AUDIO_FEAT_KEY_LONG_PRESS, v)
+        var audioFeatKeyRepeatedAction: Boolean
+            get() =  prefs.getPref(AUDIO_FEAT_KEY_REPEATED_ACTION, false)
+            set(v) = prefs.setPref(AUDIO_FEAT_KEY_REPEATED_ACTION, v)
+        var audioFeatGestureSwipe: Boolean
+            get() =  prefs.getPref(AUDIO_FEAT_GESTURE_SWIPE, false)
+            set(v) = prefs.setPref(AUDIO_FEAT_GESTURE_SWIPE, v)
+        var audioFeatGestureMovingSwipe: Boolean
+            get() =  prefs.getPref(AUDIO_FEAT_GESTURE_MOVING_SWIPE, false)
+            set(v) = prefs.setPref(AUDIO_FEAT_GESTURE_MOVING_SWIPE, v)
+
+        var hapticEnabled: Boolean
+            get() =  prefs.getPref(HAPTIC_ENABLED, true)
+            set(v) = prefs.setPref(HAPTIC_ENABLED, v)
+        var hapticIgnoreSystemSettings: Boolean
+            get() =  prefs.getPref(HAPTIC_IGNORE_SYSTEM_SETTINGS, false)
+            set(v) = prefs.setPref(HAPTIC_IGNORE_SYSTEM_SETTINGS, v)
+        var hapticUseVibrator: Boolean
+            get() =  prefs.getPref(HAPTIC_USE_VIBRATOR, false)
+            set(v) = prefs.setPref(HAPTIC_USE_VIBRATOR, v)
+        var hapticVibrationDuration: Int
+            get() =  prefs.getPref(HAPTIC_VIBRATION_DURATION, 50)
+            set(v) = prefs.setPref(HAPTIC_VIBRATION_DURATION, v)
+        var hapticVibrationStrength: Int
+            get() =  prefs.getPref(HAPTIC_VIBRATION_STRENGTH, 50)
+            set(v) = prefs.setPref(HAPTIC_VIBRATION_STRENGTH, v)
+        var hapticFeatKeyPress: Boolean
+            get() =  prefs.getPref(HAPTIC_FEAT_KEY_PRESS, true)
+            set(v) = prefs.setPref(HAPTIC_FEAT_KEY_PRESS, v)
+        var hapticFeatKeyLongPress: Boolean
+            get() =  prefs.getPref(HAPTIC_FEAT_KEY_LONG_PRESS, false)
+            set(v) = prefs.setPref(HAPTIC_FEAT_KEY_LONG_PRESS, v)
+        var hapticFeatKeyRepeatedAction: Boolean
+            get() =  prefs.getPref(HAPTIC_FEAT_KEY_REPEATED_ACTION, true)
+            set(v) = prefs.setPref(HAPTIC_FEAT_KEY_REPEATED_ACTION, v)
+        var hapticFeatGestureSwipe: Boolean
+            get() =  prefs.getPref(HAPTIC_FEAT_GESTURE_SWIPE, false)
+            set(v) = prefs.setPref(HAPTIC_FEAT_GESTURE_SWIPE, v)
+        var hapticFeatGestureMovingSwipe: Boolean
+            get() =  prefs.getPref(HAPTIC_FEAT_GESTURE_MOVING_SWIPE, true)
+            set(v) = prefs.setPref(HAPTIC_FEAT_GESTURE_MOVING_SWIPE, v)
+    }
+
+    /**
+     * Wrapper class for internal preferences. A preference qualifies as an internal pref if the
+     * user has no ability to control this preference's value directly (via a UI pref view).
+     */
     class Internal(private val prefs: Preferences) {
         companion object {
             const val IS_IME_SET_UP =               "internal__is_ime_set_up"
@@ -377,14 +446,9 @@ class Preferences(
             const val ONE_HANDED_MODE =                     "keyboard__one_handed_mode"
             const val ONE_HANDED_MODE_SCALE_FACTOR =        "keyboard__one_handed_mode_scale_factor"
             const val POPUP_ENABLED =                       "keyboard__popup_enabled"
-            const val SOUND_ENABLED =                       "keyboard__sound_enabled"
-            const val SOUND_VOLUME =                        "keyboard__sound_volume"
             const val SPACE_BAR_SWITCHES_TO_CHARACTERS =    "keyboard__space_bar_switches_to_characters"
             const val UTILITY_KEY_ACTION =                  "keyboard__utility_key_action"
             const val UTILITY_KEY_ENABLED =                 "keyboard__utility_key_enabled"
-            const val VIBRATION_ENABLED =                   "keyboard__vibration_enabled"
-            const val VIBRATION_DURATION =                  "keyboard__vibration_duration"
-            const val VIBRATION_STRENGTH =                  "keyboard__vibration_strength"
         }
 
         var bottomOffsetPortrait: Int = 0
@@ -438,13 +502,6 @@ class Preferences(
         var popupEnabled: Boolean = false
             get() = prefs.getPref(POPUP_ENABLED, true)
             private set
-        var soundEnabled: Boolean = false
-            get() = prefs.getPref(SOUND_ENABLED, true)
-            private set
-        var soundEnabledSystem: Boolean = false
-        var soundVolume: Int = 0
-            get() = prefs.getPref(SOUND_VOLUME, -1)
-            private set
         var spaceBarSwitchesToCharacters: Boolean
             get() =  prefs.getPref(SPACE_BAR_SWITCHES_TO_CHARACTERS, true)
             set(v) = prefs.setPref(SPACE_BAR_SWITCHES_TO_CHARACTERS, v)
@@ -454,16 +511,6 @@ class Preferences(
         var utilityKeyEnabled: Boolean
             get() =  prefs.getPref(UTILITY_KEY_ENABLED, true)
             set(v) = prefs.setPref(UTILITY_KEY_ENABLED, v)
-        var vibrationEnabled: Boolean = false
-            get() = prefs.getPref(VIBRATION_ENABLED, true)
-            private set
-        var vibrationEnabledSystem: Boolean = false
-        var vibrationDuration: Int = 0
-            get() = prefs.getPref(VIBRATION_DURATION, -1)
-            private set
-        var vibrationStrength: Int = 0
-            get() = prefs.getPref(VIBRATION_STRENGTH, -1)
-            private set
 
         fun keyHintConfiguration(): KeyHintConfiguration {
             return KeyHintConfiguration(hintedSymbolsMode, hintedNumberRowMode, mergeHintPopupsEnabled)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/keyboard/InputFeedbackManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/keyboard/InputFeedbackManager.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2021 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.keyboard
+
+import android.content.Context
+import android.inputmethodservice.InputMethodService
+import android.media.AudioManager
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.provider.Settings
+import android.view.HapticFeedbackConstants
+import dev.patrickgold.florisboard.ime.core.Preferences
+import dev.patrickgold.florisboard.ime.text.key.KeyCode
+
+/**
+ * Input feedback manager responsible to process and perform audio and haptic
+ * feedback for user interactions based on the system and floris preferences.
+ */
+class InputFeedbackManager private constructor(private val ims: InputMethodService) {
+    companion object {
+        fun new(ims: InputMethodService) = InputFeedbackManager(ims)
+    }
+
+    private val prefs get() = Preferences.default()
+
+    private val audioManager = ims.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+    private val vibrator = ims.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+    private val contentResolver = ims.contentResolver
+
+    fun keyPress(data: KeyData) {
+        if (prefs.inputFeedback.audioFeatKeyPress) performAudioFeedback(data, 1.0)
+        if (prefs.inputFeedback.hapticFeatKeyPress) performHapticFeedback(data, 1.0)
+    }
+
+    fun keyLongPress(data: KeyData) {
+        if (prefs.inputFeedback.audioFeatKeyLongPress) performAudioFeedback(data, 0.4)
+        if (prefs.inputFeedback.hapticFeatKeyLongPress) performHapticFeedback(data, 0.4)
+    }
+
+    fun keyRepeatedAction(data: KeyData) {
+        if (prefs.inputFeedback.audioFeatKeyRepeatedAction) performAudioFeedback(data, 0.2)
+        if (prefs.inputFeedback.hapticFeatKeyRepeatedAction) performHapticFeedback(data, 0.2)
+    }
+
+    fun gestureSwipe(data: KeyData) {
+        if (prefs.inputFeedback.audioFeatGestureSwipe) performAudioFeedback(data, 0.4)
+        if (prefs.inputFeedback.hapticFeatGestureSwipe) performHapticFeedback(data, 0.4)
+    }
+
+    fun gestureMovingSwipe(data: KeyData) {
+        if (prefs.inputFeedback.audioFeatGestureMovingSwipe) performAudioFeedback(data, 0.2)
+        if (prefs.inputFeedback.hapticFeatGestureMovingSwipe) performHapticFeedback(data, 0.2)
+    }
+
+    private fun systemPref(id: String): Boolean {
+        if (contentResolver == null) return false
+        return Settings.System.getInt(contentResolver, id, 0) != 0
+    }
+
+    private fun performAudioFeedback(data: KeyData, factor: Double) {
+        if (audioManager == null) return
+        if (!prefs.inputFeedback.audioEnabled) return
+
+        if (!prefs.inputFeedback.audioIgnoreSystemSettings) {
+            if (!systemPref(Settings.System.SOUND_EFFECTS_ENABLED)) return
+        }
+
+        val volume = (prefs.inputFeedback.audioVolume * factor) / 100.0
+        val effect = when (data.code) {
+            KeyCode.DELETE -> AudioManager.FX_KEYPRESS_DELETE
+            KeyCode.ENTER -> AudioManager.FX_KEYPRESS_RETURN
+            KeyCode.SPACE -> AudioManager.FX_KEYPRESS_SPACEBAR
+            else -> AudioManager.FX_KEYPRESS_STANDARD
+        }
+        if (volume in 0.01..1.00) {
+            audioManager.playSoundEffect(effect, volume.toFloat())
+        }
+    }
+
+    private fun performHapticFeedback(data: KeyData, factor: Double) {
+        if (vibrator == null || !vibrator.hasVibrator()) return
+        if (!prefs.inputFeedback.hapticEnabled) return
+
+        if (!prefs.inputFeedback.hapticIgnoreSystemSettings) {
+            if (!systemPref(Settings.System.HAPTIC_FEEDBACK_ENABLED)) return
+        }
+
+        if (!prefs.inputFeedback.hapticUseVibrator) {
+            val view = ims.window?.window?.decorView ?: return
+            val hfc = if (factor < 1.0 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                HapticFeedbackConstants.TEXT_HANDLE_MOVE
+            } else {
+                HapticFeedbackConstants.KEYBOARD_TAP
+            }
+            val didPerform = view.performHapticFeedback(hfc,
+                HapticFeedbackConstants.FLAG_IGNORE_VIEW_SETTING or
+                    HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
+            )
+            if (didPerform) return
+            // If not performed fall back to using the vibrator directly
+        }
+        val duration = prefs.inputFeedback.hapticVibrationDuration
+        val strength = prefs.inputFeedback.hapticVibrationStrength
+        if (duration > 0 && strength > 0) {
+            val effectiveDuration = (duration * factor).toLong().coerceAtLeast(1L)
+            val effectiveStrength = (255.0 * ((strength * factor) / 100.0)).toInt().coerceIn(1, 255)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val effect = VibrationEffect.createOneShot(effectiveDuration, effectiveStrength)
+                vibrator.vibrate(effect)
+            } else {
+                @Suppress("DEPRECATION")
+                vibrator.vibrate(effectiveDuration)
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/keyboard/InputFeedbackManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/keyboard/InputFeedbackManager.kt
@@ -26,6 +26,7 @@ import android.provider.Settings
 import android.view.HapticFeedbackConstants
 import dev.patrickgold.florisboard.ime.core.Preferences
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
+import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 
 /**
  * Input feedback manager responsible to process and perform audio and haptic
@@ -42,29 +43,29 @@ class InputFeedbackManager private constructor(private val ims: InputMethodServi
     private val vibrator = ims.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
     private val contentResolver = ims.contentResolver
 
-    fun keyPress(data: KeyData) {
+    fun keyPress(data: KeyData = TextKeyData.UNSPECIFIED) {
         if (prefs.inputFeedback.audioFeatKeyPress) performAudioFeedback(data, 1.0)
         if (prefs.inputFeedback.hapticFeatKeyPress) performHapticFeedback(data, 1.0)
     }
 
-    fun keyLongPress(data: KeyData) {
-        if (prefs.inputFeedback.audioFeatKeyLongPress) performAudioFeedback(data, 0.4)
+    fun keyLongPress(data: KeyData = TextKeyData.UNSPECIFIED) {
+        if (prefs.inputFeedback.audioFeatKeyLongPress) performAudioFeedback(data, 0.7)
         if (prefs.inputFeedback.hapticFeatKeyLongPress) performHapticFeedback(data, 0.4)
     }
 
-    fun keyRepeatedAction(data: KeyData) {
-        if (prefs.inputFeedback.audioFeatKeyRepeatedAction) performAudioFeedback(data, 0.2)
-        if (prefs.inputFeedback.hapticFeatKeyRepeatedAction) performHapticFeedback(data, 0.2)
+    fun keyRepeatedAction(data: KeyData = TextKeyData.UNSPECIFIED) {
+        if (prefs.inputFeedback.audioFeatKeyRepeatedAction) performAudioFeedback(data, 0.4)
+        if (prefs.inputFeedback.hapticFeatKeyRepeatedAction) performHapticFeedback(data, 0.05)
     }
 
-    fun gestureSwipe(data: KeyData) {
-        if (prefs.inputFeedback.audioFeatGestureSwipe) performAudioFeedback(data, 0.4)
+    fun gestureSwipe(data: KeyData = TextKeyData.UNSPECIFIED) {
+        if (prefs.inputFeedback.audioFeatGestureSwipe) performAudioFeedback(data, 0.7)
         if (prefs.inputFeedback.hapticFeatGestureSwipe) performHapticFeedback(data, 0.4)
     }
 
-    fun gestureMovingSwipe(data: KeyData) {
-        if (prefs.inputFeedback.audioFeatGestureMovingSwipe) performAudioFeedback(data, 0.2)
-        if (prefs.inputFeedback.hapticFeatGestureMovingSwipe) performHapticFeedback(data, 0.2)
+    fun gestureMovingSwipe(data: KeyData = TextKeyData.UNSPECIFIED) {
+        if (prefs.inputFeedback.audioFeatGestureMovingSwipe) performAudioFeedback(data, 0.4)
+        if (prefs.inputFeedback.hapticFeatGestureMovingSwipe) performHapticFeedback(data, 0.05)
     }
 
     private fun systemPref(id: String): Boolean {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/MediaInputManager.kt
@@ -133,8 +133,7 @@ class MediaInputManager private constructor() : CoroutineScope by MainScope(),
         }
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
-                florisboard.keyPressVibrate()
-                florisboard.keyPressSound(data)
+                florisboard.inputFeedbackManager.keyPress(data)
                 florisboard.textInputManager.inputEventDispatcher.send(InputKeyEvent.down(data))
             }
             MotionEvent.ACTION_UP -> {

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoji/EmojiKeyView.kt
@@ -29,6 +29,7 @@ import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.FlorisBoard
 import dev.patrickgold.florisboard.ime.core.Preferences
 import dev.patrickgold.florisboard.ime.text.key.KeyHintConfiguration
+import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import dev.patrickgold.florisboard.ime.theme.Theme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import kotlinx.coroutines.CoroutineScope
@@ -105,8 +106,7 @@ class EmojiKeyView(
                     emojiKeyboardView.isScrollBlocked = true
                     emojiKeyboardView.popupManager.show(key, KeyHintConfiguration.HINTS_DISABLED)
                     emojiKeyboardView.popupManager.extend(key, KeyHintConfiguration.HINTS_DISABLED)
-                    florisboard?.keyPressVibrate()
-                    florisboard?.keyPressSound()
+                    florisboard?.inputFeedbackManager?.keyPress(TextKeyData.UNSPECIFIED)
                 }, delayMillis.toLong())
             }
             MotionEvent.ACTION_MOVE -> {
@@ -134,8 +134,7 @@ class EmojiKeyView(
                     retData != null && !isCancelled
                 ) {
                     if (!emojiKeyboardView.isScrollBlocked) {
-                        florisboard?.keyPressVibrate()
-                        florisboard?.keyPressSound()
+                        florisboard?.inputFeedbackManager?.keyPress(TextKeyData.UNSPECIFIED)
                     }
                     (retData as? EmojiKeyData)?.let { florisboard?.mediaInputManager?.sendEmojiKeyPress(it) }
                     performClick()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoticon/EmoticonKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/media/emoticon/EmoticonKeyView.kt
@@ -67,8 +67,7 @@ class EmoticonKeyView : androidx.appcompat.widget.AppCompatTextView {
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 setBackgroundColor(getColorFromAttr(context, R.attr.semiTransparentColor))
-                florisboard.keyPressVibrate()
-                florisboard.keyPressSound(TextKeyData.UNSPECIFIED)
+                florisboard.inputFeedbackManager.keyPress(TextKeyData.UNSPECIFIED)
             }
             MotionEvent.ACTION_UP -> {
                 setBackgroundColor(Color.TRANSPARENT)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/onehanded/OneHandedPanel.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/onehanded/OneHandedPanel.kt
@@ -58,6 +58,7 @@ class OneHandedPanel : LinearLayout, ThemeManager.OnThemeUpdatedListener {
         closeBtn = findViewWithTag("one_handed_ctrl_close")
         closeBtn?.setOnClickListener {
             florisboard?.let {
+                it.inputFeedbackManager.keyPress()
                 prefs.keyboard.oneHandedMode = OneHandedMode.OFF
                 it.updateOneHandedPanelVisibility()
             }
@@ -65,6 +66,7 @@ class OneHandedPanel : LinearLayout, ThemeManager.OnThemeUpdatedListener {
         moveBtn = findViewWithTag("one_handed_ctrl_move")
         moveBtn?.setOnClickListener {
             florisboard?.let {
+                it.inputFeedbackManager.keyPress()
                 prefs.keyboard.oneHandedMode = panelSide
                 it.updateOneHandedPanelVisibility()
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -504,24 +504,29 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
     }
 
     override fun onSmartbarBackButtonPressed() {
+        florisboard.inputFeedbackManager.keyPress()
         setActiveKeyboardMode(KeyboardMode.CHARACTERS)
     }
 
     override fun onSmartbarCandidatePressed(word: String) {
+        florisboard.inputFeedbackManager.keyPress()
         isGlidePostEffect = false
         activeEditorInstance.commitCompletion(word)
     }
 
     override fun onSmartbarClipboardCandidatePressed(clipboardItem: ClipboardItem) {
+        florisboard.inputFeedbackManager.keyPress()
         isGlidePostEffect = false
         activeEditorInstance.commitClipboardItem(clipboardItem)
     }
 
     override fun onSmartbarPrivateModeButtonClicked() {
+        florisboard.inputFeedbackManager.keyPress()
         Toast.makeText(florisboard, R.string.private_mode_dialog__title, Toast.LENGTH_LONG).show()
     }
 
     override fun onSmartbarQuickActionPressed(quickActionId: Int) {
+        florisboard.inputFeedbackManager.keyPress()
         when (quickActionId) {
             R.id.quick_action_toggle -> {
                 activeState.isQuickActionsVisible = !activeState.isQuickActionsVisible

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/TextInputManager.kt
@@ -878,7 +878,7 @@ class TextInputManager private constructor() : CoroutineScope by MainScope(), In
     }
 
     override fun onInputKeyRepeat(ev: InputKeyEvent) {
-        florisboard.keyPressVibrate(isMovingGestureEffect = true)
+        florisboard.inputFeedbackManager.keyRepeatedAction(ev.data)
         onInputKeyUp(ev)
     }
 

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/editing/EditingKeyView.kt
@@ -112,8 +112,7 @@ class EditingKeyView : AppCompatImageButton, ThemeManager.OnThemeUpdatedListener
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 isKeyPressed = true
-                florisboard?.keyPressVibrate()
-                florisboard?.keyPressSound(data)
+                florisboard?.inputFeedbackManager?.keyPress(data)
                 when (data.code) {
                     KeyCode.ARROW_DOWN,
                     KeyCode.ARROW_LEFT,

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
@@ -431,8 +431,7 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
             if (prefs.keyboard.popupEnabled && popupManager.isSuitableForPopups(key)) {
                 popupManager.show(key, keyHintConfiguration)
             }
-            florisboard!!.keyPressVibrate()
-            florisboard!!.keyPressSound(key.computedData)
+            florisboard!!.inputFeedbackManager.keyPress(key.computedData)
             key.setPressed(true) { invalidate(key) }
             if (pointer.initialKey == null) {
                 pointer.initialKey = key
@@ -458,8 +457,7 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                     KeyCode.SHIFT -> {
                         delay((delayMillis * 2.5f).toLong())
                         florisboard!!.textInputManager.inputEventDispatcher.send(InputKeyEvent.downUp(TextKeyData.SHIFT_LOCK))
-                        florisboard!!.keyPressVibrate()
-                        florisboard!!.keyPressSound(key.computedData)
+                        florisboard!!.inputFeedbackManager.keyLongPress(key.computedData)
                     }
                     KeyCode.LANGUAGE_SWITCH -> {
                         delay((delayMillis * 2.0f).toLong())
@@ -475,8 +473,7 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                             ).isNotEmpty()
                         ) {
                             popupManager.extend(key, keyHintConfiguration)
-                            florisboard!!.keyPressVibrate()
-                            florisboard!!.keyPressSound(key.computedData)
+                            florisboard!!.inputFeedbackManager.keyLongPress(key.computedData)
                         }
                     }
                 }
@@ -633,7 +630,7 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                 SwipeAction.DELETE_CHARACTERS_PRECISELY -> {
                     florisboard.activeEditorInstance.apply {
                         if (abs(event.relUnitCountX) > 0) {
-                            florisboard.keyPressVibrate(isMovingGestureEffect = true)
+                            florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.DELETE)
                         }
                         markComposingRegion(null)
                         selection.updateAndNotify(
@@ -646,7 +643,7 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                 }
                 SwipeAction.DELETE_WORDS_PRECISELY -> when (event.direction) {
                     SwipeGesture.Direction.LEFT -> {
-                        florisboard.keyPressVibrate(isMovingGestureEffect = true)
+                        florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.DELETE)
                         florisboard.activeEditorInstance.apply {
                             leftAppendWordToSelection()
                         }
@@ -654,7 +651,7 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                         true
                     }
                     SwipeGesture.Direction.RIGHT -> {
-                        florisboard.keyPressVibrate(isMovingGestureEffect = true)
+                        florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.DELETE)
                         florisboard.activeEditorInstance.apply {
                             leftPopWordFromSelection()
                         }
@@ -693,7 +690,7 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                                 it
                             }
                             if (count > 0) {
-                                florisboard.keyPressVibrate(isMovingGestureEffect = true)
+                                florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.SPACE)
                                 florisboard.textInputManager.inputEventDispatcher.send(
                                     InputKeyEvent.downUp(
                                         TextKeyData.ARROW_LEFT, count
@@ -713,7 +710,7 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                                 it
                             }
                             if (count > 0) {
-                                florisboard.keyPressVibrate(isMovingGestureEffect = true)
+                                florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.SPACE)
                                 florisboard.textInputManager.inputEventDispatcher.send(
                                     InputKeyEvent.downUp(
                                         TextKeyData.ARROW_RIGHT, count

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/SettingsMainActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/SettingsMainActivity.kt
@@ -56,7 +56,6 @@ class SettingsMainActivity : AppCompatActivity(),
     val subtypeManager: SubtypeManager get() = SubtypeManager.default()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        prefs.syncSystemSettings()
         layoutManager = LayoutManager()
 
         val mode = when (prefs.advanced.settingsTheme) {

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/fragments/KeyboardFragment.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/fragments/KeyboardFragment.kt
@@ -18,12 +18,16 @@ package dev.patrickgold.florisboard.settings.fragments
 
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.ListPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.core.Preferences
 import dev.patrickgold.florisboard.ime.onehanded.OneHandedMode
+import dev.patrickgold.florisboard.settings.SettingsMainActivity
 import dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
 
 class KeyboardFragment : PreferenceFragmentCompat(),
@@ -67,5 +71,21 @@ class KeyboardFragment : PreferenceFragmentCompat(),
                 utilityKeyAction?.isVisible = sharedPrefs?.getBoolean(key, false) == true
             }
         }
+    }
+
+    override fun onPreferenceTreeClick(preference: Preference?): Boolean {
+        when (preference?.key) {
+            "keyboard__input_feedback" -> {
+                // Hard-coded constant and access logic because this whole code base will be completely rewritten soon anyways
+                (requireActivity() as? AppCompatActivity)?.supportActionBar?.setTitle(R.string.settings__input_feedback__title)
+                requireActivity().findViewById<View>(R.id.scroll_view)?.scrollY = 0
+                requireActivity().supportFragmentManager
+                    .beginTransaction()
+                    .replace(R.id.page_frame, SettingsMainActivity.PrefFragment.createFromResource(R.xml.prefs_input_feedback))
+                    .commit()
+                return true
+            }
+        }
+        return false
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">تباعد المفاتيح (عموديًا)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">تباعد المفاتيح (افقيا)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">ضغط المفتاح</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">الصوت عند ضغط المفتاح</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">حجم الصوت عند ضغط المفتاح</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">إهتزاز عند ضغط المفتاح</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">اهتزاز عند الضغط على المفتاح</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">شدة الاهتزاز عند ضغط على المفتاح</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">رؤية النافذة المنبثقة</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">إظهار النافذة المنبثقة عندما تضغط على مفتاح</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">مدة الضغط المطوّل على المفتاح</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Разстояние между клавишите (вертикално)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Разстояние между клавишите (хоризонтално)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Докосване на клавишите</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Звук при докосване на клавиш</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Сила на звука при докосване на клавиш</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Вибрация при докосване на клавиш</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Продължителност на вибрацията при докосване на клавиш</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Сила на вибрацията при докосване на клавиш</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Видима изскачаща подсказка</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Показва се изскачаща подсказка при докосване на клавиш</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Закъснение при задържане на клавиш</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -113,9 +113,6 @@
     <string name="pref__keyboard__height_factor__tall" comment="Preference value">Visoko</string>
     <string name="pref__keyboard__height_factor__extra_tall" comment="Preference value">Ekstra-visoko</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Pritisak tastera</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Zvuk na dodir tastera</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Jačina zvuka na dodir tastera</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibracija na dodir tastera</string>
     <string name="pref__smartbar__enabled__label" comment="Preference title">Uključi pametnu traku</string>
     <string name="pref__suggestion__title" comment="Preference group title">Sugestije</string>
     <string name="pref__correction__title" comment="Preference group title">Ispravke</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Espaiat de la clau (vertical)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Espaiat de la clau (horitzontal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Tecla premuda</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">So en prémer la tecla</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Volum del so en prémer la tecla</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibrar al prémer la tecla</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Durada de la vibració en prémer la tecla</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Força de vibració en prémer la tecla</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Visibilitat de la finestra emergent</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Mostra una finestra emergent quan premeu una tecla</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Retard de la premuda de tecla llarga</string>

--- a/app/src/main/res/values-ckb-rIR/strings.xml
+++ b/app/src/main/res/values-ckb-rIR/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">بۆشایی دوگمەکان (ستوونی)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">بۆشایی دوگمەکان (ئاسۆیی)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">کاریگەرییەکان</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">دەنگ لەکاتی نووسین</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">ئاستی دەنگ</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">لەرزین لەکاتی نووسین</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">ماوەی لەرزین</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">ئاستی لەرزین</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">بچووککراوە پیت</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">پیشاندانی بچووککراوەی پیت لەکاتی نووسین</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">ماوەی دەست راگرتن بۆ پیتە لاوەکییەکان</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -198,11 +198,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Mezery mezi klávesami (na výšku)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Spodní odsazení (na šířku)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Stisk klávesy</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Zvuk při stisku klávesy</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Hlasitost zvuku při stisku klávesy</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibrace při stisku klávesy</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Trvání vibrací při stisku klávesy</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Síla vibrací při stisku klávesy</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Viditelnost vyskakovacího okna</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Zobrazit vyskakovací okno při stisku klávesy</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Délka dlouhého stisku</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -99,10 +99,6 @@
     <string name="pref__keyboard__height_factor__custom" comment="Preference value">Brugerdefineret</string>
     <string name="pref__keyboard__height_factor_custom__label" comment="Preference title">Brugerdefineret tastatur højde</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Tastetryk</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Lyd ved tastetryk</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Lydstryke ved tastetryk</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibrer ved tastetryk</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Vibrationsstyrke ved tastetryk</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">PopUp synlighed</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Hvis popup ved tastetryk</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Langt tastetryk forsinkelse</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -200,11 +200,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Platz zwischen Zeichen (vertikal)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Platz zwischen Zeichen (horizontal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Tastendruck</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Ton bei Tastendruck</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Lautstärke der Tastendrucktöne</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibration bei Tastendruck</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Vibration bei Tastendruck</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Vibrationsstärke bei Tastendruck</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Pop-Up Sichtbarkeit</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Pop-Up bei Tastendruck anzeigen</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Verzögerung bei langem Tastendruck</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Απόσταση μεταξύ πλήκτρων (κάθετα)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Απόσταση μεταξύ πλήκτρων (οριζόντια)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Πάτημα πλήκτρου</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Ήχος κατά το πάτημα πλήκτρου</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Ένταση ήχου κατά το πάτημα πλήκτρου</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Δόνηση κατά το πάτημα πλήκτρου</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Διάρκεια δόνησης κατά το πάτημα κλειδιού</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Ένταση δόνησης κατά το πάτημα πλήκτρου</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Εμφάνιση κατά το πάτημα πλήκτρου</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Επιπλέον εμφάνιση πλήκτρου όταν πατήσετε ένα πλήκτρο</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Καθυστέρηση παρατεταμένου πατήματος πλήκτρου</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Espacio entre teclas (vertical)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Espacio entre teclas (horizontal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Presionar tecla</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Sonido al presionar una tecla</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Volumen del sonido al presionar una tecla</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibración al presionar una tecla</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Intensidad de la vibración al presionar una tecla</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Intensidad de la vibración al presionar una tecla</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Visibilidad de las teclas emergentes</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Ampliar al pulsar una tecla</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Retardo de la pulsación larga</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">فاصله گذاری کلید (عمودی)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">فاصله گذاری کلید (افقی)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">فشردن کلید</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">صدای فشردن کلید</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">میزان صدای فشردن کلید</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">لرزش هنگام فشردن کلید</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">مدت زمان لرزش با فشردن دکمه</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">قدرت لرزش هنگام فشردن کلید</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">نمایش پاپ‌آپ</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">نمایش پاپآپ وقتی کلیدی را می فشارید</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">تاخیر فشردن طولانی کلید</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -172,11 +172,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Näppäinten väli (pysty)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Näppäinten väli (vaaka)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Painallus</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Painikeääni</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Painikeäänen voimakkuus</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Värinä painalluksella</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Värinän pituus painalluksella</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Värinän voimakkuus painalluksella</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Ponnahdusikkunoiden Näkyvyys</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Näytä ponnahdusikkuna, kun painat näppäintä</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Pitkän painalluksen viive</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -200,11 +200,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Espacement des touches (vertical)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Espacement des touches (horizontal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Appui sur la touche</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Son lors de l\'appui des touches</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Volume sonore lors de l\'appui des touches</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibrer à chaque touche pressée</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Durée de la vibration lors de la pression d\'une touche</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Force de vibration lors de l\'appui sur une touche</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Visibilité des pop-up</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Afficher un pop-up à l\'appuie d\'une touche</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Délai d\'appui prolongé</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -196,11 +196,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Gombtávolság (vízszintes)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Gombtávolság (függőleges)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Gombnyomás</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Hang gombnyomáskor</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Gombnyomás hangereje</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Rezgés gombnyomáskor</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Rezgés időtartama gombnyomáskor</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Rezgés erőssége gombnyomáskor</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Nagyobb gomb megjelenítése</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Nagyobb gomb megjelenítése gombnyomáskor</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Hosszú gombnyomás késleltetése</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -200,11 +200,6 @@ Klik di sini untuk menyelesaikan masalah ini.</string>
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Spasi tombol (vertikal)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Spasi tombol (horizontal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Tekanan tombol</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Suara saat menekan tombol</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Volume suara saat menekan tombol</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Getar pada tekanan tombol</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Durasi getaran saat menekan tombol</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Kekuatan getaran saat menekan tombol</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Visibilitas popup</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Tampilkan popup ketika Anda menekan tombol</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Tundaan tekan lama tombol</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Spazio tra i pulsanti (verticale)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Spazio tra i pulsanti (orizzontale)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Pressione tasti</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Suono pressione tasti</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Volume del suono alla pressione dei tasti</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibrazione alla pressione dei tasti</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Intensità della vibrazione alla pressione dei tasti</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Intensità della vibrazione alla pressione dei tasti</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Visibilità Popup</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Mostra popup quando si preme un tasto</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Ritardo lunga pressione tasti</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -187,11 +187,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">ריווח מקשים (אנכי)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">ריווח מקשים (אופקי)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">לחיצת מקש</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">שמע בעת לחיצה על מקש</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">השמע צליל בעת לחיצה על מקש</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">הפעל רטט בעת לחיצה על מקש</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">משך הרטט בלחיצת מקש</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">עוצמת רטט בעת לחיצה על מקש</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">תצוגת חלונית</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">הצד חלונית בעת לחיצה על מקש</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">השהיית לחיצה מקש ארוכה</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -196,11 +196,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Mifteya mifteyê (emûdî)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Navbera mifteyê (asoyî)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Çapemeniya kilît</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Dengê li ser çapa sereke</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Dengê li ser pêlkirina mifteyan</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Li ser çapameniyê ya sereke bilerize</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Dema ku tûşan tepandin hêza lerz</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Dema ku mifte tê tepandin hêza lerz</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">PopUp Dîtinî</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Dema pêl bişkojkê bikî popup nîşan bide</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Derengketina bişkojka bişkojka dirêj</string>

--- a/app/src/main/res/values-lv-rLV/strings.xml
+++ b/app/src/main/res/values-lv-rLV/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Taustiņu atstatums (statenisks)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Taustiņu atstatums (līmenisks)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Taustiņa piespiešana</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Taustiņa piespiešanas skaņa</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Taustiņa piespiešanas skaņas skaļums</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Trīcēt, kad tiek nospiesta poga</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Trīcēšanas ilgums, kad tiek nospiesta poga</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Trīcēšanas stiprums, kad tiek nospiesta poga</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Uznirstošā lodziņa redzamība</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Rādīt uznirstošo lodziņu, kad tiek nospiests taustiņš</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Ilgas taustiņa piespiešanas aizture</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Toetsafstand (verticaal)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Toetsafstand (horizontaal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Toetsdruk</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Geluid bij toetsdruk</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Geluidsvolume bij toetsdruk</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibreren bij toetsdruk</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Trillingsduur bij toetsdruk</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Trillingssterkte bij toetsdruk</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Zichtbaarheid pop-up</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Pop-up tonen als je op een toets drukt</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Vertraging voor lange toetsdruk</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -180,10 +180,6 @@
     <string name="pref__keyboard__bottom_offset_portrait__label" comment="Preference title">Dolny odstęp (układ pionowy)</string>
     <string name="pref__keyboard__bottom_offset_landscape__label" comment="Preference title">Dolny odstęp (układ poziomy)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Naciśnięcie klawisza</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Dźwięk po naciśnięciu klawisza</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Głośność dźwięku po naciśnięciu klawisza</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Wibracja przy naciśnięciu klawisza</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Siła wibracji przy naciskaniu klawiszy</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Widoczność PopUp</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Pokaż popup po naciśnięciu klawisza</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Opóznienie długiego przytrzymania</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -200,11 +200,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Espaçamento das teclas (vertical)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Espaçamento das teclas (horizontal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Pressionar tecla</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Som ao pressionar uma tecla</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Volume do som ao pressionar uma tecla</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibrar ao pressionar uma tecla</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Duração da vibração ao pressionar uma tecla</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Força da vibração ao pressionar uma tecla</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Visibilidade do Pop-up</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Mostrar pop-up quando pressionar uma tecla</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Atraso ao pressionar e segurar uma tecla</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -199,11 +199,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Espaçamento de tecla (vertical)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Espaçamento de tecla (horizontal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Pressão de teclas</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Som ao premir teclas</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Volume do som ao premir teclas</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibrar ao premir teclas</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Duração de vibração ao premir uma tecla</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Intensidade de vibração ao premir teclas</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Destaque de teclas</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Ampliar caracteres ao premir uma tecla</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Atraso para a pressão longa de teclas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -200,11 +200,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Расстояние между клавишами (вертикально)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Расстояние между клавишами (горизонтально)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Нажатие клавиши</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Звук при нажатии</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Громкость звука при нажатии</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Вибрация при нажатии</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Длительность вибрации при нажатии</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Сила вибрации при нажатии</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Видимость всплывающей подсказки</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Показывать всплывающую подсказку при нажатии клавиши</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Задержка при нажатии</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -146,10 +146,6 @@
     <string name="pref__keyboard__height_factor__custom" comment="Preference value">Anpassat</string>
     <string name="pref__keyboard__height_factor_custom__label" comment="Preference title">Anpassad tangentbordshöjd värde</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Tangenttryck</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Ljud vid tangenttryck</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Volym vid tangenttryck</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibrera vid tangenttryck</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Vibrationsstyrka vid tangentryck</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Popup synlighet</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Visa popup vid tangenttryck</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Fördröjning vid långt tryck</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -200,11 +200,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Tuş aralığı (dikey)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Tuş aralığı (yatay)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Tuşa basıldığında</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Tuşa basıldığında ses</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Tuşa basıldığındaki ses düzeyi</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Tuşa basıldığında titreşim</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Tuşa basıldığındaki titreşim süresi</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Tuşa basıldığındaki titreşim gücü</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Açılır bildirim görünürlüğü</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Bir tuşa basıldığında açılır tuşu göster</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Tuşa uzun basma gecikmesi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -196,11 +196,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Відстань між клавішами (вертикально)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Відстань між клавішами (горизонтально)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Натискання клавіші</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Звук при натисканні</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Гучність звуку при натисканні</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Вібрація при натисканні</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Тривалість вібрації при натисканні</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Сила вібрації при натисканні</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">Видимість спливаючої підказки</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Показувати спливаючу підказку при натисканні клавіші</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Затримка при натисканні</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,13 +175,13 @@
     <string name="pref__input_feedback__audio_enabled__label" comment="Preference title">Enable audio feedback</string>
     <string name="pref__input_feedback__audio_enabled__summary" comment="Preference summary">Play sounds for input events, dependent on system settings</string>
     <string name="pref__input_feedback__audio_ignore_system_settings__label" comment="Preference title">Ignore system audio settings</string>
-    <string name="pref__input_feedback__audio_ignore_system_settings__summary" comment="Preference summary">Use below preferences, even if audio is disabled in the system</string>
+    <string name="pref__input_feedback__audio_ignore_system_settings__summary" comment="Preference summary">Use below preferences, even if audio is disabled in the system. Does not work when system ringtone is muted</string>
     <string name="pref__input_feedback__audio_volume__label" comment="Preference title">Sound volume for input events</string>
     <string name="pref__input_feedback__audio_feat_key_press__label" comment="Preference title">Key press sounds</string>
-    <string name="pref__input_feedback__audio_feat_key_long_press__label" comment="Preference title">Key long press sounds (e.g. popup menu)</string>
-    <string name="pref__input_feedback__audio_feat_key_repeated_action__label" comment="Preference title">Key repeated action sounds (e.g. delete key)</string>
+    <string name="pref__input_feedback__audio_feat_key_long_press__label" comment="Preference title">Key long press sounds</string>
+    <string name="pref__input_feedback__audio_feat_key_repeated_action__label" comment="Preference title">Key repeated action sounds</string>
     <string name="pref__input_feedback__audio_feat_gesture_swipe__label" comment="Preference title">Gesture swipe sounds</string>
-    <string name="pref__input_feedback__audio_feat_gesture_moving_swipe__label" comment="Preference title">Gesture moving swipe sounds (e.g. cursor control swipes)</string>
+    <string name="pref__input_feedback__audio_feat_gesture_moving_swipe__label" comment="Preference title">Gesture moving swipe sounds</string>
     <string name="pref__input_feedback__group_haptic__label" comment="Preference group title">Haptic feedback / Vibration</string>
     <string name="pref__input_feedback__haptic_enabled__label" comment="Preference title">Enable haptic feedback</string>
     <string name="pref__input_feedback__haptic_enabled__summary" comment="Preference summary">Vibrate for input events, dependent on system settings</string>
@@ -192,10 +192,15 @@
     <string name="pref__input_feedback__haptic_vibration_duration__label" comment="Preference title">Vibration duration</string>
     <string name="pref__input_feedback__haptic_vibration_strength__label" comment="Preference title">Vibration strength</string>
     <string name="pref__input_feedback__haptic_feat_key_press__label" comment="Preference title">Key press vibration</string>
-    <string name="pref__input_feedback__haptic_feat_key_long_press__label" comment="Preference title">Key long press vibration (e.g. popup menu)</string>
-    <string name="pref__input_feedback__haptic_feat_key_repeated_action__label" comment="Preference title">Key repeated action vibration (e.g. delete key)</string>
+    <string name="pref__input_feedback__haptic_feat_key_long_press__label" comment="Preference title">Key long press vibration</string>
+    <string name="pref__input_feedback__haptic_feat_key_repeated_action__label" comment="Preference title">Key repeated action vibration</string>
     <string name="pref__input_feedback__haptic_feat_gesture_swipe__label" comment="Preference title">Gesture swipe vibration</string>
-    <string name="pref__input_feedback__haptic_feat_gesture_moving_swipe__label" comment="Preference title">Gesture moving swipe vibration (e.g. cursor control swipes)</string>
+    <string name="pref__input_feedback__haptic_feat_gesture_moving_swipe__label" comment="Preference title">Gesture moving swipe vibration</string>
+    <string name="pref__input_feedback__any_feat_key_press__summary" comment="Preference summary">e.g. keys, buttons, emoji tabs</string>
+    <string name="pref__input_feedback__any_feat_key_long_press__summary" comment="Preference summary">e.g. popup menu</string>
+    <string name="pref__input_feedback__any_feat_key_repeated_action__summary" comment="Preference summary">e.g. delete key</string>
+    <string name="pref__input_feedback__any_feat_gesture_swipe__summary" comment="Preference summary">not implemented</string>
+    <string name="pref__input_feedback__any_feat_gesture_moving_swipe__summary" comment="Preference summary">e.g. cursor control swipe</string>
 
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Keyboard Preferences</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Keys</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,33 @@
     <string name="settings__theme__attr_textColor"              comment="Theme attribute label">Text color</string>
     <string name="settings__theme__attr_custom"                 comment="Theme attribute label (%s is custom attribute name)">Custom attribute (%s)</string>
 
+    <string name="settings__input_feedback__title" comment="Title of Input Feedback preferences fragment">Sounds &amp; Vibration</string>
+    <string name="pref__input_feedback__group_audio__label" comment="Preference group title">Audio feedback / Sounds</string>
+    <string name="pref__input_feedback__audio_enabled__label" comment="Preference title">Enable audio feedback</string>
+    <string name="pref__input_feedback__audio_enabled__summary" comment="Preference summary">Play sounds for input events, dependent on system settings</string>
+    <string name="pref__input_feedback__audio_ignore_system_settings__label" comment="Preference title">Ignore system audio settings</string>
+    <string name="pref__input_feedback__audio_ignore_system_settings__summary" comment="Preference summary">Use below preferences, even if audio is disabled in the system</string>
+    <string name="pref__input_feedback__audio_volume__label" comment="Preference title">Sound volume for input events</string>
+    <string name="pref__input_feedback__audio_feat_key_press__label" comment="Preference title">Key press sounds</string>
+    <string name="pref__input_feedback__audio_feat_key_long_press__label" comment="Preference title">Key long press sounds (e.g. popup menu)</string>
+    <string name="pref__input_feedback__audio_feat_key_repeated_action__label" comment="Preference title">Key repeated action sounds (e.g. delete key)</string>
+    <string name="pref__input_feedback__audio_feat_gesture_swipe__label" comment="Preference title">Gesture swipe sounds</string>
+    <string name="pref__input_feedback__audio_feat_gesture_moving_swipe__label" comment="Preference title">Gesture moving swipe sounds (e.g. cursor control swipes)</string>
+    <string name="pref__input_feedback__group_haptic__label" comment="Preference group title">Haptic feedback / Vibration</string>
+    <string name="pref__input_feedback__haptic_enabled__label" comment="Preference title">Enable haptic feedback</string>
+    <string name="pref__input_feedback__haptic_enabled__summary" comment="Preference summary">Vibrate for input events, dependent on system settings</string>
+    <string name="pref__input_feedback__haptic_ignore_system_settings__label" comment="Preference title">Ignore system haptic settings</string>
+    <string name="pref__input_feedback__haptic_ignore_system_settings__summary" comment="Preference summary">Use below preferences, even if haptic is disabled in the system</string>
+    <string name="pref__input_feedback__haptic_use_vibrator__label" comment="Preference title">Use vibrator directly</string>
+    <string name="pref__input_feedback__haptic_use_vibrator__summary" comment="Preference summary">Control the vibrator directly instead of using the haptic feedback API</string>
+    <string name="pref__input_feedback__haptic_vibration_duration__label" comment="Preference title">Vibration duration</string>
+    <string name="pref__input_feedback__haptic_vibration_strength__label" comment="Preference title">Vibration strength</string>
+    <string name="pref__input_feedback__haptic_feat_key_press__label" comment="Preference title">Key press vibration</string>
+    <string name="pref__input_feedback__haptic_feat_key_long_press__label" comment="Preference title">Key long press vibration (e.g. popup menu)</string>
+    <string name="pref__input_feedback__haptic_feat_key_repeated_action__label" comment="Preference title">Key repeated action vibration (e.g. delete key)</string>
+    <string name="pref__input_feedback__haptic_feat_gesture_swipe__label" comment="Preference title">Gesture swipe vibration</string>
+    <string name="pref__input_feedback__haptic_feat_gesture_moving_swipe__label" comment="Preference title">Gesture moving swipe vibration (e.g. cursor control swipes)</string>
+
     <string name="settings__keyboard__title" comment="Title of Keyboard preferences fragment">Keyboard Preferences</string>
     <string name="pref__keyboard__group_keys__label" comment="Preference group title">Keys</string>
     <string name="pref__keyboard__number_row__label" comment="Preference title">Number row</string>
@@ -216,11 +243,6 @@
     <string name="pref__keyboard__key_spacing_vertical__label" comment="Preference title">Key spacing (vertical)</string>
     <string name="pref__keyboard__key_spacing_horizontal__label" comment="Preference title">Key spacing (horizontal)</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Key press</string>
-    <string name="pref__keyboard__sound_enabled__label" comment="Preference title">Sound on key press</string>
-    <string name="pref__keyboard__sound_volume__label" comment="Preference title">Sound volume on key press</string>
-    <string name="pref__keyboard__vibration_enabled__label" comment="Preference title">Vibrate on key press</string>
-    <string name="pref__keyboard__vibration_duration__label" comment="Preference title">Vibration duration on key press</string>
-    <string name="pref__keyboard__vibration_strength__label" comment="Preference title">Vibration strength on key press</string>
     <string name="pref__keyboard__popup_visible__label" comment="Preference title">PopUp Visibility</string>
     <string name="pref__keyboard__popup_visible__summary" comment="Preference summary">Show popup when you press a key</string>
     <string name="pref__keyboard__long_press_delay__label" comment="Preference title">Long key press delay</string>

--- a/app/src/main/res/xml/prefs_input_feedback.xml
+++ b/app/src/main/res/xml/prefs_input_feedback.xml
@@ -1,0 +1,161 @@
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="@string/pref__input_feedback__group_audio__label">
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:key="input_feedback__audio_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__audio_enabled__label"
+            app:summary="@string/pref__input_feedback__audio_enabled__summary"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="input_feedback__audio_ignore_system_settings"
+            app:dependency="input_feedback__audio_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__audio_ignore_system_settings__label"
+            app:summary="@string/pref__input_feedback__audio_ignore_system_settings__summary"/>
+
+        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
+            app:allowDividerAbove="false"
+            android:defaultValue="50"
+            app:key="input_feedback__audio_volume"
+            app:dependency="input_feedback__audio_enabled"
+            app:min="0"
+            app:max="100"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__audio_volume__label"
+            app:seekBarIncrement="1"
+            app:unit="%"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:key="input_feedback__audio_feat_key_press"
+            app:dependency="input_feedback__audio_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__audio_feat_key_press__label"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="input_feedback__audio_feat_key_long_press"
+            app:dependency="input_feedback__audio_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__audio_feat_key_long_press__label"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="input_feedback__audio_feat_key_repeated_action"
+            app:dependency="input_feedback__audio_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__audio_feat_key_repeated_action__label"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="input_feedback__audio_feat_gesture_swipe"
+            app:dependency="input_feedback__audio_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__audio_feat_gesture_swipe__label"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="input_feedback__audio_feat_gesture_moving_swipe"
+            app:dependency="input_feedback__audio_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__audio_feat_gesture_moving_swipe__label"/>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="@string/pref__input_feedback__group_haptic__label">
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:key="input_feedback__haptic_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_enabled__label"
+            app:summary="@string/pref__input_feedback__haptic_enabled__summary"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="input_feedback__haptic_ignore_system_settings"
+            app:dependency="input_feedback__haptic_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_ignore_system_settings__label"
+            app:summary="@string/pref__input_feedback__haptic_ignore_system_settings__summary"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="input_feedback__haptic_use_vibrator"
+            app:dependency="input_feedback__haptic_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_use_vibrator__label"
+            app:summary="@string/pref__input_feedback__haptic_use_vibrator__summary"/>
+
+        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
+            app:allowDividerAbove="false"
+            android:defaultValue="50"
+            app:key="input_feedback__haptic_vibration_duration"
+            app:dependency="input_feedback__haptic_use_vibrator"
+            app:min="0"
+            app:max="100"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_vibration_duration__label"
+            app:seekBarIncrement="10"
+            app:unit=" ms"/>
+
+        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
+            app:allowDividerAbove="false"
+            android:defaultValue="50"
+            app:key="input_feedback__haptic_vibration_strength"
+            app:dependency="input_feedback__haptic_use_vibrator"
+            app:min="0"
+            app:max="100"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_vibration_strength__label"
+            app:seekBarIncrement="1"
+            app:unit="%"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:key="input_feedback__haptic_feat_key_press"
+            app:dependency="input_feedback__haptic_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_feat_key_press__label"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="input_feedback__haptic_feat_key_long_press"
+            app:dependency="input_feedback__haptic_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_feat_key_long_press__label"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:key="input_feedback__haptic_feat_key_repeated_action"
+            app:dependency="input_feedback__haptic_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_feat_key_repeated_action__label"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="input_feedback__haptic_feat_gesture_swipe"
+            app:dependency="input_feedback__haptic_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_feat_gesture_swipe__label"/>
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:key="input_feedback__haptic_feat_gesture_moving_swipe"
+            app:dependency="input_feedback__haptic_enabled"
+            app:iconSpaceReserved="false"
+            app:title="@string/pref__input_feedback__haptic_feat_gesture_moving_swipe__label"/>
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/prefs_input_feedback.xml
+++ b/app/src/main/res/xml/prefs_input_feedback.xml
@@ -38,35 +38,40 @@
             app:key="input_feedback__audio_feat_key_press"
             app:dependency="input_feedback__audio_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__audio_feat_key_press__label"/>
+            app:title="@string/pref__input_feedback__audio_feat_key_press__label"
+            app:summary="@string/pref__input_feedback__any_feat_key_press__summary"/>
 
         <SwitchPreferenceCompat
             app:defaultValue="false"
             app:key="input_feedback__audio_feat_key_long_press"
             app:dependency="input_feedback__audio_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__audio_feat_key_long_press__label"/>
+            app:title="@string/pref__input_feedback__audio_feat_key_long_press__label"
+            app:summary="@string/pref__input_feedback__any_feat_key_long_press__summary"/>
 
         <SwitchPreferenceCompat
             app:defaultValue="false"
             app:key="input_feedback__audio_feat_key_repeated_action"
             app:dependency="input_feedback__audio_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__audio_feat_key_repeated_action__label"/>
+            app:title="@string/pref__input_feedback__audio_feat_key_repeated_action__label"
+            app:summary="@string/pref__input_feedback__any_feat_key_repeated_action__summary"/>
 
         <SwitchPreferenceCompat
             app:defaultValue="false"
             app:key="input_feedback__audio_feat_gesture_swipe"
             app:dependency="input_feedback__audio_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__audio_feat_gesture_swipe__label"/>
+            app:title="@string/pref__input_feedback__audio_feat_gesture_swipe__label"
+            app:summary="@string/pref__input_feedback__any_feat_gesture_swipe__summary"/>
 
         <SwitchPreferenceCompat
             app:defaultValue="false"
             app:key="input_feedback__audio_feat_gesture_moving_swipe"
             app:dependency="input_feedback__audio_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__audio_feat_gesture_moving_swipe__label"/>
+            app:title="@string/pref__input_feedback__audio_feat_gesture_moving_swipe__label"
+            app:summary="@string/pref__input_feedback__any_feat_gesture_moving_swipe__summary"/>
 
     </PreferenceCategory>
 
@@ -90,7 +95,7 @@
             app:summary="@string/pref__input_feedback__haptic_ignore_system_settings__summary"/>
 
         <SwitchPreferenceCompat
-            app:defaultValue="false"
+            app:defaultValue="true"
             app:key="input_feedback__haptic_use_vibrator"
             app:dependency="input_feedback__haptic_enabled"
             app:iconSpaceReserved="false"
@@ -126,35 +131,40 @@
             app:key="input_feedback__haptic_feat_key_press"
             app:dependency="input_feedback__haptic_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__haptic_feat_key_press__label"/>
+            app:title="@string/pref__input_feedback__haptic_feat_key_press__label"
+            app:summary="@string/pref__input_feedback__any_feat_key_press__summary"/>
 
         <SwitchPreferenceCompat
             app:defaultValue="false"
             app:key="input_feedback__haptic_feat_key_long_press"
             app:dependency="input_feedback__haptic_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__haptic_feat_key_long_press__label"/>
+            app:title="@string/pref__input_feedback__haptic_feat_key_long_press__label"
+            app:summary="@string/pref__input_feedback__any_feat_key_long_press__summary"/>
 
         <SwitchPreferenceCompat
             app:defaultValue="true"
             app:key="input_feedback__haptic_feat_key_repeated_action"
             app:dependency="input_feedback__haptic_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__haptic_feat_key_repeated_action__label"/>
+            app:title="@string/pref__input_feedback__haptic_feat_key_repeated_action__label"
+            app:summary="@string/pref__input_feedback__any_feat_key_repeated_action__summary"/>
 
         <SwitchPreferenceCompat
             app:defaultValue="false"
             app:key="input_feedback__haptic_feat_gesture_swipe"
             app:dependency="input_feedback__haptic_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__haptic_feat_gesture_swipe__label"/>
+            app:title="@string/pref__input_feedback__haptic_feat_gesture_swipe__label"
+            app:summary="@string/pref__input_feedback__any_feat_gesture_swipe__summary"/>
 
         <SwitchPreferenceCompat
             app:defaultValue="true"
             app:key="input_feedback__haptic_feat_gesture_moving_swipe"
             app:dependency="input_feedback__haptic_enabled"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__input_feedback__haptic_feat_gesture_moving_swipe__label"/>
+            app:title="@string/pref__input_feedback__haptic_feat_gesture_moving_swipe__label"
+            app:summary="@string/pref__input_feedback__any_feat_gesture_moving_swipe__summary"/>
 
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/prefs_keyboard.xml
+++ b/app/src/main/res/xml/prefs_keyboard.xml
@@ -181,59 +181,10 @@
         app:iconSpaceReserved="false"
         app:title="@string/pref__keyboard__group_keypress__label">
 
-        <SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:key="keyboard__sound_enabled"
+        <Preference
+            app:key="keyboard__input_feedback"
             app:iconSpaceReserved="false"
-            app:title="@string/pref__keyboard__sound_enabled__label"/>
-
-        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
-            app:allowDividerAbove="false"
-            android:defaultValue="-1"
-            app:systemDefaultValue="-1"
-            app:systemDefaultValueText="@string/settings__system_default"
-            app:dependency="keyboard__sound_enabled"
-            app:key="keyboard__sound_volume"
-            app:min="0"
-            app:max="100"
-            app:iconSpaceReserved="false"
-            app:title="@string/pref__keyboard__sound_volume__label"
-            app:seekBarIncrement="1"
-            app:unit="%"/>
-
-        <SwitchPreferenceCompat
-            android:defaultValue="true"
-            android:key="keyboard__vibration_enabled"
-            app:iconSpaceReserved="false"
-            app:title="@string/pref__keyboard__vibration_enabled__label"/>
-
-        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
-            app:allowDividerAbove="false"
-            android:defaultValue="-1"
-            app:systemDefaultValue="-1"
-            app:systemDefaultValueText="@string/settings__system_default"
-            app:dependency="keyboard__vibration_enabled"
-            app:key="keyboard__vibration_strength"
-            app:min="0"
-            app:max="100"
-            app:iconSpaceReserved="false"
-            app:title="@string/pref__keyboard__vibration_strength__label"
-            app:seekBarIncrement="1"
-            app:unit="%"/>
-
-        <dev.patrickgold.florisboard.settings.components.DialogSeekBarPreference
-            app:allowDividerAbove="false"
-            android:defaultValue="-1"
-            app:systemDefaultValue="-1"
-            app:systemDefaultValueText="@string/settings__system_default"
-            app:dependency="keyboard__vibration_enabled"
-            app:key="keyboard__vibration_duration"
-            app:min="0"
-            app:max="100"
-            app:iconSpaceReserved="false"
-            app:title="@string/pref__keyboard__vibration_duration__label"
-            app:seekBarIncrement="1"
-            app:unit=" ms"/>
+            app:title="@string/settings__input_feedback__title"/>
 
         <SwitchPreferenceCompat
             android:defaultValue="true"


### PR DESCRIPTION
This PR adds a completely revamped settings panel for audio and haptic feedback when pressing keys, doing gestures, etc. and fixes a lot of bugs / unexpected behavior etc.

### Audio/haptic feedback screen

The new audio/haptic screen is accessible where the old settings for sounds & vibration where located.

| Audio | Haptic |
|---------|----------|
| ![input-feedback-screen-audio](https://user-images.githubusercontent.com/19412843/128628456-26b5457c-6148-4d8a-8512-92fd09c2882b.jpeg) | ![input-feedback-screen-haptic](https://user-images.githubusercontent.com/19412843/128628464-787c15a6-f9ad-4787-916c-599806b2aec8.jpeg) |

The feature toggles may change and do not work fully yet, still working on it.

### Fixes

- Add option to have configurable audio/haptic feedback for repeated actions, such as holding down the delete key. Closes #1041
- Fix crash when either vibration duration or strength is set to `0`. Fixes #824 and fixes #859
- FlorisBoard's haptic/audio prefs can now work even if these are disabled at a system level, thus allowing for a more granular control of haptic feedback if one does not want to enable audio/haptics across all apps. Closes #217
- Additionally closes #652 and probably closes #1084

### Known issues currently
- When the phone is set to muted, even ignore system prefs can't help here and audio won't play at all. Fixed by adding a note that this is the cause.
- Some features don't respect feature toggles or are assigned to the incorrect ones. Fixed by implementing the feature toggles

---

| Old settings for reference |
|------|
| ![input-feedback-screen-old](https://user-images.githubusercontent.com/19412843/128628504-e8b412d7-885a-47a4-9674-f70a97142ec4.jpeg) |