### PR TITLE
Update hu.json

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/hu.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/hu.json
@@ -22,6 +22,11 @@
         { "$": "auto_text_key", "code":  337, "label": "ő" }
       ]
     },
+    "ö": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  337, "label": "ő" }
+      ]
+    },
     "u": {
       "relevant": [
         { "$": "auto_text_key", "code":  250, "label": "ú" },
@@ -29,6 +34,11 @@
         { "$": "auto_text_key", "code":  369, "label": "ű" }
       ]
     },
+    "ü": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  369, "label": "ű" }
+      ]
+    },    
     "~right": {
       "main": { "code":   44, "label": "," },
       "relevant": [
@@ -58,13 +68,13 @@
   },
   "uri": {
     "~right": {
-      "main": { "code": -255, "label": ".com" },
+      "main": { "code": -255, "label": ".hu" },
       "relevant": [
-        { "code": -255, "label": ".gov" },
-        { "code": -255, "label": ".edu" },
-        { "code": -255, "label": ".hu" },
+        { "code": -255, "label": ".com" },
+        { "code": -255, "label": ".net" },
         { "code": -255, "label": ".org" },
-        { "code": -255, "label": ".net" }
+        { "code": -255, "label": ".eu" },
+        { "code": -255, "label": ".gov.hu" }        
       ]
     }
   }


### PR DESCRIPTION
Addition character assignments and changed TLD strings for Hungarian keyboard layouts.

These are important changes because Hungarian users mostly search accented characters where they belong.
For example, the u ú ü ű are similar shapes but u ú and ü ű are the short and long symbol pairs for two different sounds (the same is true for o ó and ö ő).
So the changes are intended to show up as follows:
- assignments for o and u is kept for compatibility with the old style and non-hungarian layouts but with hungarian language (as I use florisboard)
- assignments added for ö and ü to found their long versions (ő and ű) in the right place too (as others use florisboard)

TLD strings are changed because .hu and .eu is widely used in Hungary and .gov.hu is the official ending for government sites.