### PR TITLE
Enable encrypted backup for app data (#272, #1324)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,12 +36,15 @@
 
     <application
         android:name="dev.patrickgold.florisboard.FlorisApplication"
-        android:allowBackup="false"
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/backup_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/floris_app_icon"
         android:label="@string/floris_app_name"
         android:roundIcon="@mipmap/floris_app_icon_round"
         android:supportsRtl="true"
-        android:theme="@style/FlorisAppTheme">
+        android:theme="@style/FlorisAppTheme"
+        tools:targetApi="s">
 
         <!-- IME service -->
         <service

--- a/app/src/main/res/xml-v31/backup_rules.xml
+++ b/app/src/main/res/xml-v31/backup_rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <include
+            domain="root"
+            path="jetpref_datastore"/>
+        <include
+            domain="file"
+            path="ime"/>
+        <include
+            domain="database"
+            path="floris_user_dictionary.db"/>
+    </cloud-backup>
+    <device-transfer>
+        <include
+            domain="root"
+            path="jetpref_datastore"/>
+        <include
+            domain="file"
+            path="ime"/>
+        <include
+            domain="database"
+            path="floris_user_dictionary.db"/>
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include
+        domain="root"
+        path="jetpref_datastore"
+        requireFlags="clientSideEncryption"/>
+    <include
+        domain="file"
+        path="ime"
+        requireFlags="clientSideEncryption"/>
+    <include
+        domain="database"
+        path="floris_user_dictionary.db"
+        requireFlags="clientSideEncryption"/>
+</full-backup-content>


### PR DESCRIPTION
Add manifest entry for allowing encrypted auto backup, either via Google's auto backup service on GMS devices or via Seedvault on AOSP-based devices.

Included files in auto-backups:
- All app preferences: `jetpref_datastore/*`
- Custom layouts, dictionaries (spelling) and custom themes: `files/ime/*`

Excluded files from auto-backup:
- Clipboard history, pins, images stored in the clipboard history
- Generated crash reports (which have not been viewed in the crash report screen)
- Floris user dictionary

---

Closes #272 
Closes #1324 