### PR TITLE
Improve telpad UI (alphabetic letters and popups)

### DIFF
--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
@@ -226,7 +226,21 @@ class TextKey(override val data: AbstractKeyData) : Key(data) {
         foregroundDrawableId = evaluator.computeIconResId(computedData)
 
         val data = computedData
-        if (data.type == KeyType.CHARACTER && data.code != KeyCode.SPACE && data.code != KeyCode.CJK_SPACE
+        if (data.type == KeyType.NUMERIC && evaluator.keyboard().mode == KeyboardMode.PHONE) {
+            hintedLabel = when (data.code) {
+                48 /* 0 */ -> "+"
+                49 /* 1 */ -> ""
+                50 /* 2 */ -> "ABC"
+                51 /* 3 */ -> "DEF"
+                52 /* 4 */ -> "GHI"
+                53 /* 5 */ -> "JKL"
+                54 /* 6 */ -> "MNO"
+                55 /* 7 */ -> "PQRS"
+                56 /* 8 */ -> "TUV"
+                57 /* 9 */ -> "WXYZ"
+                else -> null
+            }
+        } else if (data.type == KeyType.CHARACTER && data.code != KeyCode.SPACE && data.code != KeyCode.CJK_SPACE
             && data.code != KeyCode.HALF_SPACE && data.code != KeyCode.KESHIDA || data.type == KeyType.NUMERIC
         ) {
             val prefs by florisPreferenceModel()

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
@@ -269,7 +269,8 @@ fun TextKeyboardLayout(
                     val c = key.computedData.code
                     val t = key.computedData.type
                     val numeric = keyboard.mode == KeyboardMode.NUMERIC ||
-                            keyboard.mode == KeyboardMode.NUMERIC_ADVANCED && t == KeyType.NUMERIC
+                        keyboard.mode == KeyboardMode.PHONE || keyboard.mode == KeyboardMode.PHONE2 ||
+                        keyboard.mode == KeyboardMode.NUMERIC_ADVANCED && t == KeyType.NUMERIC
                     c > KeyCode.SPACE && c != KeyCode.MULTIPLE_CODE_POINTS && c != KeyCode.CJK_SPACE && !numeric
                 } else {
                     true

--- a/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
+++ b/app/src/main/java/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
@@ -332,6 +333,7 @@ private fun TextKeyButton(
         style = keyStyle,
         clip = true,
     ) {
+        val isTelpadKey = key.computedData.type == KeyType.NUMERIC && renderInfo.keyboard.mode == KeyboardMode.PHONE
         key.label?.let { label ->
             if (key.computedData.code == KeyCode.SPACE) {
                 val prefs by florisPreferenceModel()
@@ -343,7 +345,7 @@ private fun TextKeyButton(
             Text(
                 modifier = Modifier
                     .wrapContentSize()
-                    .align(Alignment.Center),
+                    .align(if (isTelpadKey) BiasAlignment(-0.5f, 0f) else Alignment.Center),
                 text = label,
                 color = keyStyle.foreground.solidColor(),
                 fontSize = fontSize,
@@ -367,7 +369,7 @@ private fun TextKeyButton(
                 modifier = Modifier
                     .padding(end = (key.visibleBounds.width / 12f).toDp())
                     .wrapContentSize()
-                    .align(Alignment.TopEnd)
+                    .align(if (isTelpadKey) BiasAlignment(0.5f, 0f) else Alignment.TopEnd)
                     .snyggBackground(keyHintStyle),
                 text = hintedLabel,
                 color = keyHintStyle.foreground.solidColor(),


### PR DESCRIPTION
This PR aims to improve the telpad input UI. Two simple changes are done:

1. Remove popups from phone layouts, in accordance to the removal from numeric in #1044
2. Add alphabetic characters to phone digits (Fixes #355):
   ![image](https://user-images.githubusercontent.com/19412843/160022317-9cd31c4d-beaa-43be-b6f1-ddfe20474bb1.png)
