### PR TITLE
Improve devtools and crash log / Add debug log

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/Routes.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/Routes.kt
@@ -24,6 +24,7 @@ import androidx.navigation.compose.composable
 import dev.patrickgold.florisboard.app.devtools.AndroidLocalesScreen
 import dev.patrickgold.florisboard.app.devtools.AndroidSettingsScreen
 import dev.patrickgold.florisboard.app.devtools.DevtoolsScreen
+import dev.patrickgold.florisboard.app.devtools.ExportDebugLogScreen
 import dev.patrickgold.florisboard.app.ext.ExtensionEditScreen
 import dev.patrickgold.florisboard.app.ext.ExtensionExportScreen
 import dev.patrickgold.florisboard.app.ext.ExtensionImportScreen
@@ -121,6 +122,8 @@ object Routes {
         const val AndroidLocales = "devtools/android/locales"
         const val AndroidSettings = "devtools/android/settings/{name}"
         fun AndroidSettings(name: String) = AndroidSettings.curlyFormat("name" to name)
+
+        const val ExportDebugLog = "export-debug-log"
     }
 
     object Ext {
@@ -215,6 +218,7 @@ object Routes {
                 val name = navBackStack.arguments?.getString("name")
                 AndroidSettingsScreen(name)
             }
+            composable(Devtools.ExportDebugLog) { ExportDebugLogScreen() }
 
             composable(Ext.Edit) { navBackStack ->
                 val extensionId = navBackStack.arguments?.getString("id")

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/DevtoolsScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/DevtoolsScreen.kt
@@ -115,6 +115,12 @@ fun DevtoolsScreen() = FlorisScreen {
                 onClick = { throw DebugOnPurposeCrashException() },
                 enabledIf = { prefs.devtools.enabled isEqualTo true },
             )
+            Preference(
+                title = "Debug log",
+                summary = "View and export the debug log",
+                onClick = { navController.navigate(Routes.Devtools.ExportDebugLog) },
+                enabledIf = { prefs.devtools.enabled isEqualTo true },
+            )
         }
 
         PreferenceGroup(title = stringRes(R.string.devtools__group_android__title)) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/ExportDebugLogScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/ExportDebugLogScreen.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.app.devtools
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.sp
+import dev.patrickgold.florisboard.app.florisPreferenceModel
+import dev.patrickgold.florisboard.clipboardManager
+import dev.patrickgold.florisboard.lib.android.showShortToast
+import dev.patrickgold.florisboard.lib.compose.FlorisButton
+import dev.patrickgold.florisboard.lib.compose.FlorisScreen
+import dev.patrickgold.florisboard.lib.compose.florisHorizontalScroll
+import dev.patrickgold.florisboard.lib.compose.florisScrollbar
+import dev.patrickgold.florisboard.lib.devtools.Devtools
+
+// TODO: This screen is just a quick thrown-together thing and needs further enhancing in the UI and in localization
+@Composable
+fun ExportDebugLogScreen() = FlorisScreen {
+    title = "Debug log"
+    scrollable = false
+
+    val prefs by florisPreferenceModel()
+    val context = LocalContext.current
+    val clipboardManager by context.clipboardManager()
+
+    var debugLog by remember { mutableStateOf<List<String>?>(null) }
+
+    LaunchedEffect(Unit) {
+        debugLog = Devtools.generateDebugLog(context, prefs, includeLogcat = true).lines()
+    }
+
+    bottomBar {
+        FlorisButton(
+            onClick = {
+                clipboardManager.addNewPlaintext(debugLog!!.joinToString("\n"))
+                context.showShortToast("Copied debug log to clipboard")
+            },
+            modifier = Modifier.fillMaxWidth(),
+            text = "Export (copy to clipboard)",
+            enabled = debugLog != null,
+        )
+    }
+
+    content {
+        // Forcing LTR because text displayed is a debug log
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            val lazyListState = rememberLazyListState()
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .florisScrollbar(lazyListState, isVertical = true)
+                    .florisHorizontalScroll(),
+                state = lazyListState,
+            ) {
+                val log = debugLog
+                if (log == null) {
+                    item {
+                        Text("Loading...")
+                    }
+                } else {
+                    items(log) { logLine ->
+                        Text(
+                            text = logLine,
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 10.sp,
+                            softWrap = false,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -58,6 +58,8 @@ import dev.patrickgold.florisboard.lib.android.showShortToast
 import dev.patrickgold.florisboard.lib.devtools.LogTopic
 import dev.patrickgold.florisboard.lib.devtools.flogError
 import dev.patrickgold.florisboard.lib.ext.ExtensionComponentName
+import dev.patrickgold.florisboard.lib.kotlin.titlecase
+import dev.patrickgold.florisboard.lib.kotlin.uppercase
 import dev.patrickgold.florisboard.lib.observeAsNonNullState
 import dev.patrickgold.florisboard.lib.util.InputMethodUtils
 import dev.patrickgold.florisboard.nlpManager
@@ -319,16 +321,10 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
     fun fixCase(word: String): String {
         return when(activeState.inputShiftState) {
             InputShiftState.CAPS_LOCK -> {
-                word.uppercase(subtypeManager.activeSubtype().primaryLocale.base)
+                word.uppercase(subtypeManager.activeSubtype().primaryLocale)
             }
             InputShiftState.SHIFTED_MANUAL, InputShiftState.SHIFTED_AUTOMATIC -> {
-                word.replaceFirstChar {
-                    if (it.isLowerCase()) {
-                        it.titlecase(subtypeManager.activeSubtype().primaryLocale.base)
-                    } else {
-                        it.toString()
-                    }
-                }
+                word.titlecase(subtypeManager.activeSubtype().primaryLocale)
             }
             else -> word
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/FlorisLocale.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/FlorisLocale.kt
@@ -16,6 +16,7 @@
 
 package dev.patrickgold.florisboard.lib
 
+import dev.patrickgold.florisboard.lib.kotlin.titlecase
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -226,9 +227,7 @@ class FlorisLocale private constructor(val base: Locale) {
      * @see java.util.Locale.getDisplayLanguage
      */
     fun displayLanguage(locale: FlorisLocale = default()): String {
-        return base.getDisplayLanguage(locale.base).replaceFirstChar {
-            if (it.isLowerCase()) it.titlecase(locale.base) else it.toString()
-        }
+        return base.getDisplayLanguage(locale.base).titlecase(locale)
     }
 
     /**

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2022 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.lib.devtools
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import android.os.Debug
+import dev.patrickgold.florisboard.BuildConfig
+import dev.patrickgold.florisboard.R
+import dev.patrickgold.florisboard.app.AppPrefs
+import dev.patrickgold.florisboard.lib.android.systemService
+import dev.patrickgold.florisboard.lib.kotlin.titlecase
+import dev.patrickgold.florisboard.lib.util.TimeUtils
+import dev.patrickgold.florisboard.lib.util.UnitUtils
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+
+@Suppress("MemberVisibilityCanBePrivate")
+object Devtools {
+    fun generateDebugLog(context: Context, prefs: AppPrefs? = null, includeLogcat: Boolean = false): String {
+        return buildString {
+            append(generateSystemInfoLog(context))
+            appendLine()
+            append(generateAppInfoLog(context))
+            if (prefs != null) {
+                appendLine()
+                append(generateFeatureConfigLog(prefs))
+            }
+            if (includeLogcat) {
+                appendLine()
+                append(generateLogcatDump())
+            }
+        }
+    }
+
+    fun generateSystemInfoLog(context: Context, withTitle: Boolean = true): String {
+        return buildString {
+            if (withTitle) appendLine("======= SYSTEM INFO =======")
+            append("Time                : ").appendLine(TimeUtils.currentUtcTimestamp())
+            append("Manufacturer        : ").appendLine(Build.MANUFACTURER)
+            append("Model               : ").appendLine(Build.MODEL)
+            append("Product             : ").appendLine(Build.PRODUCT)
+            append("Android             : ").appendLine(getAndroidVersion(includeOemBuildId = true))
+            append("ABIs                : ").appendLine(Build.SUPPORTED_ABIS.contentToString())
+            append("Memory              : ").appendLine(getSystemMemoryUsage(context))
+            append("Font scale          : ").appendLine(context.resources.configuration.fontScale)
+            append("Locales             : ").appendLine(context.resources.configuration.locales.toLanguageTags())
+        }
+    }
+
+    fun generateAppInfoLog(context: Context, withTitle: Boolean = true): String {
+        return buildString {
+            if (withTitle) appendLine("======= APP INFO =======")
+            append("Package             : ").appendLine(BuildConfig.APPLICATION_ID)
+            append("Name                : ").appendLine(context.resources.getString(R.string.floris_app_name))
+            append("Version             : ").appendLine("${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+            append("Build type          : ").appendLine(BuildConfig.BUILD_TYPE)
+            append("Build commit hash   : ").appendLine(BuildConfig.BUILD_COMMIT_HASH)
+            append("Java heap memory    : ").appendLine(getAppJavaHeapMemoryUsage())
+            append("Native heap memory  : ").appendLine(getAppNativeHeapMemoryUsage())
+        }
+    }
+
+    fun generateFeatureConfigLog(prefs: AppPrefs, withTitle: Boolean = true): String {
+        return buildString {
+            if (withTitle) appendLine("======= FEATURE CONFIG =======")
+            append("Smartbar enabled            : ").appendLine(prefs.smartbar.enabled.get())
+            append("Suggestions enabled         : ").appendLine(prefs.suggestion.enabled.get())
+            append("Inline autofill enabled     : ").appendLine(prefs.suggestion.api30InlineSuggestionsEnabled.get())
+            append("Glide enabled               : ").appendLine(prefs.glide.enabled.get())
+            append("Internal clipboard enabled  : ").appendLine(prefs.clipboard.useInternalClipboard.get())
+        }
+    }
+
+    fun generateLogcatDump(withTitle: Boolean = true): String {
+        return buildString {
+            if (withTitle) appendLine("======= LOGCAT =======")
+            try {
+                val process = Runtime.getRuntime().exec("logcat -d")
+                val bufferedReader = BufferedReader(InputStreamReader(process.inputStream))
+                var line: String?
+                while (bufferedReader.readLine().also { line = it } != null) {
+                    appendLine(line)
+                }
+            } catch (_: IOException) {
+                appendLine("Failed to retrieve.")
+            }
+        }
+    }
+
+    fun getDeviceName(): String {
+        val manufacturer = Build.MANUFACTURER
+        val model = Build.MODEL
+        val product = Build.PRODUCT
+        return buildString {
+            if (model.startsWith(manufacturer, ignoreCase = true)) {
+                append(model.titlecase())
+            } else {
+                append(manufacturer.titlecase())
+                append(" ")
+                append(model.titlecase())
+            }
+            if (product.isNotBlank()) {
+                append(" (")
+                append(product)
+                append(")")
+            }
+        }
+    }
+
+    fun getAndroidVersion(includeOemBuildId: Boolean = false): String {
+        val fields = Build.VERSION_CODES::class.java.fields
+        val codeName = fields.firstOrNull { it.getInt(Build.VERSION_CODES::class) == Build.VERSION.SDK_INT }?.name
+            ?: return "Unknown"
+        return buildString {
+            append(Build.VERSION.RELEASE)
+            append(" (cn=")
+            append(codeName)
+            append(" sdk=")
+            append(Build.VERSION.SDK_INT)
+            append(")")
+            if (includeOemBuildId) {
+                append(" [")
+                append(Build.DISPLAY)
+                append("]")
+            }
+        }
+    }
+
+    fun getSystemMemoryUsage(context: Context): String {
+        return buildString {
+            try {
+                //  Source: https://stackoverflow.com/a/19267315/6801193
+                val memoryInfo = ActivityManager.MemoryInfo()
+                context.systemService(ActivityManager::class).getMemoryInfo(memoryInfo)
+                val nativeHeapSize = memoryInfo.totalMem
+                val nativeHeapFreeSize = memoryInfo.availMem
+                val usedMemInBytes = nativeHeapSize - nativeHeapFreeSize
+                val usedMemInPercentage = usedMemInBytes * 100f / nativeHeapSize
+                append(UnitUtils.formatMemorySize(usedMemInBytes))
+                append(" (")
+                append(String.format("%.2f", usedMemInPercentage))
+                append("% used, ")
+                append(UnitUtils.formatMemorySize(nativeHeapSize))
+                append(" max)")
+            } catch (e: Exception) {
+                append("Failed to retrieve memory usage: ")
+                append(e.message)
+            }
+        }
+    }
+
+    fun getAppJavaHeapMemoryUsage(): String {
+        return buildString {
+            try {
+                //  Source: https://stackoverflow.com/a/19267315/6801193
+                val runtime = Runtime.getRuntime()
+                val javaHeapSize = runtime.maxMemory()
+                val usedMemInBytes = runtime.totalMemory() - runtime.freeMemory()
+                val usedMemInPercentage = usedMemInBytes * 100f / javaHeapSize
+                append(UnitUtils.formatMemorySize(usedMemInBytes))
+                append(" (")
+                append(String.format("%.2f", usedMemInPercentage))
+                append("% used, ")
+                append(UnitUtils.formatMemorySize(javaHeapSize))
+                append(" max)")
+            } catch (e: Exception) {
+                append("Failed to retrieve memory usage: ")
+                append(e.message)
+            }
+        }
+    }
+
+    fun getAppNativeHeapMemoryUsage(): String {
+        return buildString {
+            try {
+                //  Source: https://stackoverflow.com/a/19267315/6801193
+                val nativeHeapSize = Debug.getNativeHeapSize()
+                val nativeHeapFreeSize = Debug.getNativeHeapFreeSize()
+                val usedMemInBytes = nativeHeapSize - nativeHeapFreeSize
+                val usedMemInPercentage = usedMemInBytes * 100f / nativeHeapSize
+                append(UnitUtils.formatMemorySize(usedMemInBytes))
+                append(" (")
+                append(String.format("%.2f", usedMemInPercentage))
+                append("% used, ")
+                append(UnitUtils.formatMemorySize(nativeHeapSize))
+                append(" max)")
+            } catch (e: Exception) {
+                append("Failed to retrieve memory usage: ")
+                append(e.message)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Flog.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Flog.kt
@@ -153,35 +153,6 @@ inline fun flogDebug(topic: FlogTopic = Flog.TOPIC_OTHER, block: () -> String = 
 }
 
 /**
- * Logs a wtf message returned by [block] together with the automatically retrieved
- * calling class and method name either to the console or to a log file. The class name
- * is used for the tag, the method name prepended to the message.
- *
- * This method automatically evaluates if logging is enabled and calls [block] only
- * if a log message should be generated.
- *
- * Optionally a [topic] can also be specified to allow to only partially enable
- * debug messages across the codebase. The passed [topic] is compared with the
- * currently active [Flog.flogTopics] variable and only if at least 1 topic match
- * is found, [block] will be called and a log message written.
- *
- * @param topic The topic of this message. To specify multiple topics, use the binary
- *  OR operator. Defaults to [Flog.TOPIC_OTHER].
- * @param block The lambda expression to evaluate the message which is appended to the
- *  method name. Is called only if logging is enabled and the topics match. Must return
- *  a [String]. If this argument is omitted, only the calling method name will be used
- *  as the log message.
- */
-inline fun flogWtf(topic: FlogTopic = Flog.TOPIC_OTHER, block: () -> String = { "" }) {
-    contract {
-        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
-    }
-    if (Flog.checkShouldFlog(topic, Flog.LEVEL_WTF)) {
-        log(Flog.LEVEL_WTF, block())
-    }
-}
-
-/**
  * Helper function to evaluate if a bit flag is set in an integer value.
  *
  * @param flag The flag to check if it is set.
@@ -218,7 +189,6 @@ object Flog {
     const val LEVEL_WARNING: FlogLevel =            0x02u
     const val LEVEL_INFO: FlogLevel =               0x04u
     const val LEVEL_DEBUG: FlogLevel =              0x08u
-    const val LEVEL_WTF: FlogLevel =                0x10u
     const val LEVEL_ALL: FlogLevel =                UInt.MAX_VALUE
 
     const val OUTPUT_CONSOLE: FlogOutput =          0x01u
@@ -348,7 +318,6 @@ object Flog {
             level isSet LEVEL_WARNING ->    Log.w(tag, message)
             level isSet LEVEL_INFO ->       Log.i(tag, message)
             level isSet LEVEL_DEBUG ->      Log.d(tag, message)
-            level isSet LEVEL_WTF ->        Log.wtf(tag, message)
         }
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/kotlin/Strings.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/kotlin/Strings.kt
@@ -26,6 +26,10 @@ inline fun String.lowercase(locale: FlorisLocale): String = this.lowercase(local
 
 inline fun String.uppercase(locale: FlorisLocale): String = this.uppercase(locale.base)
 
+inline fun String.titlecase(locale: FlorisLocale = FlorisLocale.ROOT): String {
+    return this.replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale.base) else it.toString() }
+}
+
 fun String.safeSubstring(startIndex: Int): String {
     return try {
         this.substring(startIndex)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/util/TimeUtils.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/util/TimeUtils.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.lib.util
+
+import android.icu.text.SimpleDateFormat
+import android.icu.util.Calendar
+import android.icu.util.TimeZone
+import dev.patrickgold.florisboard.lib.FlorisLocale
+import dev.patrickgold.florisboard.lib.android.AndroidVersion
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+object TimeUtils {
+    private val ISO_INSTANT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", FlorisLocale.ENGLISH.base)
+
+    fun currentUtcTimestamp(): CharSequence {
+        return if (AndroidVersion.ATLEAST_API26_O) {
+            DateTimeFormatter.ISO_INSTANT.format(Instant.now())
+        } else {
+            ISO_INSTANT.format(Calendar.getInstance(TimeZone.GMT_ZONE, FlorisLocale.ENGLISH.base))
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/util/UnitUtils.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/util/UnitUtils.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.lib.util
+
+object UnitUtils {
+    private const val KiB = (1024).toFloat()
+    private const val MiB = (1024 * 1024).toFloat()
+    private const val GiB = (1024 * 1024 * 1024).toFloat()
+
+    fun formatMemorySize(sizeBytes: Long): String {
+        return when {
+            sizeBytes >= GiB -> String.format("%.2f GiB", sizeBytes / GiB)
+            sizeBytes >= MiB -> String.format("%.2f MiB", sizeBytes / MiB)
+            sizeBytes >= KiB -> String.format("%.2f KiB", sizeBytes / KiB)
+            else -> String.format("%d bytes")
+        }
+    }
+}

--- a/app/src/main/res/values/strings_dont_translate.xml
+++ b/app/src/main/res/values/strings_dont_translate.xml
@@ -3,6 +3,7 @@
     <string name="florisboard__issue_tracker_url" translatable="false">https://github.com/florisboard/florisboard/issues</string>
     <string name="florisboard__privacy_policy_url" translatable="false">https://gist.github.com/patrickgold/a18f1e47468d72f0868afc69d6faaf0b</string>
     <string name="florisboard__changelog_url" translatable="false">https://github.com/florisboard/florisboard/releases/v{version}</string>
+    <string name="florisboard__commit_by_hash_url" translatable="false">https://github.com/florisboard/florisboard/commit/{hash}</string>
     <string name="florisboard__spell_checker_wiki_url" translatable="false">https://github.com/florisboard/florisboard/wiki/System-spell-checker-service</string>
     <string name="florisboard__theme_editor_wiki_url" translatable="false">https://github.com/florisboard/florisboard/wiki/Using-the-new-Theme-Editor</string>
     <string name="florisboard__internal_key_codes_url" translatable="false">https://github.com/florisboard/florisboard/blob/master/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt</string>


### PR DESCRIPTION
This PR adds a debug log feature, which allows to export (copy to clipboard) the full debug log (header + Logcat) via the devtools. The main motivation behind this change is to be able to have more detailed logs available in case something goes wrong and to improve the bug finding workflow by having more details in the crash section.

### Changes to the version name for debug builds

To be able to better identify debug versions and with that commit they were built, the version name suffix for this track now looks like this: `-debug-abcd123`, where `abcd123` is the short git hash of the build commit (first 7 chars by default). In the debug and crash log the full commit hash is included for exact identification.

### Crash log generation

The crash log generation has changed a bit, to include a bit more details (in the detailed info tag). This allows me to identify issues more quickly by knowing which ABI they are on, what locales are selected as the system defaults, etc. Also the version name is now automatically a link and either links to the release changelog of that version or to the build commit for debug builds. An example crash log can be seen below:

---

#### Environment information
- FlorisBoard [0.3.16-debug-f83d40d1](https://github.com/florisboard/florisboard/commit/f83d40d1377cad283496fe0fef796d7c25cefb86) (83)
- Device: OnePlus HD1903 (OnePlus7T_EEA)
- Android: 11 (cn=R sdk=30)

#### Attached logs and stacktrace files
<details>
<summary>Detailed info (Debug log header)</summary>

```
======= SYSTEM INFO =======
Time                : 2022-05-24T23:16:58.957Z
Manufacturer        : OnePlus
Model               : HD1903
Product             : OnePlus7T_EEA
Android             : 11 (cn=R sdk=30) [HD1903_14_220406]
ABIs                : [arm64-v8a, armeabi-v7a, armeabi]
Memory              : 3.15 GiB (43.16% used, 7.30 GiB max)
Font scale          : 1.0
Locales             : en-US,de-AT,fr-FR

======= APP INFO =======
Package             : dev.patrickgold.florisboard.debug
Name                : FlorisBoard Debug
Version             : 0.3.16-debug-f83d40d1 (83)
Build type          : debug
Build commit hash   : f83d40d1377cad283496fe0fef796d7c25cefb86
Java heap memory    : 10.05 MiB (1.96% used, 512.00 MiB max)
Native heap memory  : 22.63 MiB (87.00% used, 26.01 MiB max)

======= FEATURE CONFIG =======
Smartbar enabled            : true
Suggestions enabled         : false
Inline autofill enabled     : true
Glide enabled               : false
Internal clipboard enabled  : false

```
</details>

<details>
<summary>1653434216494.stacktrace</summary>

```
dev.patrickgold.florisboard.app.devtools.DebugOnPurposeCrashException: Success! The app crashed purposely to display this beautiful screen we all love :)
	at dev.patrickgold.florisboard.app.devtools.ComposableSingletons$DevtoolsScreenKt$lambda-2$1$2$1$11.invoke(DevtoolsScreen.kt:115)
	at dev.patrickgold.florisboard.app.devtools.ComposableSingletons$DevtoolsScreenKt$lambda-2$1$2$1$11.invoke(DevtoolsScreen.kt:112)
	at androidx.compose.foundation.ClickableKt$clickable$4$gesture$1$2.invoke-k-4lQ0M(Clickable.kt:153)
	at androidx.compose.foundation.ClickableKt$clickable$4$gesture$1$2.invoke(Clickable.kt:142)
	at androidx.compose.foundation.gestures.TapGestureDetectorKt$detectTapAndPress$2$1$1.invokeSuspend(TapGestureDetector.kt:223)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:178)
	at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:166)
	at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:397)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:431)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default(CancellableContinuationImpl.kt:420)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeWith(CancellableContinuationImpl.kt:328)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputFilter$PointerEventHandlerCoroutine.offerPointerEvent(SuspendingPointerInputFilter.kt:511)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputFilter.dispatchPointerEvent(SuspendingPointerInputFilter.kt:406)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputFilter.onPointerEvent-H0pRuoY(SuspendingPointerInputFilter.kt:419)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:310)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:297)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:297)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:297)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:297)
	at androidx.compose.ui.input.pointer.NodeParent.dispatchMainEventPass(HitPathTracker.kt:179)
	at androidx.compose.ui.input.pointer.HitPathTracker.dispatchChanges(HitPathTracker.kt:98)
	at androidx.compose.ui.input.pointer.PointerInputEventProcessor.process-BIzXfog(PointerInputEventProcessor.kt:80)
	at androidx.compose.ui.platform.AndroidComposeView.sendMotionEvent-8iAsVTc(AndroidComposeView.android.kt:1159)
	at androidx.compose.ui.platform.AndroidComposeView.handleMotionEvent-8iAsVTc(AndroidComposeView.android.kt:1109)
	at androidx.compose.ui.platform.AndroidComposeView.dispatchTouchEvent(AndroidComposeView.android.kt:1059)
	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3143)
	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2814)
	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3143)
	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2814)
	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3143)
	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2814)
	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3143)
	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2814)
	at com.android.internal.policy.DecorView.superDispatchTouchEvent(DecorView.java:517)
	at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent(PhoneWindow.java:1894)
	at android.app.Activity.dispatchTouchEvent(Activity.java:4131)
	at com.android.internal.policy.DecorView.dispatchTouchEvent(DecorView.java:475)
	at android.view.View.dispatchPointerEvent(View.java:14648)
	at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent(ViewRootImpl.java:6498)
	at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:6269)
	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5735)
	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5792)
	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5758)
	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:5910)
	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5766)
	at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:5967)
	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5739)
	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5792)
	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:5758)
	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:5766)
	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:5739)
	at android.view.ViewRootImpl.deliverInputEvent(ViewRootImpl.java:8639)
	at android.view.ViewRootImpl.doProcessInputEvents(ViewRootImpl.java:8590)
	at android.view.ViewRootImpl.enqueueInputEvent(ViewRootImpl.java:8488)
	at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent(ViewRootImpl.java:8762)
	at android.view.InputEventReceiver.dispatchInputEvent(InputEventReceiver.java:221)
	at android.os.MessageQueue.nativePollOnce(Native Method)
	at android.os.MessageQueue.next(MessageQueue.java:335)
	at android.os.Looper.loop(Looper.java:183)
	at android.app.ActivityThread.main(ActivityThread.java:8010)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:631)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:978)
	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [androidx.compose.runtime.BroadcastFrameClock@aa545a8, StandaloneCoroutine{Cancelling}@b8808c1, AndroidUiDispatcher@1dcb866]

```
</details>


---

@Glitchy-Tozier and @tsiflimagas Something I wasn't sure is if I should display the detailed info as a collapsible section (like above) or directly in the text flow, like it is currently with the "Features enabled" section. What do you both think?