### PR TITLE
Fixes to Chinese shape-based layout: mixed language support

### DIFF
--- a/LANGUAGEPACKS-CHINESE.md
+++ b/LANGUAGEPACKS-CHINESE.md
@@ -1,0 +1,143 @@
+# Chinese language pack
+
+[简体中文翻译点这里](#简体中文翻译)
+
+[繁体中文翻譯點這裡](#繁体中文翻譯)
+
+
+## Default barebones Chinese shape-based pack
+
+Default barebones Chinese shape-based language pack which are always available.
+
+Please download the [full Chinese language pack](#full-chinese-shape-based-pack) to access input methods such as wubi, quick cangjie, and other versions of these input methods.
+
+This pack is released under the same license as Florisboard.
+
+
+## Full Chinese shape-based pack
+
+Chinese shape-based language pack based on fcitx5-table-extra.
+
+This pack is released under a separate license. Please visit to download: [TODO: add link to release page](https://)
+
+:no_entry: :no_entry: **WARNING** :no_entry: :no_entry:
+
+- **Input methods that include pinyin, jyutping, zhuyin as (auxiliary) functions are only provided for convenience. Currently, FlorisBoard lacks phonetic input algorithms. These functions currently have poor user experience and are not recommended for daily use.**
+
+The following input methods are included in this language pack:
+
+- 中文 (中国) [T9笔画] / Chinese (China) [T9]
+- 中文 (中国) [五笔98] / Chinese (China) [WUBI98]
+- ~中文 (中国) [五笔98-拼音混打] / Chinese (China) [WUBI98PINYIN]~
+- 中文 (中国) [五笔98-单字] / Chinese (China) [WUBI98SINGLE]
+- 中文 (中国) [五笔-大字库] / Chinese (China) [WUBILARGE]
+- 中文 (中国) [郑码] / Chinese (China) [ZHENGMA]
+- 中文 (中国) [郑码-大字库] / Chinese (China) [ZHENGMALARGE]
+- ~中文 (中国) [郑码-拼音混打] / Chinese (China) [ZHENGMAPINYIN]~
+- ~中文 (香港) [廣東拼音] / Chinese (Hong Kong) [CANTONESE]~
+- ~中文 (香港) [港式廣東話] / Chinese (Hong Kong) [CANTONHK]~
+- 中文 (香港) [輕鬆-大字庫] / Chinese (Hong Kong) [EASYLARGE]
+- ~中文 (香港) [粤語拼音-表格] / Chinese (Hong Kong) [JYUTPINGTABLE]~
+- 中文 (香港) [速成三代] / Chinese (Hong Kong) [QUICK3]
+- 中文 (香港) [經典速成] / Chinese (Hong Kong) [QUICKCLASSIC]
+- 中文 (香港) [筆順五碼] / Chinese (Hong Kong) [STROKE5]
+- 中文 (台灣) [行列] / Chinese (Taiwan) [ARRAY30]
+- 中文 (台灣) [行列-大字库] / Chinese (Taiwan) [ARRAY30LARGE]
+- 中文 (台灣) [嘸蝦米] / Chinese (Taiwan) [BOSHIAMY]
+- 中文 (台灣) [倉頡三代] / Chinese (Taiwan) [CANGJIE3]
+- 中文 (台灣) [倉頡五代] / Chinese (Taiwan) [CANGJIE5]
+- 中文 (台灣) [倉頡-大字庫] / Chinese (Taiwan) [CANGJIELARGE]
+- 中文 (台灣) [速成五代] / Chinese (Taiwan) [QUICK5]
+- 中文 (台灣) [快倉六] / Chinese (Taiwan) [SCJ6]
+- ~中文 (台灣) [吳語注音] / Chinese (Taiwan) [WU]~
+
+Third-party license: [https://github.com/fcitx/fcitx5-table-extra/blob/master/LICENSES/GPL-3.0-or-later.txt]
+
+# 简体中文翻译
+## 默认中文形码语言包
+
+请下载[完整中文语言包](#fcitx5-中文形码语言包)来获得五笔、快速仓颉等输入法，及这些输入法的其他版本。
+
+这一语言包的使用许可与FlorisBoard相同。
+
+## Fcitx5 中文形码语言包
+
+这一语言包由另一使用许可提供。下载请访问：[TODO: add link to release page](https://)
+
+:no_entry: :no_entry: **注意** :no_entry: :no_entry:
+
+- **含拼音、粤拼、注音等功能的输入法，仅为便利提供。目前，FlorisBoard缺乏音码输入算法，这些功能目前使用体验不佳，暂不推荐日常使用。**
+
+语言包内含以下输入法：
+
+- 中文 (中国) [T9笔画] / Chinese (China) [T9]
+- 中文 (中国) [五笔98] / Chinese (China) [WUBI98]
+- ~中文 (中国) [五笔98-拼音混打] / Chinese (China) [WUBI98PINYIN]~
+- 中文 (中国) [五笔98-单字] / Chinese (China) [WUBI98SINGLE]
+- 中文 (中国) [五笔-大字库] / Chinese (China) [WUBILARGE]
+- 中文 (中国) [郑码] / Chinese (China) [ZHENGMA]
+- 中文 (中国) [郑码-大字库] / Chinese (China) [ZHENGMALARGE]
+- ~中文 (中国) [郑码-拼音混打] / Chinese (China) [ZHENGMAPINYIN]~
+- ~中文 (香港) [廣東拼音] / Chinese (Hong Kong) [CANTONESE]~
+- ~中文 (香港) [港式廣東話] / Chinese (Hong Kong) [CANTONHK]~
+- 中文 (香港) [輕鬆-大字庫] / Chinese (Hong Kong) [EASYLARGE]
+- ~中文 (香港) [粤語拼音-表格] / Chinese (Hong Kong) [JYUTPINGTABLE]~
+- 中文 (香港) [速成三代] / Chinese (Hong Kong) [QUICK3]
+- 中文 (香港) [經典速成] / Chinese (Hong Kong) [QUICKCLASSIC]
+- 中文 (香港) [筆順五碼] / Chinese (Hong Kong) [STROKE5]
+- 中文 (台灣) [行列] / Chinese (Taiwan) [ARRAY30]
+- 中文 (台灣) [行列-大字库] / Chinese (Taiwan) [ARRAY30LARGE]
+- 中文 (台灣) [嘸蝦米] / Chinese (Taiwan) [BOSHIAMY]
+- 中文 (台灣) [倉頡三代] / Chinese (Taiwan) [CANGJIE3]
+- 中文 (台灣) [倉頡五代] / Chinese (Taiwan) [CANGJIE5]
+- 中文 (台灣) [倉頡-大字庫] / Chinese (Taiwan) [CANGJIELARGE]
+- 中文 (台灣) [速成五代] / Chinese (Taiwan) [QUICK5]
+- 中文 (台灣) [快倉六] / Chinese (Taiwan) [SCJ6]
+- ~中文 (台灣) [吳語注音] / Chinese (Taiwan) [WU]~
+
+第三方许可证: [https://github.com/fcitx/fcitx5-table-extra/blob/master/LICENSES/GPL-3.0-or-later.txt]
+
+
+# 繁体中文翻譯
+## 預設中文形碼語言包
+
+請下載[完整中文語言包](#fcitx5-中文形碼語言包)來獲得五筆、快速倉頡等輸入法，及這些輸入法的其他版本。
+
+這一語言包的使用許可與FlorisBoard相同。
+
+## Fcitx5 中文形碼語言包
+
+這一語言包由另一使用許可提供。下載請訪問：[TODO: add link to release page](https://)
+
+:no_entry: :no_entry: **注意** :no_entry: :no_entry:
+
+- **含拼音、粵拼、注音等功能的輸入法，僅為便利提供。目前，FlorisBoard缺乏音碼輸入算法，這些功能目前使用體驗不佳，暫不推薦日常使用。**
+
+語言包內含以下輸入法：
+
+- 中文 (中国) [T9笔画] / Chinese (China) [T9]
+- 中文 (中国) [五笔98] / Chinese (China) [WUBI98]
+- ~中文 (中国) [五笔98-拼音混打] / Chinese (China) [WUBI98PINYIN]~
+- 中文 (中国) [五笔98-单字] / Chinese (China) [WUBI98SINGLE]
+- 中文 (中国) [五笔-大字库] / Chinese (China) [WUBILARGE]
+- 中文 (中国) [郑码] / Chinese (China) [ZHENGMA]
+- 中文 (中国) [郑码-大字库] / Chinese (China) [ZHENGMALARGE]
+- ~中文 (中国) [郑码-拼音混打] / Chinese (China) [ZHENGMAPINYIN]~
+- ~中文 (香港) [廣東拼音] / Chinese (Hong Kong) [CANTONESE]~
+- ~中文 (香港) [港式廣東話] / Chinese (Hong Kong) [CANTONHK]~
+- 中文 (香港) [輕鬆-大字庫] / Chinese (Hong Kong) [EASYLARGE]
+- ~中文 (香港) [粤語拼音-表格] / Chinese (Hong Kong) [JYUTPINGTABLE]~
+- 中文 (香港) [速成三代] / Chinese (Hong Kong) [QUICK3]
+- 中文 (香港) [經典速成] / Chinese (Hong Kong) [QUICKCLASSIC]
+- 中文 (香港) [筆順五碼] / Chinese (Hong Kong) [STROKE5]
+- 中文 (台灣) [行列] / Chinese (Taiwan) [ARRAY30]
+- 中文 (台灣) [行列-大字库] / Chinese (Taiwan) [ARRAY30LARGE]
+- 中文 (台灣) [嘸蝦米] / Chinese (Taiwan) [BOSHIAMY]
+- 中文 (台灣) [倉頡三代] / Chinese (Taiwan) [CANGJIE3]
+- 中文 (台灣) [倉頡五代] / Chinese (Taiwan) [CANGJIE5]
+- 中文 (台灣) [倉頡-大字庫] / Chinese (Taiwan) [CANGJIELARGE]
+- 中文 (台灣) [速成五代] / Chinese (Taiwan) [QUICK5]
+- 中文 (台灣) [快倉六] / Chinese (Taiwan) [SCJ6]
+- ~中文 (台灣) [吳語注音] / Chinese (Taiwan) [WU]~
+
+第三方許可證: [https://github.com/fcitx/fcitx5-table-extra/blob/master/LICENSES/GPL-3.0-or-later.txt]

--- a/LANGUAGEPACKS.md
+++ b/LANGUAGEPACKS.md
@@ -16,39 +16,57 @@ The homepage of default language packs included in FlorisBoard should link to th
 
 ## Chinese / 中文
 
-TODO: translate into native language
-
 ### Default barebones Chinese shape-based pack
 
 默认中文形码语言包 / 預設中文形碼語言包 / Default barebones Chinese shape-based language pack which are always available.
 
-Please download the [full Chinese language pack](#full-chinese-shape-based-pack) to access input methods
-such as wubi, boshiami, and other versions of cangjie.
+
+请下载[完整中文语言包](#full-chinese-shape-based-pack)来获得五笔、快速仓颉等输入法，及这些输入法的其他版本。
+
+請下載[完整中文語言包](#full-chinese-shape-based-pack)來獲得五筆、快速倉頡等輸入法，及這些輸入法的其他版本。
+
+Please download the [full Chinese language pack](#full-chinese-shape-based-pack) to access input methods such as wubi, quick cangjie, and other versions of these input methods.
+
+这一语言包的使用许可与FlorisBoard相同。
+
+這一語言包的使用許可與FlorisBoard相同。
 
 This pack is released under the same license as Florisboard.
-
-TODO: translate into native language
 
 ### Full Chinese shape-based pack
 
 Fcitx5 中文形码语言包 / Fcitx5 中文形碼語言包 / Chinese shape-based language pack based on fcitx5-table-extra.
 
-This pack is released under a separate license. Please visit: [TODO: add link to release page](https://)
+这一语言包由另一使用许可提供。下载请访问：[TODO: add link to release page](https://)
+
+這一語言包由另一使用許可提供。下載請訪問：[TODO: add link to release page](https://)
+
+This pack is released under a separate license. Please visit to download: [TODO: add link to release page](https://)
+
+#### :no_entry: :no_entry: **注意 / WARNING** :no_entry: :no_entry:
+
+- **含拼音、粤拼、注音等功能的输入法，仅为便利提供。目前，FlorisBoard缺乏音码输入算法，这些功能目前使用体验不佳，暂不推荐日常使用。**
+- **含拼音、粵拼、注音等功能的輸入法，僅為便利提供。目前，FlorisBoard缺乏音碼輸入算法，這些功能目前使用體驗不佳，暫不推薦日常使用。**
+- **Input methods that include pinyin, jyutping, zhuyin as (auxiliary) functions are only provided for convenience. Currently, FlorisBoard lacks phonetic input algorithms. These functions currently have poor user experience and are not recommended for daily use.**
+
+语言包内含以下输入法：
+
+語言包內含以下輸入法：
 
 The following input methods are included in this language pack:
 
 - 中文 (中国) [T9笔画] / Chinese (China) [T9]
 - 中文 (中国) [五笔98] / Chinese (China) [WUBI98]
-- 中文 (中国) [五笔98-拼音混打] / Chinese (China) [WUBI98PINYIN]
+- ~中文 (中国) [五笔98-拼音混打] / Chinese (China) [WUBI98PINYIN]~
 - 中文 (中国) [五笔98-单字] / Chinese (China) [WUBI98SINGLE]
 - 中文 (中国) [五笔-大字库] / Chinese (China) [WUBILARGE]
 - 中文 (中国) [郑码] / Chinese (China) [ZHENGMA]
 - 中文 (中国) [郑码-大字库] / Chinese (China) [ZHENGMALARGE]
-- 中文 (中国) [郑码-拼音混打] / Chinese (China) [ZHENGMAPINYIN]
-- 中文 (香港) [廣東拼音] / Chinese (Hong Kong) [CANTONESE]
-- 中文 (香港) [港式廣東話] / Chinese (Hong Kong) [CANTONHK]
+- ~中文 (中国) [郑码-拼音混打] / Chinese (China) [ZHENGMAPINYIN]~
+- ~中文 (香港) [廣東拼音] / Chinese (Hong Kong) [CANTONESE]~
+- ~中文 (香港) [港式廣東話] / Chinese (Hong Kong) [CANTONHK]~
 - 中文 (香港) [輕鬆-大字庫] / Chinese (Hong Kong) [EASYLARGE]
-- 中文 (香港) [粤語拼音-表格] / Chinese (Hong Kong) [JYUTPINGTABLE]
+- ~中文 (香港) [粤語拼音-表格] / Chinese (Hong Kong) [JYUTPINGTABLE]~
 - 中文 (香港) [速成三代] / Chinese (Hong Kong) [QUICK3]
 - 中文 (香港) [經典速成] / Chinese (Hong Kong) [QUICKCLASSIC]
 - 中文 (香港) [筆順五碼] / Chinese (Hong Kong) [STROKE5]
@@ -60,8 +78,7 @@ The following input methods are included in this language pack:
 - 中文 (台灣) [倉頡-大字庫] / Chinese (Taiwan) [CANGJIELARGE]
 - 中文 (台灣) [速成五代] / Chinese (Taiwan) [QUICK5]
 - 中文 (台灣) [快倉六] / Chinese (Taiwan) [SCJ6]
-- 中文 (台灣) [吳語注音] / Chinese (Taiwan) [WU]
+- ~中文 (台灣) [吳語注音] / Chinese (Taiwan) [WU]~
 
-Third-party license: [https://github.com/fcitx/fcitx5-table-extra/blob/master/LICENSES/GPL-3.0-or-later.txt]
 
-TODO: translate into native language
+第三方许可证 / 第三方許可證 / Third-party license: [https://github.com/fcitx/fcitx5-table-extra/blob/master/LICENSES/GPL-3.0-or-later.txt]

--- a/LANGUAGEPACKS.md
+++ b/LANGUAGEPACKS.md
@@ -3,7 +3,7 @@
 ## Languages
 
 - [Summary](#summary)
-- [Chinese / 中文](#chinese--中文)
+- [Chinese / 中文](LANGUAGEPACKS-CHINESE.md)
 
 ## Summary
 
@@ -14,71 +14,3 @@ language packs.
 
 The homepage of default language packs included in FlorisBoard should link to this page.
 
-## Chinese / 中文
-
-### Default barebones Chinese shape-based pack
-
-默认中文形码语言包 / 預設中文形碼語言包 / Default barebones Chinese shape-based language pack which are always available.
-
-
-请下载[完整中文语言包](#full-chinese-shape-based-pack)来获得五笔、快速仓颉等输入法，及这些输入法的其他版本。
-
-請下載[完整中文語言包](#full-chinese-shape-based-pack)來獲得五筆、快速倉頡等輸入法，及這些輸入法的其他版本。
-
-Please download the [full Chinese language pack](#full-chinese-shape-based-pack) to access input methods such as wubi, quick cangjie, and other versions of these input methods.
-
-这一语言包的使用许可与FlorisBoard相同。
-
-這一語言包的使用許可與FlorisBoard相同。
-
-This pack is released under the same license as Florisboard.
-
-### Full Chinese shape-based pack
-
-Fcitx5 中文形码语言包 / Fcitx5 中文形碼語言包 / Chinese shape-based language pack based on fcitx5-table-extra.
-
-这一语言包由另一使用许可提供。下载请访问：[TODO: add link to release page](https://)
-
-這一語言包由另一使用許可提供。下載請訪問：[TODO: add link to release page](https://)
-
-This pack is released under a separate license. Please visit to download: [TODO: add link to release page](https://)
-
-#### :no_entry: :no_entry: **注意 / WARNING** :no_entry: :no_entry:
-
-- **含拼音、粤拼、注音等功能的输入法，仅为便利提供。目前，FlorisBoard缺乏音码输入算法，这些功能目前使用体验不佳，暂不推荐日常使用。**
-- **含拼音、粵拼、注音等功能的輸入法，僅為便利提供。目前，FlorisBoard缺乏音碼輸入算法，這些功能目前使用體驗不佳，暫不推薦日常使用。**
-- **Input methods that include pinyin, jyutping, zhuyin as (auxiliary) functions are only provided for convenience. Currently, FlorisBoard lacks phonetic input algorithms. These functions currently have poor user experience and are not recommended for daily use.**
-
-语言包内含以下输入法：
-
-語言包內含以下輸入法：
-
-The following input methods are included in this language pack:
-
-- 中文 (中国) [T9笔画] / Chinese (China) [T9]
-- 中文 (中国) [五笔98] / Chinese (China) [WUBI98]
-- ~中文 (中国) [五笔98-拼音混打] / Chinese (China) [WUBI98PINYIN]~
-- 中文 (中国) [五笔98-单字] / Chinese (China) [WUBI98SINGLE]
-- 中文 (中国) [五笔-大字库] / Chinese (China) [WUBILARGE]
-- 中文 (中国) [郑码] / Chinese (China) [ZHENGMA]
-- 中文 (中国) [郑码-大字库] / Chinese (China) [ZHENGMALARGE]
-- ~中文 (中国) [郑码-拼音混打] / Chinese (China) [ZHENGMAPINYIN]~
-- ~中文 (香港) [廣東拼音] / Chinese (Hong Kong) [CANTONESE]~
-- ~中文 (香港) [港式廣東話] / Chinese (Hong Kong) [CANTONHK]~
-- 中文 (香港) [輕鬆-大字庫] / Chinese (Hong Kong) [EASYLARGE]
-- ~中文 (香港) [粤語拼音-表格] / Chinese (Hong Kong) [JYUTPINGTABLE]~
-- 中文 (香港) [速成三代] / Chinese (Hong Kong) [QUICK3]
-- 中文 (香港) [經典速成] / Chinese (Hong Kong) [QUICKCLASSIC]
-- 中文 (香港) [筆順五碼] / Chinese (Hong Kong) [STROKE5]
-- 中文 (台灣) [行列] / Chinese (Taiwan) [ARRAY30]
-- 中文 (台灣) [行列-大字库] / Chinese (Taiwan) [ARRAY30LARGE]
-- 中文 (台灣) [嘸蝦米] / Chinese (Taiwan) [BOSHIAMY]
-- 中文 (台灣) [倉頡三代] / Chinese (Taiwan) [CANGJIE3]
-- 中文 (台灣) [倉頡五代] / Chinese (Taiwan) [CANGJIE5]
-- 中文 (台灣) [倉頡-大字庫] / Chinese (Taiwan) [CANGJIELARGE]
-- 中文 (台灣) [速成五代] / Chinese (Taiwan) [QUICK5]
-- 中文 (台灣) [快倉六] / Chinese (Taiwan) [SCJ6]
-- ~中文 (台灣) [吳語注音] / Chinese (Taiwan) [WU]~
-
-
-第三方许可证 / 第三方許可證 / Third-party license: [https://github.com/fcitx/fcitx5-table-extra/blob/master/LICENSES/GPL-3.0-or-later.txt]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbolsMod/cjk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbolsMod/cjk.json
@@ -8,7 +8,7 @@
     { "code": -201, "label": "view_characters", "type": "system_gui" },
     { "$": "char_width_selector",
       "full": { "code": 12289, "label": "、", "popup": {
-          "main": { "code":   44, "label": "," }
+          "main": { "code": 65292, "label": "，" }
         }
       },
       "half": { "code": 65380, "label": "､", "popup": {

--- a/app/src/main/assets/ime/languagepack/org.florisboard.hanshapebasedbasicpack/extension.json
+++ b/app/src/main/assets/ime/languagepack/org.florisboard.hanshapebasedbasicpack/extension.json
@@ -6,7 +6,7 @@
     "title": "Default barebones Chinese shape-based pack",
     "description": "默认中文形码语言包 / 預設中文形碼語言包 / Default barebones Chinese shape-based language pack which are always available.\n请访问下面的主页链接下载更多输入法 / 請訪問下面的主頁鏈接下載更多輸入法 / Please visit the homepage linked below to download more input methods.",
     "maintainers": [ "patrickgold <patrick@patrickgold.dev>", "waelwindows", "moonbeamcelery" ],
-    "homepage": "https://github.com/florisboard/florisboard/blob/master/LANGUAGEPACKS.md#default-barebones-chinese-shape-based-pack",
+    "homepage": "https://github.com/florisboard/florisboard/blob/master/LANGUAGEPACKS-CHINESE.md#default-barebones-chinese-shape-based-pack",
     "license": "apache-2.0"
   },
   "items": [

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -25,6 +25,7 @@ import android.os.Bundle
 import android.util.Size
 import android.util.TypedValue
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -634,6 +635,11 @@ class FlorisImeService : LifecycleInputMethodService() {
             DevtoolsOverlay(modifier = Modifier.fillMaxSize())
         }
     }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean =
+        if (keyboardManager.onHardwareKeyDown(keyCode, event)) true
+        else super.onKeyDown(keyCode, event)
+
 
     private inner class ComposeInputView : AbstractComposeView(this) {
         init {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/DevtoolsOverlay.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/DevtoolsOverlay.kt
@@ -112,6 +112,7 @@ private fun DevtoolsInputStateOverlay() {
             DevtoolsText(text = "After: \"${content.textAfterSelection}\"")
             DevtoolsText(text = "Composing: ${content.composing}")
             DevtoolsText(text = "CurrentWord: ${content.currentWord}")
+            DevtoolsText(text = "LastCommit: ${editorInstance.lastCommitPosition}")
         }
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
@@ -435,7 +435,7 @@ abstract class AbstractEditorInstance(context: Context) {
         // Cannot perform below check due to editors which lie about their correct selection
         //if (content.selection.isValid && content.selection.start == 0) return true
         val oldTextBeforeSelection = content.textBeforeSelection
-        return if (activeInfo.isRawInputEditor || oldTextBeforeSelection.isEmpty()) {
+        return (if (activeInfo.isRawInputEditor || oldTextBeforeSelection.isEmpty()) {
             // If editor is rich and text before selection is empty we seem to have an invalid state here, so we fall
             // back to emulating a hardware backspace.
             when (type) {
@@ -463,6 +463,8 @@ abstract class AbstractEditorInstance(context: Context) {
                 ic.endBatchEdit()
                 true
             }
+        }).also {
+            deleteMoveLastCommitPosition()
         }
     }
 
@@ -646,6 +648,7 @@ abstract class AbstractEditorInstance(context: Context) {
     }
 
     fun updateLastCommitPosition() = _lastCommitPosition.handleCommit(activeContent.selection)
+    fun deleteMoveLastCommitPosition() = _lastCommitPosition.handleDelete(activeContent.selection)
 
     /**
      * Class for handling history of last commit position.
@@ -670,6 +673,13 @@ abstract class AbstractEditorInstance(context: Context) {
             val start = min(selection.start, selection.end)
             if (start < pos) {
                 reset()
+            }
+        }
+
+        fun handleDelete(selection: EditorRange) {
+            val start = min(selection.start, selection.end)
+            if (start < pos) {
+                pos = start
             }
         }
     }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
@@ -468,6 +468,19 @@ abstract class AbstractEditorInstance(context: Context) {
         }
     }
 
+    fun refreshComposing() {
+        val content = activeContent
+        val ic = currentInputConnection()
+        if (activeInfo.isRawInputEditor || ic == null) return
+        runBlocking {
+            val newContent = content.generateCopy()
+            if (newContent.composing != content.composing) {
+                expectedContentQueue.push(newContent)
+                ic.setComposingRegion(newContent.composing)
+            }
+        }
+    }
+
     /**
      * Gets [n] characters before the cursor's current position. The resulting string may be any
      * length ranging from 0 to n.

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
@@ -403,8 +403,7 @@ abstract class AbstractEditorInstance(context: Context) {
             val newContent = content.generateCopy(
                 selection = newSelection,
                 textBeforeSelection = buildString {
-                    append(content.textBeforeSelection)
-                    removeSuffix(content.composingText)
+                    append(content.textBeforeSelection.removeSuffix(content.composingText))
                     append(text)
                 },
                 selectedText = "",

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
@@ -238,7 +238,7 @@ abstract class AbstractEditorInstance(context: Context) {
         // Determine local composing word range, if any
         val localCurrentWord =
             if (shouldDetermineComposingRegion(editorInfo) && localSelection.isCursorMode && textBeforeSelection.isNotEmpty()) {
-                determineLocalComposing(textBeforeSelection)
+                determineLocalComposing(textBeforeSelection, _lastCommitPosition.pos - offset)
             } else {
                 EditorRange.Unspecified
             }
@@ -284,8 +284,10 @@ abstract class AbstractEditorInstance(context: Context) {
         return editorInfo.isRichInputEditor
     }
 
-    private suspend fun determineLocalComposing(textBeforeSelection: CharSequence): EditorRange {
-        return nlpManager.determineLocalComposing(textBeforeSelection, breakIterators)
+    private suspend fun determineLocalComposing(
+        textBeforeSelection: CharSequence, localLastCommitPosition: Int
+    ): EditorRange {
+        return nlpManager.determineLocalComposing(textBeforeSelection, breakIterators, localLastCommitPosition)
     }
 
     private fun InputConnection.setComposingRegion(composing: EditorRange) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -139,7 +139,7 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
     }
 
     override fun determineComposingEnabled(): Boolean {
-        return prefs.suggestion.enabled.get() || nlpManager.providerForcesSuggestionOn(subtypeManager.activeSubtype)
+        return nlpManager.isSuggestionOn()
     }
 
     override fun determineComposer(composerName: ExtensionComponentName): Composer {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -479,10 +479,8 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
 
     fun tryPerformEnterCommitRaw(): Boolean {
         return if (subtypeManager.activeSubtype.primaryLocale.language.startsWith("zh") && activeContent.composing.length > 0) {
-            flogDebug { "ENTER: FINALIZECOMPOSINGTEXT ${activeContent.composingText}" }
             finalizeComposingText(activeContent.composingText)
         } else {
-            flogDebug { "ENTER: NOTHING" }
             false
         }
     }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -264,6 +264,9 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
                 super.commitText("$SPACE$text")
             } else {
                 super.commitText(text)
+            }.also {
+                // handled in finalizeComposingText if content.composing.isValid
+                updateLastCommitPosition()
             }
         }
     }
@@ -286,6 +289,8 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
             super.commitText("$SPACE$text")
         } else {
             super.commitText(text)
+        }.also {
+            updateLastCommitPosition()
         }
     }
 
@@ -303,7 +308,9 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
         val mimeTypes = item.mimeTypes
         return when (item.type) {
             ItemType.TEXT -> {
-                commitText(item.text.toString())
+                commitText(item.text.toString()).also {
+                    updateLastCommitPosition()
+                }
             }
             ItemType.IMAGE, ItemType.VIDEO -> {
                 item.uri ?: return false

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -139,7 +139,7 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
     }
 
     override fun determineComposingEnabled(): Boolean {
-        return prefs.suggestion.enabled.get()
+        return prefs.suggestion.enabled.get() || nlpManager.providerForcesSuggestionOn(subtypeManager.activeSubtype)
     }
 
     override fun determineComposer(composerName: ExtensionComponentName): Composer {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -477,6 +477,16 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
         }
     }
 
+    fun tryPerformEnterCommitRaw(): Boolean {
+        return if (subtypeManager.activeSubtype.primaryLocale.language.startsWith("zh") && activeContent.composing.length > 0) {
+            flogDebug { "ENTER: FINALIZECOMPOSINGTEXT ${activeContent.composingText}" }
+            finalizeComposingText(activeContent.composingText)
+        } else {
+            flogDebug { "ENTER: NOTHING" }
+            false
+        }
+    }
+
     /**
      * Performs a given [action] on the current input editor.
      *

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -146,6 +146,7 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             subtypeManager.activeSubtypeFlow.collectLatestIn(scope) {
                 reevaluateInputShiftState()
                 updateActiveEvaluators()
+                editorInstance.refreshComposing()
                 resetSuggestions(editorInstance.activeContent)
             }
             clipboardManager.primaryClipFlow.collectLatestIn(scope) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -35,6 +35,7 @@ import dev.patrickgold.florisboard.ime.ImeUiMode
 import dev.patrickgold.florisboard.ime.core.DisplayLanguageNamesIn
 import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.core.SubtypePreset
+import dev.patrickgold.florisboard.ime.editor.EditorContent
 import dev.patrickgold.florisboard.ime.editor.FlorisEditorInfo
 import dev.patrickgold.florisboard.ime.editor.ImeOptions
 import dev.patrickgold.florisboard.ime.editor.InputAttributes
@@ -144,16 +145,13 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             subtypeManager.activeSubtypeFlow.collectLatestIn(scope) {
                 reevaluateInputShiftState()
                 updateActiveEvaluators()
+                resetSuggestions(editorInstance.activeContent)
             }
             clipboardManager.primaryClipFlow.collectLatestIn(scope) {
                 updateActiveEvaluators()
             }
             editorInstance.activeContentFlow.collectIn(scope) { content ->
-                if (!activeState.isComposingEnabled) {
-                    nlpManager.clearSuggestions()
-                    return@collectIn
-                }
-                nlpManager.suggest(subtypeManager.activeSubtype, content)
+                resetSuggestions(content)
             }
             prefs.devtools.enabled.observeForever {
                 reevaluateDebugFlags()
@@ -211,6 +209,14 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                 else -> InputShiftState.UNSHIFTED
             }
         }
+    }
+
+    fun resetSuggestions(content: EditorContent) {
+        if (!activeState.isComposingEnabled) {
+            nlpManager.clearSuggestions()
+            return
+        }
+        nlpManager.suggest(subtypeManager.activeSubtype, content)
     }
 
     /**

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -214,12 +214,11 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
     }
 
     fun resetSuggestions(content: EditorContent) {
-        val activeSubtype = subtypeManager.activeSubtype
-        if (!(activeState.isComposingEnabled || nlpManager.providerForcesSuggestionOn(activeSubtype))) {
+        if (!(activeState.isComposingEnabled || nlpManager.isSuggestionOn())) {
             nlpManager.clearSuggestions()
             return
         }
-        nlpManager.suggest(activeSubtype, content)
+        nlpManager.suggest(subtypeManager.activeSubtype, content)
     }
 
     /**

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -435,6 +435,9 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
     private fun handleEnter() {
         val info = editorInstance.activeInfo
         val isShiftPressed = inputEventDispatcher.isPressed(KeyCode.SHIFT)
+        if (editorInstance.tryPerformEnterCommitRaw()) {
+            return
+        }
         if (info.imeOptions.flagNoEnterAction || info.inputAttributes.flagTextMultiLine && isShiftPressed) {
             editorInstance.performEnter()
         } else {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -213,11 +213,12 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
     }
 
     fun resetSuggestions(content: EditorContent) {
-        if (!activeState.isComposingEnabled) {
+        val activeSubtype = subtypeManager.activeSubtype
+        if (!(activeState.isComposingEnabled || nlpManager.providerForcesSuggestionOn(activeSubtype))) {
             nlpManager.clearSuggestions()
             return
         }
-        nlpManager.suggest(subtypeManager.activeSubtype, content)
+        nlpManager.suggest(activeSubtype, content)
     }
 
     /**

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -825,7 +825,6 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
     }
 
     fun onHardwareKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-        flogDebug { "Calling from FlorisImeService.onKeyDown with $keyCode" }
         when (keyCode) {
             KeyEvent.KEYCODE_SPACE -> {
                 handleHardwareKeyboardSpace()

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpManager.kt
@@ -17,7 +17,6 @@
 package dev.patrickgold.florisboard.ime.nlp
 
 import android.content.Context
-import android.icu.text.BreakIterator
 import android.os.Build
 import android.os.SystemClock
 import android.util.LruCache
@@ -174,9 +173,11 @@ class NlpManager(context: Context) {
         )
     }
 
-    suspend fun determineLocalComposing(textBeforeSelection: CharSequence, breakIterators: BreakIteratorGroup): EditorRange {
+    suspend fun determineLocalComposing(
+        textBeforeSelection: CharSequence, breakIterators: BreakIteratorGroup, localLastCommitPosition: Int
+    ): EditorRange {
         return getSuggestionProvider(subtypeManager.activeSubtype).determineLocalComposing(
-            subtypeManager.activeSubtype, textBeforeSelection, breakIterators
+            subtypeManager.activeSubtype, textBeforeSelection, breakIterators, localLastCommitPosition
         )
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpManager.kt
@@ -192,6 +192,9 @@ class NlpManager(context: Context) {
         }
     }
 
+    fun isSuggestionOn(): Boolean =
+        prefs.suggestion.enabled.get() || providerForcesSuggestionOn(subtypeManager.activeSubtype)
+
     fun suggest(subtype: Subtype, content: EditorContent) {
         val reqTime = SystemClock.uptimeMillis()
         scope.launch {
@@ -254,7 +257,7 @@ class NlpManager(context: Context) {
     private fun assembleCandidates() {
         runBlocking {
             val candidates = when {
-                prefs.suggestion.enabled.get() -> {
+                isSuggestionOn() -> {
                     clipboardSuggestionProvider.suggest(
                         subtype = Subtype.DEFAULT,
                         content = editorInstance.activeContent,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
@@ -208,7 +208,8 @@ interface SuggestionProvider : NlpProvider {
     suspend fun determineLocalComposing(
         subtype: Subtype,
         textBeforeSelection: CharSequence,
-        breakIterators: BreakIteratorGroup
+        breakIterators: BreakIteratorGroup,
+        localLastCommitPosition: Int,
     ): EditorRange {
         return breakIterators.word(subtype.primaryLocale) {
             it.setText(textBeforeSelection.toString())

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
@@ -223,6 +223,9 @@ interface SuggestionProvider : NlpProvider {
             }
         }
     }
+
+    val forcesSuggestionOn
+        get() = false
 }
 
 /**

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
@@ -299,4 +299,6 @@ class HanShapeBasedLanguageProvider(val context: Context) : SpellingProvider, Su
         }
     }
 
+    override val forcesSuggestionOn
+        get() = true
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
@@ -230,39 +230,41 @@ class HanShapeBasedLanguageProvider(val context: Context) : SpellingProvider, Su
     }
 
     override suspend fun getListOfWords(subtype: Subtype): List<String> {
-        val (languagePackItem, languagePackExtension) = getLanguagePack(subtype) ?: return emptyList();
-        val layout: String = languagePackItem.hanShapeBasedTable
-        try {
-            val database = languagePackExtension.hanShapeBasedSQLiteDatabase
-            val cur = database.query(layout, arrayOf ( "text" ), "", arrayOf(), "", "", "weight DESC, code ASC", "");
-            cur.moveToFirst();
-            val rowCount = cur.getCount();
-            val suggestions = buildList {
-                for (n in 0 until rowCount) {
-                    val word = cur.getString(0);
-                    cur.moveToNext();
-                    add(word)
-                }
-            }
-            flogDebug { "Read ${suggestions.size} words for ${subtype.primaryLocale.localeTag()}" }
-            return suggestions;
-        } catch (e: SQLiteException) {
-            flogError { "Encountered an SQL error: ${e}" }
-            return emptyList();
-        }
+        return emptyList()
+//        val (languagePackItem, languagePackExtension) = getLanguagePack(subtype) ?: return emptyList();
+//        val layout: String = languagePackItem.hanShapeBasedTable
+//        try {
+//            val database = languagePackExtension.hanShapeBasedSQLiteDatabase
+//            val cur = database.query(layout, arrayOf ( "text" ), "", arrayOf(), "", "", "weight DESC, code ASC", "");
+//            cur.moveToFirst();
+//            val rowCount = cur.getCount();
+//            val suggestions = buildList {
+//                for (n in 0 until rowCount) {
+//                    val word = cur.getString(0);
+//                    cur.moveToNext();
+//                    add(word)
+//                }
+//            }
+//            flogDebug { "Read ${suggestions.size} words for ${subtype.primaryLocale.localeTag()}" }
+//            return suggestions;
+//        } catch (e: SQLiteException) {
+//            flogError { "Encountered an SQL error: ${e}" }
+//            return emptyList();
+//        }
     }
 
     override suspend fun getFrequencyForWord(subtype: Subtype, word: String): Double {
-        val (languagePackItem, languagePackExtension) = getLanguagePack(subtype) ?: return 0.0;
-        val layout: String = languagePackItem.hanShapeBasedTable
-        try {
-            val database = languagePackExtension.hanShapeBasedSQLiteDatabase
-            val cur = database.query(layout, arrayOf ( "weight" ), "code = ?", arrayOf(word), "", "", "", "");
-            cur.moveToFirst();
-            return try { cur.getDouble(0) } catch (e: Exception) { 0.0 };
-        } catch (e: SQLiteException) {
-            return 0.0;
-        }
+        return 0.0
+//        val (languagePackItem, languagePackExtension) = getLanguagePack(subtype) ?: return 0.0;
+//        val layout: String = languagePackItem.hanShapeBasedTable
+//        try {
+//            val database = languagePackExtension.hanShapeBasedSQLiteDatabase
+//            val cur = database.query(layout, arrayOf ( "weight" ), "code = ?", arrayOf(word), "", "", "", "");
+//            cur.moveToFirst();
+//            return try { cur.getDouble(0) } catch (e: Exception) { 0.0 };
+//        } catch (e: SQLiteException) {
+//            return 0.0;
+//        }
     }
 
     override suspend fun destroy() {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
@@ -270,14 +270,19 @@ class HanShapeBasedLanguageProvider(val context: Context) : SpellingProvider, Su
         // the app process is killed (which will most likely always be the case).
     }
 
-    override suspend fun determineLocalComposing(subtype: Subtype, textBeforeSelection: CharSequence, breakIterators: BreakIteratorGroup): EditorRange {
+    override suspend fun determineLocalComposing(
+        subtype: Subtype,
+        textBeforeSelection: CharSequence,
+        breakIterators: BreakIteratorGroup,
+        localLastCommitPosition: Int
+    ): EditorRange {
         return breakIterators.character(subtype.primaryLocale) {
             it.setText(textBeforeSelection.toString())
             val end = it.last()
             var start = end
             var next = it.previous()
             val keyCodeLocale = keyCode[subtype.primaryLocale.localeTag()]?: keyCode["default"]?: emptySet()
-            while (next != BreakIterator.DONE) {
+            while (next != BreakIterator.DONE && start > localLastCommitPosition) {
                 val sub = textBeforeSelection.substring(next, start)
                 if (! sub.all { char -> char in keyCodeLocale })
                     break


### PR DESCRIPTION
This PR is based on #2054 and adds some quality-of-life updates for using the new subtype to type a mixture of Chinese and English text.

- Allowing committing raw input using Enter with CJK, and allowing the committed text to persist instead of being included in the composing range again. ~See below for caveat.~
- Reset suggestions when changing keyboard subtypes.
- ~Delegate NlpProvider to determine composing range when starting IME or moving cursor. Latin behavior remains considering the last word, and HanShapeBased only consider viable characters (lowercase letters for now, but may need to add support a different set for each input method).~ (already merged)
- Update: tracks the last commit position, and limits `HanShapeBasedLanguageProvider` to not compose beyond that position.
- Force suggestion on if a subtype uses HanShapeBased, so when people first use the IME they would not be confused to think the IME is broken if suggestion is off.

Some extra fixes:
- Full-width comma for CJK keyboard, which seems to be missing.
- Allow minimal handling of physical keyboard input (space and enter). Full-width characters, tab to select candidate etc. are still missing.

~Caveat: these work now, but I'm currently using the previous composing range as a reference for changing the composing range. For some use cases, this breaks the composing range preservation due to how Android handles an zero-length composing range when calling onUpdateSelection (e.g. deleting the composing range forces re-evaluation of composing range. So if you type abc and hit Enter, abc gets commited, and then you type def and three backspaces, abc becomes the composing range again despite them being committed). I am not exactly sure if this is the best way to go about it.~

~Maybe I should just maintain an internal record of where the last committed text ended? But the character limit of context may make this hard.~
