### PR TITLE
Add ñ as popup on catalan layout

### DIFF
--- a/app/src/main/assets/ime/text/characters/extended_popups/ca.json
+++ b/app/src/main/assets/ime/text/characters/extended_popups/ca.json
@@ -79,6 +79,9 @@
           { "$": "auto_text_key", "code":  251, "label": "û" }
         ]
       },
+      "n": {
+        "main": { "$": "auto_text_key", "code":  241, "label": "ñ" }
+      },
       "~right": {
         "main": { "code":   44, "label": "," },
         "relevant": [


### PR DESCRIPTION
Let me explain this. Catalan people like me also speak Spanish, and we usually use both languages at the same time while typing, so it comes very handy to have ñ on the Catalan keyboard (even though it's not on the alphabet). Keyboards like GBoard already do this.

Thanks!