### PR TITLE
Update persian.json

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/charactersMod/persian.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/charactersMod/persian.json
@@ -13,8 +13,6 @@
     { "code": -227, "label": "language_switch", "type": "system_gui" },
     { "code": -212, "label": "ime_ui_mode_media", "type": "system_gui" },
     { "code":   32, "label": "space" },
-    { "code": 8204, "label": "half_space" },
-    { "code": 1600, "label": "kashida" },
     { "code":   46, "label": ".", "groupId": 2 },
     { "code":   10, "label": "enter", "groupId": 3, "type": "enter_editing" }
   ]


### PR DESCRIPTION
kashida and half_space characters are practically useless in Persian, and due to the large space occupied, when typing the spacebar and half_space buttons quickly, they are often mistakenly touched.