### PR TITLE
Fix TLDs of Arabic and Urdu-Phonetic

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ar.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ar.json
@@ -70,27 +70,27 @@
       ]
     },
     "~right": {
-      "main": { "code": 1611, "label": "ً" },
+      "main": { "code": 1611, "label": "ً◌" },
       "relevant": [
-        { "code": 1622, "label": "ٖ" },
-        { "code": 1648, "label": "ٰ" },
-        { "code": 1619, "label": "ٓ" },
-        { "code": 1615, "label": "ُ" },
-        { "code": 1616, "label": "ِ" },
-        { "code": 1614, "label": "َ" },
+        { "code": 1622, "label": "ٖ◌" },
+        { "code": 1648, "label": "ٰ◌" },
+        { "code": 1619, "label": "ٓ◌" },
+        { "code": 1615, "label": "ُ◌" },
+        { "code": 1616, "label": "ِ◌" },
+        { "code": 1614, "label": "َ◌" },
         { "code": 1600, "label": "ـ" },
-        { "code": 1621, "label": "ٕ" },
-        { "code": 1620, "label": "ٔ" },
-        { "code": 1617, "label": "ّ" },
-        { "code": 1612, "label": "ٌ" },
-        { "code": 1613, "label": "ٍ" },
-        { "code": 1618, "label": "ْ" }
+        { "code": 1621, "label": "ٕ◌" },
+        { "code": 1620, "label": "ٔ◌" },
+        { "code": 1617, "label": "ّ◌" },
+        { "code": 1612, "label": "ٌ◌" },
+        { "code": 1613, "label": "ٍ◌" },
+        { "code": 1618, "label": "ْ◌" }
       ]
     }
   },
   "uri": {
     "~right": {
-      "main": { "code": -255, "label": ".ir"},
+      "main": { "code": -255, "label": ".sa"},
       "relevant": [
         { "code": -255, "label": ".gov" },
         { "code": -255, "label": ".edu" },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ar.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ar.json
@@ -69,21 +69,22 @@
         { "code": 1688, "label": "ژ" }
       ]
     },
-    "~right": {        "main": { "code": 1611, "label": "ً" },
-        "relevant": [
-          { "code": 1622, "label": "ٖ" },
-          { "code": 1648, "label": "ٰ" },
-          { "code": 1619, "label": "ٓ" },
-          { "code": 1615, "label": "ُ" },
-          { "code": 1616, "label": "ِ" },
-          { "code": 1614, "label": "َ" },
-          { "code": 1600, "label": "ـ" },
-          { "code": 1621, "label": "ٕ" },
-          { "code": 1620, "label": "ٔ" },
-          { "code": 1617, "label": "ّ" },
-          { "code": 1612, "label": "ٌ" },
-          { "code": 1613, "label": "ٍ" },
-          { "code": 1618, "label": "ْ" }
+    "~right": {
+      "main": { "code": 1611, "label": "ً" },
+      "relevant": [
+        { "code": 1622, "label": "ٖ" },
+        { "code": 1648, "label": "ٰ" },
+        { "code": 1619, "label": "ٓ" },
+        { "code": 1615, "label": "ُ" },
+        { "code": 1616, "label": "ِ" },
+        { "code": 1614, "label": "َ" },
+        { "code": 1600, "label": "ـ" },
+        { "code": 1621, "label": "ٕ" },
+        { "code": 1620, "label": "ٔ" },
+        { "code": 1617, "label": "ّ" },
+        { "code": 1612, "label": "ٌ" },
+        { "code": 1613, "label": "ٍ" },
+        { "code": 1618, "label": "ْ" }
       ]
     }
   },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ar.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ar.json
@@ -69,22 +69,21 @@
         { "code": 1688, "label": "ژ" }
       ]
     },
-    "~right": {
-      "main": { "code": 1611, "label": "ً◌" },
-      "relevant": [
-        { "code": 1622, "label": "ٖ◌" },
-        { "code": 1648, "label": "ٰ◌" },
-        { "code": 1619, "label": "ٓ◌" },
-        { "code": 1615, "label": "ُ◌" },
-        { "code": 1616, "label": "ِ◌" },
-        { "code": 1614, "label": "َ◌" },
-        { "code": 1600, "label": "ـ" },
-        { "code": 1621, "label": "ٕ◌" },
-        { "code": 1620, "label": "ٔ◌" },
-        { "code": 1617, "label": "ّ◌" },
-        { "code": 1612, "label": "ٌ◌" },
-        { "code": 1613, "label": "ٍ◌" },
-        { "code": 1618, "label": "ْ◌" }
+    "~right": {        "main": { "code": 1611, "label": "ً" },
+        "relevant": [
+          { "code": 1622, "label": "ٖ" },
+          { "code": 1648, "label": "ٰ" },
+          { "code": 1619, "label": "ٓ" },
+          { "code": 1615, "label": "ُ" },
+          { "code": 1616, "label": "ِ" },
+          { "code": 1614, "label": "َ" },
+          { "code": 1600, "label": "ـ" },
+          { "code": 1621, "label": "ٕ" },
+          { "code": 1620, "label": "ٔ" },
+          { "code": 1617, "label": "ّ" },
+          { "code": 1612, "label": "ٌ" },
+          { "code": 1613, "label": "ٍ" },
+          { "code": 1618, "label": "ْ" }
       ]
     }
   },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/fa.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/fa.json
@@ -44,21 +44,21 @@
       ]
     },
     "~right": {
-      "main": { "code": 1611, "label": "ً" },
+      "main": { "code": 1611, "label": "ً◌" },
       "relevant": [
-        { "code": 1622, "label": "ٖ" },
-        { "code": 1648, "label": "ٰ" },
-        { "code": 1619, "label": "ٓ" },
-        { "code": 1615, "label": "ُ" },
-        { "code": 1616, "label": "ِ" },
-        { "code": 1614, "label": "َ" },
+        { "code": 1622, "label": "ٖ◌" },
+        { "code": 1648, "label": "ٰ◌" },
+        { "code": 1619, "label": "ٓ◌" },
+        { "code": 1615, "label": "ُ◌" },
+        { "code": 1616, "label": "ِ◌" },
+        { "code": 1614, "label": "َ◌" },
         { "code": 1600, "label": "ـ" },
-        { "code": 1621, "label": "ٕ" },
-        { "code": 1618, "label": "ْ" },
-        { "code": 1617, "label": "ّ" },
-        { "code": 1612, "label": "ٌ" },
-        { "code": 1613, "label": "ٍ" },
-        { "code": 1620, "label": "ٔ" }
+        { "code": 1621, "label": "ٕ◌" },
+        { "code": 1620, "label": "ٔ◌" },
+        { "code": 1617, "label": "ّ◌" },
+        { "code": 1612, "label": "ٌ◌" },
+        { "code": 1613, "label": "ٍ◌" },
+        { "code": 1618, "label": "ْ◌" }
       ]
     }
   },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/fa.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/fa.json
@@ -43,22 +43,21 @@
         { "code": 1572, "label": "ؤ" }
       ]
     },
-    "~right": {
-      "main": { "code": 1611, "label": "ً◌" },
-      "relevant": [
-        { "code": 1622, "label": "ٖ◌" },
-        { "code": 1648, "label": "ٰ◌" },
-        { "code": 1619, "label": "ٓ◌" },
-        { "code": 1615, "label": "ُ◌" },
-        { "code": 1616, "label": "ِ◌" },
-        { "code": 1614, "label": "َ◌" },
-        { "code": 1600, "label": "ـ" },
-        { "code": 1621, "label": "ٕ◌" },
-        { "code": 1620, "label": "ٔ◌" },
-        { "code": 1617, "label": "ّ◌" },
-        { "code": 1612, "label": "ٌ◌" },
-        { "code": 1613, "label": "ٍ◌" },
-        { "code": 1618, "label": "ْ◌" }
+    "~right": {        "main": { "code": 1611, "label": "ً" },
+        "relevant": [
+          { "code": 1622, "label": "ٖ" },
+          { "code": 1648, "label": "ٰ" },
+          { "code": 1619, "label": "ٓ" },
+          { "code": 1615, "label": "ُ" },
+          { "code": 1616, "label": "ِ" },
+          { "code": 1614, "label": "َ" },
+          { "code": 1600, "label": "ـ" },
+          { "code": 1621, "label": "ٕ" },
+          { "code": 1620, "label": "ٔ" },
+          { "code": 1617, "label": "ّ" },
+          { "code": 1612, "label": "ٌ" },
+          { "code": 1613, "label": "ٍ" },
+          { "code": 1618, "label": "ْ" }
       ]
     }
   },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/fa.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/fa.json
@@ -43,21 +43,22 @@
         { "code": 1572, "label": "ؤ" }
       ]
     },
-    "~right": {        "main": { "code": 1611, "label": "ً" },
-        "relevant": [
-          { "code": 1622, "label": "ٖ" },
-          { "code": 1648, "label": "ٰ" },
-          { "code": 1619, "label": "ٓ" },
-          { "code": 1615, "label": "ُ" },
-          { "code": 1616, "label": "ِ" },
-          { "code": 1614, "label": "َ" },
-          { "code": 1600, "label": "ـ" },
-          { "code": 1621, "label": "ٕ" },
-          { "code": 1620, "label": "ٔ" },
-          { "code": 1617, "label": "ّ" },
-          { "code": 1612, "label": "ٌ" },
-          { "code": 1613, "label": "ٍ" },
-          { "code": 1618, "label": "ْ" }
+    "~right": {
+      "main": { "code": 1611, "label": "ً" },
+      "relevant": [
+        { "code": 1622, "label": "ٖ" },
+        { "code": 1648, "label": "ٰ" },
+        { "code": 1619, "label": "ٓ" },
+        { "code": 1615, "label": "ُ" },
+        { "code": 1616, "label": "ِ" },
+        { "code": 1614, "label": "َ" },
+        { "code": 1600, "label": "ـ" },
+        { "code": 1621, "label": "ٕ" },
+        { "code": 1618, "label": "ْ" },
+        { "code": 1617, "label": "ّ" },
+        { "code": 1612, "label": "ٌ" },
+        { "code": 1613, "label": "ٍ" },
+        { "code": 1620, "label": "ٔ" }
       ]
     }
   },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ur-PK.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ur-PK.json
@@ -2,7 +2,7 @@
   "all": {
     "ق": {
       "relevant": [
-        { "code": 1618, "label": "ْ◌" },
+        { "code": 1618, "label": "ْ" },
         { "code": 49, "label": "1" }
       ]
     },
@@ -14,15 +14,15 @@
     },
     "ع": {
       "relevant": [
-        { "code": 1553, "label": "ؑ◌" },
+        { "code": 1553, "label": "ؑ" },
         { "code": 51, "label": "3" }
       ]
     },
     "ر": {
       "relevant": [
         { "code": 1681, "label": "ڑ" },
-        { "code": 1554, "label": "ؒ◌" },
-        { "code": 1555, "label": "ؓ◌" },
+        { "code": 1554, "label": "ؒ" },
+        { "code": 1555, "label": "ؓ" },
         { "code": 52, "label": "4" }
       ]
     },
@@ -41,8 +41,8 @@
     },
     "ء": {
       "relevant": [
-        { "code": 1621, "label": "ٕ◌" },
-        { "code": 1620, "label": "ٔ◌" },
+        { "code": 1621, "label": "ٕ" },
+        { "code": 1620, "label": "ٔ" },
         { "code": 55, "label": "7" }
       ]
     },
@@ -89,7 +89,7 @@
         { "code": 1589, "label": "ص" },
         { "code": 1537, "label": "؁" },
         { "code": 1539, "label": "؃" },
-        { "code": 1750, "label": "ؐ◌ۖ" }
+        { "code": 1750, "label": "ؐۖ" }
       ]
     },
     "د": {
@@ -163,21 +163,21 @@
       ]
     },
     "~right": {
-      "main": { "code": 1611, "label": "ً◌" },
+      "main": { "code": 1611, "label": "ً" },
       "relevant": [
-        { "code": 1622, "label": "ٖ◌" },
-        { "code": 1648, "label": "ٰ◌" },
-        { "code": 1619, "label": "ٓ◌" },
-        { "code": 1615, "label": "ُ◌" },
-        { "code": 1616, "label": "ِ◌" },
-        { "code": 1614, "label": "َ◌" },
+        { "code": 1622, "label": "ٖ" },
+        { "code": 1648, "label": "ٰ" },
+        { "code": 1619, "label": "ٓ" },
+        { "code": 1615, "label": "ُ" },
+        { "code": 1616, "label": "ِ" },
+        { "code": 1614, "label": "َ" },
         { "code": 1600, "label": "ـ" },
-        { "code": 1621, "label": "ٕ◌" },
-        { "code": 1620, "label": "ٔ◌" },
-        { "code": 1617, "label": "ّ◌" },
-        { "code": 1612, "label": "ٌ◌" },
-        { "code": 1613, "label": "ٍ◌" },
-        { "code": 1618, "label": "ْ◌" }
+        { "code": 1621, "label": "ٕ" },
+        { "code": 1620, "label": "ٔ" },
+        { "code": 1617, "label": "ّ" },
+        { "code": 1612, "label": "ٌ" },
+        { "code": 1613, "label": "ٍ" },
+        { "code": 1618, "label": "ْ" }
       ]
     }
   },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ur-PK.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ur-PK.json
@@ -2,7 +2,7 @@
   "all": {
     "ق": {
       "relevant": [
-        { "code": 1618, "label": "ْ" },
+        { "code": 1618, "label": "ْ◌" },
         { "code": 49, "label": "1" }
       ]
     },
@@ -14,15 +14,15 @@
     },
     "ع": {
       "relevant": [
-        { "code": 1553, "label": "ؑ" },
+        { "code": 1553, "label": "ؑ◌" },
         { "code": 51, "label": "3" }
       ]
     },
     "ر": {
       "relevant": [
         { "code": 1681, "label": "ڑ" },
-        { "code": 1554, "label": "ؒ" },
-        { "code": 1555, "label": "ؓ" },
+        { "code": 1554, "label": "ؒ◌" },
+        { "code": 1555, "label": "ؓ◌" },
         { "code": 52, "label": "4" }
       ]
     },
@@ -41,8 +41,8 @@
     },
     "ء": {
       "relevant": [
-        { "code": 1621, "label": "ٕ" },
-        { "code": 1620, "label": "ٔ" },
+        { "code": 1621, "label": "ٕ◌" },
+        { "code": 1620, "label": "ٔ◌" },
         { "code": 55, "label": "7" }
       ]
     },
@@ -89,7 +89,7 @@
         { "code": 1589, "label": "ص" },
         { "code": 1537, "label": "؁" },
         { "code": 1539, "label": "؃" },
-        { "code": 1750, "label": "ؐۖ" }
+        { "code": 1750, "label": "ؐ◌ۖ" }
       ]
     },
     "د": {
@@ -163,27 +163,27 @@
       ]
     },
     "~right": {
-      "main": { "code": 1611, "label": "ً" },
+      "main": { "code": 1611, "label": "ً◌" },
       "relevant": [
-        { "code": 1622, "label": "ٖ" },
-        { "code": 1648, "label": "ٰ" },
-        { "code": 1619, "label": "ٓ" },
-        { "code": 1615, "label": "ُ" },
-        { "code": 1616, "label": "ِ" },
-        { "code": 1614, "label": "َ" },
+        { "code": 1622, "label": "ٖ◌" },
+        { "code": 1648, "label": "ٰ◌" },
+        { "code": 1619, "label": "ٓ◌" },
+        { "code": 1615, "label": "ُ◌" },
+        { "code": 1616, "label": "ِ◌" },
+        { "code": 1614, "label": "َ◌" },
         { "code": 1600, "label": "ـ" },
-        { "code": 1621, "label": "ٕ" },
-        { "code": 1620, "label": "ٔ" },
-        { "code": 1617, "label": "ّ" },
-        { "code": 1612, "label": "ٌ" },
-        { "code": 1613, "label": "ٍ" },
-        { "code": 1618, "label": "ْ" }
+        { "code": 1621, "label": "ٕ◌" },
+        { "code": 1620, "label": "ٔ◌" },
+        { "code": 1617, "label": "ّ◌" },
+        { "code": 1612, "label": "ٌ◌" },
+        { "code": 1613, "label": "ٍ◌" },
+        { "code": 1618, "label": "ْ◌" }
       ]
     }
   },
   "uri": {
     "~right": {
-      "main": { "code": -255, "label": ".ir"},
+      "main": { "code": -255, "label": ".pk"},
       "relevant": [
         { "code": -255, "label": ".gov" },
         { "code": -255, "label": ".edu" },


### PR DESCRIPTION
Fix Arabic diacritics showing empty popups on long press, Also changed the default top-level-domain `TLD` to saudi arabia `SA` for arabic popup mapping and `PK` for Urdu language.

This PR is fixes #1679 