### PR TITLE
Ukrainian popup mappings improvements

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -180,7 +180,11 @@
     },
     {
       "id": "uk",
-      "authors": [ "williamtheaker", "33kk" ]
+      "authors": [ "williamtheaker", "33kk", "honsiorovskyi" ]
+    },
+    {
+      "id": "uk-cyr-ext",
+      "authors": [ "williamtheaker", "33kk", "honsiorovskyi" ]
     },
     {
       "id": "ur-PK",

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk-cyr-ext.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk-cyr-ext.json
@@ -1,31 +1,37 @@
 {
   "all": {
     "е": {
-      "main": { "$": "auto_text_key", "code":  1105, "label": "ё" }
+      "relevant": [
+        { "$": "auto_text_key", "code":  1105, "label": "ё" }
+      ]
     },
     "у": {
-      "main": { "$": "auto_text_key", "code":  1118, "label": "ў" }
+      "relevant": [
+        { "$": "auto_text_key", "code":  1118, "label": "ў" }
+      ]
     },
     "г": {
-      "main": { "$": "auto_text_key", "code":  1169, "label": "ґ" }
+      "relevant": [
+        { "$": "auto_text_key", "code":  1169, "label": "ґ" }
+      ]
     },
     "і": {
-      "main": { "$": "auto_text_key", "code":  1111, "label": "ї" },
       "relevant": [
+        { "$": "auto_text_key", "code":  1111, "label": "ї" },
         { "$": "auto_text_key", "code":  1099, "label": "ы" }
       ]
     },
     "є": {
-      "main": { "$": "auto_text_key", "code":  8212, "label": "—" },
       "relevant": [
+        { "$": "auto_text_key", "code":  8212, "label": "—" },
         { "$": "auto_text_key", "code":  1101, "label": "э" }
       ]
     },
     "ь": {
-      "main": { "$": "auto_text_key", "code":  700, "label": "ʼ" },
       "relevant": [
-        { "$": "auto_text_key", "code":  1098, "label": "ъ" },
-        { "$": "auto_text_key", "code":  39, "label": "'" }
+        { "$": "auto_text_key", "code":  700, "label": "ʼ" },
+        { "$": "auto_text_key", "code":  39, "label": "'" },
+        { "$": "auto_text_key", "code":  1098, "label": "ъ" }
       ]
     },
     "~right": {

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk-cyr-ext.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk-cyr-ext.json
@@ -1,17 +1,30 @@
 {
   "all": {
+    "е": {
+      "main": { "$": "auto_text_key", "code":  1105, "label": "ё" }
+    },
+    "у": {
+      "main": { "$": "auto_text_key", "code":  1118, "label": "ў" }
+    },
     "г": {
       "main": { "$": "auto_text_key", "code":  1169, "label": "ґ" }
     },
     "і": {
-      "main": { "$": "auto_text_key", "code":  1111, "label": "ї" }
+      "main": { "$": "auto_text_key", "code":  1111, "label": "ї" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  1099, "label": "ы" }
+      ]
     },
     "є": {
-      "main": { "$": "auto_text_key", "code":  8212, "label": "—" }
+      "main": { "$": "auto_text_key", "code":  8212, "label": "—" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  1101, "label": "э" }
+      ]
     },
     "ь": {
       "main": { "$": "auto_text_key", "code":  700, "label": "ʼ" },
       "relevant": [
+        { "$": "auto_text_key", "code":  1098, "label": "ъ" },
         { "$": "auto_text_key", "code":  39, "label": "'" }
       ]
     },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk-cyr-ext.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk-cyr-ext.json
@@ -67,10 +67,7 @@
       "relevant": [
         { "code": -255, "label": ".ua" },
         { "code": -255, "label": ".org" },
-        { "code": -255, "label": ".net" },
-        { "code": -255, "label": ".com.ua" },
-        { "code": -255, "label": ".org.ua" },
-        { "code": -255, "label": ".gov.ua" }
+        { "code": -255, "label": ".net" }
       ]
     }
   }

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk.json
@@ -54,10 +54,7 @@
       "relevant": [
         { "code": -255, "label": ".ua" },
         { "code": -255, "label": ".org" },
-        { "code": -255, "label": ".net" },
-        { "code": -255, "label": ".com.ua" },
-        { "code": -255, "label": ".org.ua" },
-        { "code": -255, "label": ".gov.ua" }
+        { "code": -255, "label": ".net" }
       ]
     }
   }

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/uk.json
@@ -1,17 +1,23 @@
 {
   "all": {
     "г": {
-      "main": { "$": "auto_text_key", "code":  1169, "label": "ґ" }
+      "relevant": [
+        { "$": "auto_text_key", "code":  1169, "label": "ґ" }
+      ]
     },
     "і": {
-      "main": { "$": "auto_text_key", "code":  1111, "label": "ї" }
+      "relevant": [
+        { "$": "auto_text_key", "code":  1111, "label": "ї" }
+      ]
     },
     "є": {
-      "main": { "$": "auto_text_key", "code":  8212, "label": "—" }
+      "relevant": [
+        { "$": "auto_text_key", "code":  8212, "label": "—" }
+      ]
     },
     "ь": {
-      "main": { "$": "auto_text_key", "code":  700, "label": "ʼ" },
       "relevant": [
+        { "$": "auto_text_key", "code":  700, "label": "ʼ" },
         { "$": "auto_text_key", "code":  39, "label": "'" }
       ]
     },


### PR DESCRIPTION
Hello!

First of all, thank you for your work on the keyboard, it's awesome!

Now, about the PR itself. This PR somewhat improves the Ukrainian popup mappings making it a bit easier to use, especially for people also using the minority languages in parallel (Crimean Tatar, Russian, Bulgarian, Belorussian etc).

Particularly, I've done two changes:
* added some missing letters and useful symbols to the core Ukrainian layout (`uk.json`)
* created a new extended layout with extra letters for the Cyrillic-based minority languages (`uk-cyr-ext.json`)

Hope it works well, tell me if I need to make some changes.

Good luck with the new versions of the app and thank you again!