### PR TITLE
Add new Korean layout

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -223,6 +223,12 @@
         "direction": "ltr"
       },
       {
+        "id": "korean2",
+        "label": "South Korean (단모음+)",
+        "authors": [ "agw76638" ],
+        "direction": "ltr"
+      },
+      {
         "id": "kurdish",
         "label": "کوردی (قوەرتی نوێ)",
         "authors": [ "GoRaN" ],

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/korean2.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/korean2.json
@@ -1,0 +1,63 @@
+[
+    [
+      { "$": "case_selector",
+        "lower": { "code": 12610, "label": "ㅂ" },
+        "upper": { "code": 12611, "label": "ㅃ" }
+      },
+      { "$": "case_selector",
+        "lower": { "code": 12616, "label": "ㅈ" },
+        "upper": { "code": 12617, "label": "ㅉ" }
+      },
+      { "$": "case_selector",
+        "lower": { "code": 12599, "label": "ㄷ" },
+        "upper": { "code": 12600, "label": "ㄸ" }
+      },
+      { "$": "case_selector",
+        "lower": { "code": 12593, "label": "ㄱ" },
+        "upper": { "code": 12594, "label": "ㄲ" }
+      },
+      { "$": "case_selector",
+        "lower": { "code": 12613, "label": "ㅅ" },
+        "upper": { "code": 12614, "label": "ㅆ" }
+      },
+      { "$": "case_selector",
+        "lower": { "code": 12631, "label": "ㅗ" },
+        "upper": { "code": 12635, "label": "ㅛ" }
+      },
+      { "$": "case_selector",
+        "lower": { "code": 12624, "label": "ㅐ" },
+        "upper": { "code": 12626, "label": "ㅒ" }
+      },
+      { "$": "case_selector",
+        "lower": { "code": 12628, "label": "ㅔ" },
+        "upper": { "code": 12630, "label": "ㅖ" }
+      }
+    ],
+    [
+      { "$": "auto_text_key", "code": 12609, "label": "ㅁ"},
+      { "$": "auto_text_key", "code": 12596, "label": "ㄴ"},
+      { "$": "auto_text_key", "code": 12615, "label": "ㅇ"},
+      { "$": "auto_text_key", "code": 12601, "label": "ㄹ"},
+      { "$": "auto_text_key", "code": 12622, "label": "ㅎ"},
+      { "$": "case_selector",
+        "lower": { "code": 12627, "label": "ㅓ" },
+        "upper": { "code": 12629, "label": "ㅕ" }
+      },
+      { "$": "case_selector",
+        "lower": { "code": 12623, "label": "ㅏ" },
+        "upper": { "code": 12625, "label": "ㅑ" }
+      },
+      { "$": "auto_text_key", "code": 12643, "label": "ㅣ"}
+    ],
+    [
+      { "$": "auto_text_key", "code": 12619, "label": "ㅋ"},
+      { "$": "auto_text_key", "code": 12620, "label": "ㅌ"},
+      { "$": "auto_text_key", "code": 12618, "label": "ㅊ"},
+      { "$": "auto_text_key", "code": 12621, "label": "ㅍ"},
+      { "$": "case_selector",
+        "lower": { "code": 12636, "label": "ㅜ" },
+        "upper": { "code": 12640, "label": "ㅠ" }
+      },
+      { "$": "auto_text_key", "code": 12641, "label": "ㅡ"}
+    ]
+  ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -53,6 +53,7 @@
     { "id": "iw", "authors": [ "Antony" ] },
     { "id": "ja-JP-jis", "authors": [ "waelwindows" ] },
     { "id": "ko", "authors": [ "patrickgold", "Hayleia" ] },
+    { "id": "ko2", "authors": [ "agw76638" ] },
     { "id": "ku", "authors": [ "GoRaN" ] },
     { "id": "lt", "authors": [ "patrickgold" ] },
     { "id": "lv", "authors": [ "patrickgold", "eandersons" ] },
@@ -578,6 +579,15 @@
       "popupMapping": "org.florisboard.localization:ko",
       "preferred": {
         "characters": "org.florisboard.layouts:korean"
+      }
+    },
+    {
+      "languageTag": "ko",
+      "composer": "org.florisboard.composers:hangul-unicode",
+      "currencySet": "org.florisboard.currencysets:south_korean_won",
+      "popupMapping": "org.florisboard.localization:ko2",
+      "preferred": {
+        "characters": "org.florisboard.layouts:korean2"
       }
     },
     {

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ko2.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ko2.json
@@ -1,0 +1,97 @@
+{
+    "all": {
+      "ㅂ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12611, "label": "ㅃ" }
+        ]
+      },
+      "ㅈ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12617, "label": "ㅉ" }
+        ]
+      },
+      "ㄷ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12600, "label": "ㄸ" }
+        ]
+      },
+      "ㄱ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12594, "label": "ㄲ" }
+        ]
+      },
+      "ㅅ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12614, "label": "ㅆ" }
+        ]
+      },
+      "ㅗ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12635, "label": "ㅛ" }
+        ]
+      },
+      "ㅐ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12626, "label": "ㅒ" }
+        ]
+      },
+      "ㅔ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12630, "label": "ㅖ" }
+        ]
+      },
+      "ㅓ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12629, "label": "ㅕ" }
+        ]
+      },
+      "ㅏ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12625, "label": "ㅑ" }
+        ]
+      },
+      "ㅜ": {
+        "relevant": [
+          { "$": "auto_text_key", "code": 12640, "label": "ㅠ" }
+        ]
+      },
+      "~right": {
+        "main": { "code":   44, "label": "," },
+        "relevant": [
+          { "code":   38, "label": "&" },
+          { "code":   37, "label": "%" },
+          { "code":   43, "label": "+" },
+          { "code":   34, "label": "\"" },
+          { "code":   45, "label": "-" },
+          { "code":   58, "label": ":" },
+          { "code":   39, "label": "'" },
+          { "code":   64, "label": "@" },
+          { "code":   59, "label": ";" },
+          { "code":   47, "label": "/" },
+          { "$": "layout_direction_selector",
+            "ltr": { "code":   40, "label": "(" },
+            "rtl": { "code":   41, "label": "(" }
+          },
+          { "$": "layout_direction_selector",
+            "ltr": { "code":   41, "label": ")" },
+            "rtl": { "code":   40, "label": ")" }
+          },
+          { "code":   35, "label": "#" },
+          { "code":   33, "label": "!" },
+          { "code":   63, "label": "?" }
+        ]
+      }
+    },
+    "uri": {
+      "~right": {
+        "main": { "code": -255, "label": ".com" },
+        "relevant": [
+          { "code": -255, "label": ".gov" },
+          { "code": -255, "label": ".edu" },
+          { "code": -255, "label": ".org" },
+          { "code": -255, "label": ".net" }
+        ]
+      }
+    }
+  }
+  


### PR DESCRIPTION
A layout based on Naver Smartboard "단모음+". And a layout I prefer.



<img width="112" alt="layout" src="https://user-images.githubusercontent.com/42842700/194033885-c637b90e-dfbe-4fbb-8b5c-c77cbb819823.png">
Should look like the image.