### PR TITLE
Update workflows dependencies

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,20 +20,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: temurin
+          cache: gradle
       - name: Setup CMake and Ninja
-        uses: lukka/get-cmake@v3.20.1
+        uses: lukka/get-cmake@latest
       - name: Build with Gradle
         # MUST call gradlew separately because of an OSS license plugin issue.
         # See https://github.com/google/play-services-plugins/issues/199
         run: ./gradlew clean && ./gradlew assembleDebug
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: app-debug.apk
           path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
This should fix some ci warnings. Also added gradle/wrapper-validation-action, I guess it's good to have. I don't know if you prefer another java distribution, if so, let me know.