### PR TITLE
Update the Romanian layout

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ro.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ro.json
@@ -1,19 +1,25 @@
 {
   "all": {
     "a": {
-      "main": { "$": "auto_text_key", "code": 259, "label": "ă" },
       "relevant": [
+        { "$": "auto_text_key", "code":  259, "label": "ă" },
         { "$": "auto_text_key", "code":  226, "label": "â" }
       ]
     },
     "i": {
-      "main": { "$": "auto_text_key", "code":  238, "label": "î" }
+      "relevant": [
+        { "$": "auto_text_key", "code":  238, "label": "î" }
+      ]
     },
     "s": {
-      "main": { "$": "auto_text_key", "code": 537, "label": "ș" }
+      "relevant": [
+        { "$": "auto_text_key", "code":  537, "label": "ș" }
+      ]
     },
     "t": {
-      "main": { "$": "auto_text_key", "code": 539, "label": "ț" }
+      "relevant": [
+        { "$": "auto_text_key", "code":  539, "label": "ț" }
+      ]
     },
     "~right": {
       "main": { "code":   44, "label": "," },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ro.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ro.json
@@ -40,10 +40,10 @@
     "~right": {
       "main": { "code": -255, "label": ".com" },
       "relevant": [
-        { "code": -255, "label": ".ro" },
-        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".eu" },
         { "code": -255, "label": ".net" },
-        { "code": -255, "label": ".edu" }
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".ro" }
       ]
     }
   }

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ro.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ro.json
@@ -6,6 +6,18 @@
         { "$": "auto_text_key", "code":  226, "label": "â" }
       ]
     },
+    "c": {
+      "relevant": [
+        { "code": 8217, "label": "’" }
+      ]
+    },
+    "h": {
+      "relevant": [
+        { "code": 8209, "label": "‑" },
+        { "code": 8211, "label": "–" },
+        { "code": 8212, "label": "—" }
+      ]
+    },
     "i": {
       "relevant": [
         { "$": "auto_text_key", "code":  238, "label": "î" }
@@ -19,6 +31,12 @@
     "t": {
       "relevant": [
         { "$": "auto_text_key", "code":  539, "label": "ț" }
+      ]
+    },
+    "x": {
+      "relevant": [
+        { "code": 8222, "label": "„" },
+        { "code": 8221, "label": "”" }
       ]
     },
     "~right": {


### PR DESCRIPTION
* The key hints are now the default popup keys. The old behavior was very confusing.
* Improved the URI TLD list:
  * `.ro` is now to the right of `.com`
  * added `.eu`
  * removed the US `.edu`
* Updated the Romanian layout to include all possible punctuation marks recognized by the Romanian Academy.

EDIT: Fixed uppercase letters.