### PR TITLE
Fix composer not allowing multiple code points

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
@@ -339,7 +339,7 @@ abstract class AbstractEditorInstance(context: Context) {
         val ic = currentInputConnection() ?: return false
         val composer = determineComposer(subtypeManager.activeSubtype.composer)
         val previous = content.textBeforeSelection.takeLast(composer.toRead.coerceAtLeast(if (deletePreviousSpace) 1 else 0))
-        val (tempRm, tempText) = composer.getActions(previous, char[0])
+        val (tempRm, tempText) = composer.getActions(previous, char)
         val rm = if (deletePreviousSpace && previous.isNotEmpty() && previous.last() == ' ') tempRm + 1 else tempRm
         val finalText = buildString(tempText.length + 2) {
             if (insertSpaceBeforeChar) append(' ')

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -130,7 +130,7 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
     }
 
     override fun determineComposer(composerName: ExtensionComponentName): Composer {
-        return keyboardManager.resources.composers.value?.get(composerName) ?: Appender.DefaultInstance
+        return keyboardManager.resources.composers.value?.get(composerName) ?: Appender
     }
 
     override fun shouldDetermineComposingRegion(editorInfo: FlorisEditorInfo): Boolean {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/composing/KanaUnicode.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/composing/KanaUnicode.kt
@@ -317,30 +317,31 @@ class KanaUnicode : Composer {
             rev.getOrElse(l) { base[char] }
         }
         return if (trans != null) {
-            Pair(1, ""+trans)
+            1 to trans.toString()
         } else if (isComposingCharacter(l) && isComposingCharacter(c)) {
-            Pair(1, if (l == c && !sticky) { "" } else { ""+c  })
+            1 to if (l == c && !sticky) { "" } else { ""+c  }
         } else {
-            Pair(0, if (addOnFalse) { ""+c } else { "" })
+            0 to if (addOnFalse) { ""+c } else { "" }
         }
     }
 
-    override fun getActions(s: String, c: Char): Pair<Int, String> {
-        // s is "at least the last 1 character of what's currently here"
-        if (s.isEmpty()) {
+    override fun getActions(precedingText: String, toInsert: String): Pair<Int, String> {
+        val c = toInsert.firstOrNull() ?: return 0 to toInsert
+        // precedingText is "at least the last 1 character of what's currently here"
+        if (precedingText.isEmpty()) {
             return if (c == smallSentinel || isComposingCharacter(c)) {
-                Pair(0, "")
+                0 to ""
             } else {
-                Pair(0, ""+c)
+                0 to toInsert
             }
         }
-        val lastChar = s.last()
+        val lastChar = precedingText.last()
 
         return when {
             isDakuten(c) -> handleTransform(lastChar, c, daku, reverseDaku, true)
             isHandakuten(c) -> handleTransform(lastChar, c, handaku, reverseHandaku, true)
             c == smallSentinel -> handleTransform(lastChar, c, small, reverseSmall, false)
-            else -> Pair(0, ""+c)
+            else -> 0 to toInsert
         }
     }
 }


### PR DESCRIPTION
The current composer implementation does not allow for characters with multiple code points to be inserted. This issue has been detected due to tests with the `MultiTextKey` in #1984.

This PR reworks this and now in general multiple code points are supported (especially for the default `Appender` composer), however some specific composers may internally still use single Java char notation.