### PR TITLE
Support user dictionary in suggestions

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -153,13 +153,16 @@ class FlorisImeService : LifecycleInputMethodService() {
         /**
          * Hides the IME and launches [FlorisAppActivity].
          */
-        fun launchSettings() {
+        fun launchSettings(route: String? = null) {
             val ims = FlorisImeServiceReference.get() ?: return
             ims.requestHideSelf(0)
             ims.launchActivity(FlorisAppActivity::class) {
                 it.flags = Intent.FLAG_ACTIVITY_NEW_TASK or
                     Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED or
                     Intent.FLAG_ACTIVITY_CLEAR_TOP
+                if (route != null) {
+                    it.putExtra("launchRoute", route)
+                }
             }
         }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -684,21 +684,32 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
                 val oldArrangement = QuickActionArrangement.Serializer.deserialize(entry.rawValue)
                 val newDefault = QuickActionArrangement.Default
 
-                val newStickyAction = oldArrangement.stickyAction?.takeIf { newDefault.contains(it) }
-                val newDynamicActions = oldArrangement.dynamicActions.filter { newDefault.contains(it) }.toMutableList()
-                val newHiddenActions = oldArrangement.hiddenActions.filter { newDefault.contains(it) }.toMutableList()
+                // FIXME: what is the canonical equality for two quick actions? Using .keyData().code for now.
+                val oldActionKeys = buildSet {
+                    oldArrangement.stickyAction?.let { add(it.keyData().code) }
+                    oldArrangement.dynamicActions.forEach { add(it.keyData().code) }
+                    oldArrangement.hiddenActions.forEach { add(it.keyData().code) }
+                }
+                val newActionKeys = buildSet {
+                    newDefault.stickyAction?.let { add(it.keyData().code) }
+                    newDefault.dynamicActions.forEach { add(it.keyData().code) }
+                    newDefault.hiddenActions.forEach { add(it.keyData().code) }
+                }
+                val newStickyAction = oldArrangement.stickyAction?.takeIf { it.keyData().code in newActionKeys }
+                val newDynamicActions = oldArrangement.dynamicActions.filter { it.keyData().code in newActionKeys }.toMutableList()
+                val newHiddenActions = oldArrangement.hiddenActions.filter { it.keyData().code in newActionKeys }.toMutableList()
                 newDefault.stickyAction?.let {
-                    if (!oldArrangement.contains(it)) {
+                    if (it.keyData().code !in oldActionKeys) {
                         newDynamicActions.add(it)
                     }
                 }
                 for (it in newDefault.dynamicActions) {
-                    if (!oldArrangement.contains(it)) {
+                    if (it.keyData().code !in oldActionKeys) {
                         newDynamicActions.add(it)
                     }
                 }
                 for (it in newDefault.hiddenActions) {
-                    if (!oldArrangement.contains(it)) {
+                    if (it.keyData().code !in oldActionKeys) {
                         newHiddenActions.add(it)
                     }
                 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -36,6 +36,7 @@ import dev.patrickgold.florisboard.ime.smartbar.CandidatesDisplayMode
 import dev.patrickgold.florisboard.ime.smartbar.ExtendedActionsPlacement
 import dev.patrickgold.florisboard.ime.smartbar.SmartbarLayout
 import dev.patrickgold.florisboard.ime.smartbar.quickaction.QuickActionArrangement
+import dev.patrickgold.florisboard.ime.smartbar.quickaction.keyData
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
 import dev.patrickgold.florisboard.ime.text.key.KeyHintConfiguration
 import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
@@ -678,6 +679,37 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
             "theme__editor_display_kbd_after_dialogs", "theme__editor_level",
             -> {
                 entry.transform(rawValue = entry.rawValue.uppercase())
+            }
+            "smartbar__action_arrangement" -> {
+                val oldArrangement = QuickActionArrangement.Serializer.deserialize(entry.rawValue)
+                val newDefault = QuickActionArrangement.Default
+
+                val newStickyAction = oldArrangement.stickyAction?.takeIf { newDefault.contains(it) }
+                val newDynamicActions = oldArrangement.dynamicActions.filter { newDefault.contains(it) }.toMutableList()
+                val newHiddenActions = oldArrangement.hiddenActions.filter { newDefault.contains(it) }.toMutableList()
+                newDefault.stickyAction?.let {
+                    if (!oldArrangement.contains(it)) {
+                        newDynamicActions.add(it)
+                    }
+                }
+                for (it in newDefault.dynamicActions) {
+                    if (!oldArrangement.contains(it)) {
+                        newDynamicActions.add(it)
+                    }
+                }
+                for (it in newDefault.hiddenActions) {
+                    if (!oldArrangement.contains(it)) {
+                        newHiddenActions.add(it)
+                    }
+                }
+                val newArrangement = QuickActionArrangement(
+                    stickyAction = newStickyAction,
+                    dynamicActions = newDynamicActions.toList(),
+                    hiddenActions = newHiddenActions.toList()
+                )
+                entry.transform(
+                    rawValue = QuickActionArrangement.Serializer.serialize(newArrangement)
+                )
             }
 
             // Migrate old private mode force flag as this is a sensitive preference

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/FlorisAppActivity.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/FlorisAppActivity.kt
@@ -162,5 +162,8 @@ class FlorisAppActivity : ComponentActivity() {
         SideEffect {
             navController.setOnBackPressedDispatcher(this.onBackPressedDispatcher)
         }
+        // FIXME: does this have security implications?
+        val launchRoute = intent.extras?.getString("launchRoute")
+        launchRoute?.let { navController.navigate(it) }
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/Routes.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/Routes.kt
@@ -89,7 +89,15 @@ object Routes {
 
         const val Dictionary = "settings/dictionary"
         const val UserDictionary = "settings/dictionary/user-dictionary/{type}"
+        const val UserDictionaryAdd = "settings/dictionary/user-dictionary/{type}/{locale}"
         fun UserDictionary(type: UserDictionaryType) = UserDictionary.curlyFormat("type" to type.id)
+        fun UserDictionaryAdd(type: UserDictionaryType, locale: String?): String {
+            val localeSafe = locale?.replace("/", "")
+            if (localeSafe == null || localeSafe.isEmpty())
+                return UserDictionary(type)
+            return UserDictionaryAdd.curlyFormat("type" to type.id, "locale" to localeSafe)
+        }
+
 
         const val Gestures = "settings/gestures"
 
@@ -184,7 +192,14 @@ object Routes {
                 val type = navBackStack.arguments?.getString("type")?.let { typeId ->
                     UserDictionaryType.values().firstOrNull { it.id == typeId }
                 }
-                UserDictionaryScreen(type!!)
+                UserDictionaryScreen(type!!, adding = false, addLocale = "")
+            }
+            composable(Settings.UserDictionaryAdd) { navBackStack ->
+                val type = navBackStack.arguments?.getString("type")?.let { typeId ->
+                    UserDictionaryType.values().firstOrNull { it.id == typeId }
+                }
+                val locale = navBackStack.arguments?.getString("locale") ?: ""
+                UserDictionaryScreen(type!!, adding = true, addLocale = locale)
             }
 
             composable(Settings.Gestures) { GesturesScreen() }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/dictionary/DictionaryManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/dictionary/DictionaryManager.kt
@@ -65,24 +65,38 @@ class DictionaryManager private constructor(context: Context) {
             if (prefs.dictionary.enableFlorisUserDictionary.get()) {
                 florisDao?.query(word, locale)?.let {
                     for (entry in it) {
-                        add(WordSuggestionCandidate(entry.word, confidence = entry.freq / 255.0))
+                        add(WordSuggestionCandidate(
+                            entry.word, confidence = entry.freq / 255.0,
+                            isEligibleForAutoCommit=entry.word == word, // only allow auto commit if exact match
+                        ))
                     }
                 }
                 florisDao?.queryShortcut(word, locale)?.let {
                     for (entry in it) {
-                        add(WordSuggestionCandidate(entry.word, confidence = entry.freq / 255.0))
+                        add(WordSuggestionCandidate(
+                            entry.word, secondaryText = entry.shortcut,
+                            confidence = entry.freq / 255.0,
+                            isEligibleForAutoCommit=entry.shortcut == word, // only allow auto commit if exact match
+                        ))
                     }
                 }
             }
             if (prefs.dictionary.enableSystemUserDictionary.get()) {
                 systemDao?.query(word, locale)?.let {
                     for (entry in it) {
-                        add(WordSuggestionCandidate(entry.word, confidence = entry.freq / 255.0))
+                        add(WordSuggestionCandidate(
+                            entry.word, confidence = entry.freq / 255.0,
+                            isEligibleForAutoCommit=entry.word == word, // only allow auto commit if exact match
+                        ))
                     }
                 }
                 systemDao?.queryShortcut(word, locale)?.let {
                     for (entry in it) {
-                        add(WordSuggestionCandidate(entry.word, confidence = entry.freq / 255.0))
+                        add(WordSuggestionCandidate(
+                            entry.word, secondaryText = entry.shortcut,
+                            confidence = entry.freq / 255.0,
+                            isEligibleForAutoCommit=entry.shortcut == word, // only allow auto commit if exact match
+                        ))
                     }
                 }
             }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
@@ -216,6 +216,9 @@ fun ComputingEvaluator.computeIconResId(data: KeyData): Int? {
         KeyCode.SETTINGS -> {
             R.drawable.ic_settings
         }
+        KeyCode.ADD_USER_DICTIONARY -> {
+            R.drawable.ic_library_books
+        }
         KeyCode.SHIFT -> {
             when (evaluator.state.inputShiftState != InputShiftState.UNSHIFTED) {
                 true -> R.drawable.ic_keyboard_capslock

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -26,7 +26,9 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.MutableLiveData
 import dev.patrickgold.florisboard.FlorisImeService
 import dev.patrickgold.florisboard.R
+import dev.patrickgold.florisboard.app.Routes
 import dev.patrickgold.florisboard.app.florisPreferenceModel
+import dev.patrickgold.florisboard.app.settings.dictionary.UserDictionaryType
 import dev.patrickgold.florisboard.appContext
 import dev.patrickgold.florisboard.clipboardManager
 import dev.patrickgold.florisboard.editorInstance
@@ -718,6 +720,11 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             KeyCode.LANGUAGE_SWITCH -> handleLanguageSwitch()
             KeyCode.REDO -> editorInstance.performRedo()
             KeyCode.SETTINGS -> FlorisImeService.launchSettings()
+            KeyCode.ADD_USER_DICTIONARY -> FlorisImeService.launchSettings(
+                route=Routes.Settings.UserDictionaryAdd(
+                    UserDictionaryType.FLORIS, locale=subtypeManager.activeSubtype.primaryLocale.localeTag()
+                )
+            )
             KeyCode.SHIFT -> handleShiftUp(data)
             KeyCode.SPACE -> handleSpace(data)
             KeyCode.SYSTEM_INPUT_METHOD_PICKER -> InputMethodUtils.showImePicker(appContext)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
@@ -21,7 +21,6 @@ import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.dictionary.DictionaryManager
 import dev.patrickgold.florisboard.ime.editor.EditorContent
 import dev.patrickgold.florisboard.ime.editor.EditorRange
-import dev.patrickgold.florisboard.lib.FlorisLocale
 
 /**
  * Base interface for any NLP provider implementation. NLP providers maintain their own internal state and only receive
@@ -152,47 +151,20 @@ interface SuggestionProvider : NlpProvider {
         allowPossiblyOffensive: Boolean,
         isPrivateSession: Boolean,
     ): List<SuggestionCandidate> {
-        return if (! isPrivateSession) {
+        return if (!isPrivateSession && content.composingText.isNotEmpty()) {
             // load user dictionary. Should this be put here, or in the preload() for every SuggestionProvider?
             dictionaryManager.loadUserDictionariesIfNecessary()
             // assuming no offensive ones in the dictionary?
             val subtypeLocale = subtype.primaryLocale
             // Use locale and parent locales. TODO: control this by a pref?
-            val queryLocales = buildList {
-                add(subtypeLocale)
-                if (subtypeLocale.variant.isNotBlank()) {
-                    add(FlorisLocale.from(subtypeLocale.language, subtypeLocale.country))
-                }
-                if (subtypeLocale.country.isNotBlank()) {
-                    add(FlorisLocale.from(subtypeLocale.language))
-                }
-            }
-            // For all locales, add queries sorted by confidence then alphabetical.
-            val totalCandidates = buildList {
-                for (locale in queryLocales) {
-                    val candidates = dictionaryManager.queryUserDictionary(content.composingText, locale)
-                    addAll(candidates.sortedWith(
-                        compareByDescending<SuggestionCandidate> { it.confidence }.thenBy { it.text.toString() }
-                    ))
-                    // Stop when max reached
-                    if (size >= maxCandidateCount) {
-                        break
-                    }
-                }
-            }.toMutableList()
-            // Make the first candidate
-            val first = totalCandidates.getOrNull(0) as? WordSuggestionCandidate
-            if (first != null) {
-                totalCandidates[0] = WordSuggestionCandidate(
-                    text = first.text,
-                    secondaryText = first.secondaryText,
-                    confidence = first.confidence,
-                    isEligibleForAutoCommit = true,
-                    isEligibleForUserRemoval = first.isEligibleForUserRemoval,
-                    sourceProvider = first.sourceProvider,
-                )
-            }
-            return totalCandidates.toList().subList(0, maxCandidateCount.coerceAtMost(totalCandidates.size))
+            val totalCandidates = dictionaryManager.queryUserDictionary(
+                content.composingText, subtypeLocale
+            ).sortedWith(
+                // sorted by auto commit, confidence, then alphabetical.
+                compareByDescending<SuggestionCandidate> { it.isEligibleForAutoCommit }.thenBy { it.confidence }.thenBy { it.text.toString() }
+            )
+            // Delegates to user dictionary query system (whether match is exact) for isEligibleForAutoCommit
+            return totalCandidates.subList(0, maxCandidateCount.coerceAtMost(totalCandidates.size))
         } else {
             emptyList()
         }
@@ -205,6 +177,7 @@ interface SuggestionProvider : NlpProvider {
     ): List<SuggestionCandidate> {
         // TODO: currently user dictionary supersedes other suggestions (except 1st one). Maybe use a pref to control this.
         val maxFromDictionary = (maxCandidateCount - fromNlp.size.coerceAtMost(1)).coerceAtLeast(0)
+        var existsEligibleForAutoCommit = false
         return buildList {
             addAll(fromDictionary.subList(
                 0, maxFromDictionary.coerceAtMost(fromDictionary.size)
@@ -213,6 +186,20 @@ interface SuggestionProvider : NlpProvider {
             addAll(fromNlp.subList(
                 0, remaining.coerceAtMost(fromNlp.size)
             ))
+        }.map { suggestionCandidate ->
+            // Only keep 1st isEligibleForAutoCommit true, set others to false
+            when (suggestionCandidate) {
+                is WordSuggestionCandidate -> {
+                    suggestionCandidate.copy(
+                        isEligibleForAutoCommit = if (existsEligibleForAutoCommit) false
+                        else suggestionCandidate.isEligibleForAutoCommit
+                    )
+                }
+                is ClipboardSuggestionCandidate -> suggestionCandidate
+                else -> suggestionCandidate
+            }.also {
+                existsEligibleForAutoCommit = existsEligibleForAutoCommit || suggestionCandidate.isEligibleForAutoCommit
+            }
         }
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
@@ -197,7 +197,7 @@ class HanShapeBasedLanguageProvider(val context: Context) : SpellingProvider, Su
                         text = "$word",
                         secondaryText = code,
                         confidence = 0.5,
-                        isEligibleForAutoCommit = userDictionarySuggestions.isEmpty() && (n == 0),
+                        isEligibleForAutoCommit = n == 0,
                         // We set ourselves as the source provider so we can get notify events for our candidate
                         sourceProvider = this@HanShapeBasedLanguageProvider,
                     ))

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
@@ -106,6 +106,13 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
         allowPossiblyOffensive: Boolean,
         isPrivateSession: Boolean,
     ): List<SuggestionCandidate> {
+        val userDictionarySuggestions = suggestFromUserDictionary(
+            subtype = subtype,
+            content = content,
+            maxCandidateCount = maxCandidateCount,
+            allowPossiblyOffensive = allowPossiblyOffensive,
+            isPrivateSession = isPrivateSession,
+        )
         val word = content.composingText.ifBlank { "next" }
         val suggestions = buildList {
             for (n in 0 until maxCandidateCount) {
@@ -119,7 +126,11 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
                 ))
             }
         }
-        return suggestions
+        return mergeFromSuggestionsSources(
+            userDictionarySuggestions,
+            suggestions,
+            maxCandidateCount
+        )
     }
 
     override suspend fun notifySuggestionAccepted(subtype: Subtype, candidate: SuggestionCandidate) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickAction.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickAction.kt
@@ -90,6 +90,7 @@ fun QuickAction.computeDisplayName(evaluator: ComputingEvaluator): String {
             KeyCode.IME_UI_MODE_CLIPBOARD -> R.string.quick_action__ime_ui_mode_clipboard
             KeyCode.IME_UI_MODE_MEDIA -> R.string.quick_action__ime_ui_mode_media
             KeyCode.SETTINGS -> R.string.quick_action__settings
+            KeyCode.ADD_USER_DICTIONARY -> R.string.quick_action__add_user_dictionary
             KeyCode.UNDO -> R.string.quick_action__undo
             KeyCode.REDO -> R.string.quick_action__redo
             KeyCode.TOGGLE_ACTIONS_OVERFLOW -> R.string.quick_action__toggle_actions_overflow
@@ -126,6 +127,7 @@ fun QuickAction.computeTooltip(evaluator: ComputingEvaluator): String {
             KeyCode.IME_UI_MODE_CLIPBOARD -> R.string.quick_action__ime_ui_mode_clipboard__tooltip
             KeyCode.IME_UI_MODE_MEDIA -> R.string.quick_action__ime_ui_mode_media__tooltip
             KeyCode.SETTINGS -> R.string.quick_action__settings__tooltip
+            KeyCode.ADD_USER_DICTIONARY -> R.string.quick_action__add_user_dictionary__tooltip
             KeyCode.UNDO -> R.string.quick_action__undo__tooltip
             KeyCode.REDO -> R.string.quick_action__redo__tooltip
             KeyCode.TOGGLE_ACTIONS_OVERFLOW -> R.string.quick_action__toggle_actions_overflow__tooltip

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickActionArrangement.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickActionArrangement.kt
@@ -73,6 +73,7 @@ data class QuickActionArrangement(
                 QuickAction.InsertKey(TextKeyData.CLIPBOARD_CUT),
                 QuickAction.InsertKey(TextKeyData.CLIPBOARD_PASTE),
                 QuickAction.InsertKey(TextKeyData.CLIPBOARD_SELECT_ALL),
+                QuickAction.InsertKey(TextKeyData.ADD_USER_DICTIONARY),
             ),
             hiddenActions = listOf(
             ),

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
@@ -108,6 +108,8 @@ object KeyCode {
 
     const val URI_COMPONENT_TLD =           -255
 
+    const val ADD_USER_DICTIONARY =         -260
+
     const val SETTINGS =                    -301
 
     const val CURRENCY_SLOT_1 =             -801

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
@@ -151,6 +151,7 @@ class TextKeyData(
                 IME_SHOW_UI,
                 IME_HIDE_UI,
                 SETTINGS,
+                ADD_USER_DICTIONARY,
                 VOICE_INPUT,
                 TOGGLE_SMARTBAR_VISIBILITY,
                 TOGGLE_ACTIONS_OVERFLOW,
@@ -476,6 +477,13 @@ class TextKeyData(
             type = KeyType.CHARACTER,
             code = KeyCode.SETTINGS,
             label = "settings",
+        )
+
+        /** Predefined key data for [KeyCode.ADD_USER_DICTIONARY] */
+        val ADD_USER_DICTIONARY = TextKeyData(
+            type = KeyType.CHARACTER,
+            code = KeyCode.ADD_USER_DICTIONARY,
+            label = "add_user_dictionary",
         )
 
         /** Predefined key data for [KeyCode.VOICE_INPUT] */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,8 +58,8 @@
     <string name="quick_action__ime_ui_mode_media__tooltip">Open emoji panel</string>
     <string name="quick_action__settings" maxLength="12">Settings</string>
     <string name="quick_action__settings__tooltip">Open settings</string>
-    <string name="quick_action__add_user_dictionary" maxLength="12">Add dictionary</string>
-    <string name="quick_action__add_user_dictionary__tooltip">Add a word to user dictionary</string>
+    <string name="quick_action__add_user_dictionary" maxLength="12">+ user dictionary</string>
+    <string name="quick_action__add_user_dictionary__tooltip">Add a word to internal user dictionary</string>
     <string name="quick_action__undo" maxLength="12">Undo</string>
     <string name="quick_action__undo__tooltip">Undo the last input</string>
     <string name="quick_action__redo" maxLength="12">Redo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="quick_action__ime_ui_mode_media__tooltip">Open emoji panel</string>
     <string name="quick_action__settings" maxLength="12">Settings</string>
     <string name="quick_action__settings__tooltip">Open settings</string>
+    <string name="quick_action__add_user_dictionary" maxLength="12">Add dictionary</string>
+    <string name="quick_action__add_user_dictionary__tooltip">Add a word to user dictionary</string>
     <string name="quick_action__undo" maxLength="12">Undo</string>
     <string name="quick_action__undo__tooltip">Undo the last input</string>
     <string name="quick_action__redo" maxLength="12">Redo</string>


### PR DESCRIPTION
This PR adds custom-defined dictionary into the suggestions for both Latin and HanShapeBased providers, and the fallback one.

This is ~again based on #2054 and includes changes from #2093. For now, only the last commit is specific to this PR~ rebased on to master.

~TODO:~
- ~Add default language values to the entries based on which screen the user is on.~ :heavy_check_mark: done
- ~Fix bugs in Latin that (1) auto-commits, and (2) matches empty text and non-starting positions (feature or a bug?).~ :heavy_check_mark: done
- ~The added quick action does not show up unless you delete the app's data and start over. Need to fix.~ :heavy_check_mark: done

Update: fixed these issue and added a quick action button to add things to the internal user dictionary.