### PR TITLE
Fix Armenian layouts duplicate letter

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/eastern_armenian.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/eastern_armenian.json
@@ -7,7 +7,7 @@
     { "$": "auto_text_key", "code": 1386, "label": "ժ" },
     { "$": "auto_text_key", "code": 1401, "label": "չ" },
     { "$": "auto_text_key", "code": 1403, "label": "ջ" },
-    { "$": "auto_text_key", "code": 1380, "label": "դ" },
+    { "$": "auto_text_key", "code": 1411, "label": "փ" },
     { "$": "auto_text_key", "code": 1394, "label": "ղ" },
     { "$": "auto_text_key", "code": 1390, "label": "ծ" }
   ],

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/western_armenian.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/western_armenian.json
@@ -8,7 +8,7 @@
     { "$": "auto_text_key", "code": 1386, "label": "ժ" },
     { "$": "auto_text_key", "code": 1401, "label": "չ" },
     { "$": "auto_text_key", "code": 1403, "label": "ջ" },
-    { "$": "auto_text_key", "code": 1380, "label": "դ" },
+    { "$": "auto_text_key", "code": 1411, "label": "փ" },
     { "$": "auto_text_key", "code": 1394, "label": "ղ" },
     { "$": "auto_text_key", "code": 1390, "label": "ծ" }
   ],


### PR DESCRIPTION
The Eastern and Western Armenian layouts had a duplicate letter դ instead of the letter փ.  This PR fixes that issue.