### PR TITLE
fix: add check for null selectedText when performing a copy

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/core/EditorInstance.kt
@@ -951,7 +951,10 @@ class EditorInstance(private val ims: InputMethodService) {
             !isValid -> ""
             else -> when (val ic = inputConnection) {
                 null -> ""
-                else -> ic.getSelectedText(0).toString()
+                else -> when (val selectedText = ic.getSelectedText(0)) {
+                    null -> ""
+                    else -> selectedText.toString()
+                }
             }
         }
 


### PR DESCRIPTION
Fix #1232 
Fix #1468 
Fix #1554 
Fix #1576 

Added an additional check for `ic.getSelectedText(0)` being `null`