### PR TITLE
Rework EditorInstance cached input and word detection logic

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/debug/LogTopic.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/debug/LogTopic.kt
@@ -45,4 +45,5 @@ object LogTopic {
     const val CRASH_UTILITY: FlogTopic =        2048u
 
     const val SPELL_EVENTS: FlogTopic =         4096u
+    const val EDITOR_INSTANCE: FlogTopic =      0x00_00_20_00u
 }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -953,8 +953,8 @@ class EditorInstance(private val ims: InputMethodService, private val activeStat
             wordsAfterCurrent.clear()
             currentWord = null
 
-            if (selection.isValid && selection.isCursorMode) {
-                val cursor = selection.start.coerceAtLeast(0)
+            if (selection.isValid) {
+                val cursor = selection.end.coerceAtLeast(0)
                 val detectStart = (cursor - CACHED_N_CHARS_BEFORE_CURSOR - offset).coerceAtLeast(0)
                 val detectEnd = (cursor + CACHED_N_CHARS_AFTER_CURSOR - offset).coerceAtMost(rawText.length - 1)
                 for (wordRange in TextProcessor.detectWords(rawText, detectStart, detectEnd, FlorisLocale.ENGLISH)) {
@@ -970,6 +970,30 @@ class EditorInstance(private val ims: InputMethodService, private val activeStat
                         wordsBeforeCurrent.add(Region(wordStart, wordEnd))
                     } else {
                         wordsAfterCurrent.add(Region(wordStart, wordEnd))
+                    }
+                }
+            }
+
+            flogDebug(LogTopic.EDITOR_INSTANCE) {
+                stringBuilder {
+                    append("Words before current: ")
+                    wordsBeforeCurrent.forEach {
+                        append(it.toString())
+                        append(' ')
+                    }
+                }
+            }
+            flogDebug(LogTopic.EDITOR_INSTANCE) {
+                stringBuilder {
+                    append("Current word: $currentWord")
+                }
+            }
+            flogDebug(LogTopic.EDITOR_INSTANCE) {
+                stringBuilder {
+                    append("Words after current: ")
+                    wordsAfterCurrent.forEach {
+                        append(it.toString())
+                        append(' ')
                     }
                 }
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -480,6 +480,51 @@ class EditorInstance(private val ims: InputMethodService, private val activeStat
         return true
     }
 
+    fun selectionSetNWordsLeft(n: Int): Boolean {
+        flogDebug { "$n" }
+        isPhantomSpaceActive = false
+        wasPhantomSpaceActiveLastUpdate = false
+        if (selection.start < 0) return false
+        if (n <= 0) {
+            selection.updateAndNotify(selection.end, selection.end)
+            return true
+        }
+        var wordsSelected = 0
+        var selStart = selection.end
+        val currentWord = cachedInput.currentWord
+        val wordsBeforeCurrent = cachedInput.wordsBeforeCurrent
+        if (currentWord != null && currentWord.isValid) {
+            if (selStart > currentWord.start) {
+                selStart = currentWord.start
+                if (++wordsSelected == n) {
+                    selection.updateAndNotify(selStart, selection.end)
+                    return true
+                }
+            }
+            for (word in wordsBeforeCurrent.reversed()) {
+                if (selStart > word.start) {
+                    selStart = word.start
+                    if (++wordsSelected == n) {
+                        selection.updateAndNotify(selStart, selection.end)
+                        return true
+                    }
+                }
+            }
+        } else {
+            for (word in wordsBeforeCurrent.reversed()) {
+                if (selStart > word.start) {
+                    selStart = word.start
+                    if (++wordsSelected == n) {
+                        selection.updateAndNotify(selStart, selection.end)
+                        return true
+                    }
+                }
+            }
+        }
+        selection.updateAndNotify(0, selection.end)
+        return true
+    }
+
     /**
      * Marks a given [region] as composing and notifies the input connection.
      *

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/TextProcessor.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/TextProcessor.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.core
+
+import dev.patrickgold.florisboard.common.FlorisLocale
+
+@Suppress("RegExpRedundantEscape")
+object TextProcessor {
+    private val LATIN_BASIC_WORD_REGEX = """[_]*(([\p{L}\d\']+[_-]*[\p{L}\d\']+)|[\p{L}\d\']+)[_]*""".toRegex()
+
+    private fun wordRegexFor(locale: FlorisLocale): Regex {
+        return when (locale) {
+            else -> LATIN_BASIC_WORD_REGEX
+        }
+    }
+
+    fun detectWords(text: CharSequence, locale: FlorisLocale): Sequence<IntRange> {
+        val regex = wordRegexFor(locale)
+        return regex.findAll(text).map { it.range }
+    }
+
+    fun isWord(text: CharSequence, locale: FlorisLocale): Boolean {
+        val regex = wordRegexFor(locale)
+        return regex.matches(text)
+    }
+}

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/TextProcessor.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/TextProcessor.kt
@@ -33,6 +33,13 @@ object TextProcessor {
         return regex.findAll(text).map { it.range }
     }
 
+    fun detectWords(text: CharSequence, start: Int, end: Int, locale: FlorisLocale): Sequence<IntRange> {
+        val regex = wordRegexFor(locale)
+        val tStart = start.coerceAtLeast(0)
+        val tEnd = end.coerceAtMost(text.length)
+        return regex.findAll(text.slice(tStart..tEnd)).map { it.range }
+    }
+
     fun isWord(text: CharSequence, locale: FlorisLocale): Boolean {
         val regex = wordRegexFor(locale)
         return regex.matches(text)

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
@@ -631,10 +631,12 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                             florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.DELETE)
                         }
                         markComposingRegion(null)
-                        selection.updateAndNotify(
-                            (selection.end + event.absUnitCountX + 1).coerceIn(0, selection.end),
-                            selection.end
-                        )
+                        if (selection.isValid) {
+                            selection.updateAndNotify(
+                                (selection.end + event.absUnitCountX + 1).coerceIn(0, selection.end),
+                                selection.end
+                            )
+                        }
                     }
                     pointer.shouldBlockNextUp = true
                     true
@@ -645,7 +647,9 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                             florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.DELETE)
                         }
                         markComposingRegion(null)
-                        selectionSetNWordsLeft(abs(event.absUnitCountX / 2) - 1)
+                        if (selection.isValid) {
+                            selectionSetNWordsLeft(abs(event.absUnitCountX / 2) - 1)
+                        }
                     }
                     pointer.shouldBlockNextUp = true
                     true

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardView.kt
@@ -635,28 +635,20 @@ class TextKeyboardView : KeyboardView, SwipeGesture.Listener, GlideTypingGesture
                             (selection.end + event.absUnitCountX + 1).coerceIn(0, selection.end),
                             selection.end
                         )
-                        pointer.shouldBlockNextUp = true
                     }
+                    pointer.shouldBlockNextUp = true
                     true
                 }
-                SwipeAction.DELETE_WORDS_PRECISELY -> when (event.direction) {
-                    SwipeGesture.Direction.LEFT -> {
-                        florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.DELETE)
-                        florisboard.activeEditorInstance.apply {
-                            leftAppendWordToSelection()
+                SwipeAction.DELETE_WORDS_PRECISELY -> {
+                    florisboard.activeEditorInstance.apply {
+                        if (abs(event.relUnitCountX) > 0) {
+                            florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.DELETE)
                         }
-                        pointer.shouldBlockNextUp = true
-                        true
+                        markComposingRegion(null)
+                        selectionSetNWordsLeft(abs(event.absUnitCountX / 2) - 1)
                     }
-                    SwipeGesture.Direction.RIGHT -> {
-                        florisboard.inputFeedbackManager.gestureMovingSwipe(TextKeyData.DELETE)
-                        florisboard.activeEditorInstance.apply {
-                            leftPopWordFromSelection()
-                        }
-                        pointer.shouldBlockNextUp = true
-                        true
-                    }
-                    else -> false
+                    pointer.shouldBlockNextUp = true
+                    true
                 }
                 else -> false
             }

--- a/app/src/main/java/dev/patrickgold/florisboard/settings/UdmActivity.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/settings/UdmActivity.kt
@@ -348,7 +348,7 @@ class UdmActivity : FlorisActivity<UdmActivityBinding>() {
         )
         if (currentLevel == LEVEL_WORDS) {
             currentLocale?.let {
-                dialogBinding.locale.setText(it.toString())
+                dialogBinding.locale.setText(it.localeTag())
             }
         }
 
@@ -437,7 +437,7 @@ class UdmActivity : FlorisActivity<UdmActivityBinding>() {
         }
         if (isValid) {
             val localeStr = if (locale == null) { null } else {
-                FlorisLocale.fromTag(locale).toString()
+                FlorisLocale.fromTag(locale).localeTag()
             }
             if (entry != null) {
                 userDictionaryDao()?.update(

--- a/app/src/test/java/dev/patrickgold/florisboard/ime/core/EditorInstanceTest.kt
+++ b/app/src/test/java/dev/patrickgold/florisboard/ime/core/EditorInstanceTest.kt
@@ -1,0 +1,113 @@
+package dev.patrickgold.florisboard.ime.core
+
+import android.app.Application
+import android.inputmethodservice.InputMethodService
+import android.view.inputmethod.ExtractedText
+import dev.patrickgold.florisboard.ime.keyboard.KeyboardState
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+/**
+ * Unit test for [EditorInstance].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class EditorInstanceTest {
+    private val editorInstance = EditorInstance(InputMethodService(), KeyboardState.new())
+
+    @Test
+    fun `Test normalizeBounds`() {
+        assertEquals(
+            expected = EditorInstance.Bounds(3, 5),
+            actual = editorInstance.normalizeBounds(3, 5),
+            message = "Bounds order input is already normalized and must match output, but is different."
+        )
+        assertEquals(
+            expected = EditorInstance.Bounds(3, 5),
+            actual = editorInstance.normalizeBounds(5, 3),
+            message = "Bounds order input is not normalized and start/end must be swapped, but they aren't."
+        )
+        assertEquals(
+            expected = EditorInstance.Bounds(5, 5),
+            actual = editorInstance.normalizeBounds(5, 5),
+            message = "Bounds input start and end is the same number, output should match too but doesn't."
+        )
+    }
+
+    @Test
+    fun `Test ExtractedText$isPartialChange`() {
+        assertEquals(
+            expected = true,
+            actual = editorInstance.run {
+                ExtractedText().apply { partialStartOffset = 3; partialEndOffset = 5 }.isPartialChange()
+            },
+            message = "Is partial change fails for 3/5"
+        )
+        assertEquals(
+            expected = false,
+            actual = editorInstance.run {
+                ExtractedText().apply { partialStartOffset = -1; partialEndOffset = -1 }.isPartialChange()
+            },
+            message = "Is partial change fails for -1/-1"
+        )
+        assertEquals(
+            expected = false,
+            actual = editorInstance.run {
+                ExtractedText().apply { partialStartOffset = -1; partialEndOffset = 5 }.isPartialChange()
+            },
+            message = "Is partial change fails for -1/5"
+        )
+        assertEquals(
+            expected = false,
+            actual = editorInstance.run {
+                ExtractedText().apply { partialStartOffset = 3; partialEndOffset = -1 }.isPartialChange()
+            },
+            message = "Is partial change fails for 3/-1"
+        )
+    }
+
+    @Test
+    fun `Test Bounds$equals`() {
+        assertEquals(
+            expected = true,
+            actual = EditorInstance.Bounds(3, 5) == EditorInstance.Bounds(3, 5),
+            message = "Equals for Bounds fails."
+        )
+        assertEquals(
+            expected = false,
+            actual = EditorInstance.Bounds(3, 5) == EditorInstance.Bounds(3, 4),
+            message = "Equals for Bounds fails."
+        )
+        assertEquals(
+            expected = false,
+            actual = EditorInstance.Bounds(4, 5) == EditorInstance.Bounds(3, 5),
+            message = "Equals for Bounds fails."
+        )
+        assertEquals(
+            expected = false,
+            actual = EditorInstance.Bounds(1, 2) == EditorInstance.Bounds(3, 4),
+            message = "Equals for Bounds fails."
+        )
+    }
+
+    @Test
+    fun `Test Bounds$component1`() {
+        assertEquals(
+            expected = 3,
+            actual = EditorInstance.Bounds(3, 5).component1(),
+            message = "component1 for Bounds fails."
+        )
+    }
+
+    @Test
+    fun `Test Bounds$component2`() {
+        assertEquals(
+            expected = 5,
+            actual = EditorInstance.Bounds(3, 5).component2(),
+            message = "component2 for Bounds fails."
+        )
+    }
+}

--- a/app/src/test/java/dev/patrickgold/florisboard/ime/core/TextProcessorTest.kt
+++ b/app/src/test/java/dev/patrickgold/florisboard/ime/core/TextProcessorTest.kt
@@ -1,0 +1,75 @@
+package dev.patrickgold.florisboard.ime.core
+
+import dev.patrickgold.florisboard.common.FlorisLocale
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit test for [TextProcessor].
+ */
+class TextProcessorTest {
+    @Test
+    fun `Test isWord with samples that are words`() {
+        listOf(
+            "a",
+            "word",
+            "you're",
+            "re-write",
+            "CONSTANT_NAME",
+            "__CONSTANT_NAME",
+            "__CONSTANT_NAME__",
+            "CONSTANT_NAME__",
+            "Test20",
+            "2021",
+            "20Test",
+            "Straße",
+            "Ärger",
+            "Österreich",
+            "drüber",
+        ).forEach {
+            assertEquals(
+                expected = true,
+                actual = TextProcessor.isWord(it, FlorisLocale.ENGLISH),
+                message = "Expected that '$it' is a word, but isn't."
+            )
+        }
+    }
+
+    @Test
+    fun `Test isWord with samples that are not words`() {
+        listOf(
+            " ",
+            "&",
+            "-",
+            "+",
+            "*",
+            "/",
+            "__",
+            "~",
+            "~",
+            "2.0",
+            "2,0",
+            "--word",
+            "--word--",
+            "word--",
+        ).forEach {
+            assertEquals(
+                expected = false,
+                actual = TextProcessor.isWord(it, FlorisLocale.ENGLISH),
+                message = "Expected that '$it' is a word, but isn't."
+            )
+        }
+    }
+
+    @Test
+    fun `Test detectWords for basic Latin`() {
+        val inputStr = "A test sentence, in 2021 for KOTLIN_TEST. #Test + #Kotlin 2.0"
+        assertEquals(
+            expected = listOf(
+                0..0, 2..5, 7..14, 17..18, 20..23, 25..27, 29..39, 43..46, 51..56, 58..58, 60..60
+            ),
+            actual = TextProcessor.detectWords(inputStr, FlorisLocale.ENGLISH).toList(),
+            message = "Text processor word detection fails for '$inputStr'"
+        )
+    }
+}


### PR DESCRIPTION
This PR is a rework for the cached input logic, text processing & word detection logic. Additionally fixes the fully bugged whole-word deletion and current word deletion swipe.

- Fix crash when swiping:  
  Closes #1130  
  Closes #1076  
  Closes #1065  
  Closes #1014  
- Fix inconsistent selection:
  Closes #546  
  Closes #547
- Deletion does not work:
  Closes #1072  

Will be fixed at a later stage: #548