### PR TITLE
CJK keyboard adjustments for better Chinese input convenience

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbols/cjk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbols/cjk.json
@@ -122,14 +122,15 @@
           "relevant": [
             { "code": 12304, "label": "【" },
             { "code": 12310, "label": "〖" },
-            { "code": 65288, "label": "（" }
+            { "code": 65288, "label": "（" },
+            { "code": 65339, "label": "［" }
           ]
         }
       },
       "half": { "code": 65378, "label": "｢", "popup": {
-          "main": { "code": 12301, "label": "」" },
+          "main": { "code": 12300, "label": "「" },
           "relevant": [
-            { "code": 12303, "label": "』" },
+            { "code": 12302, "label": "『" },
             { "code": 12304, "label": "【" },
             { "code": 12310, "label": "〖" },
             { "code":    40, "label": "(" },
@@ -145,7 +146,8 @@
           "relevant": [
             { "code": 12305, "label": "】" },
             { "code": 12311, "label": "〗" },
-            { "code": 65289, "label": "）" }
+            { "code": 65289, "label": "）" },
+            { "code": 65341, "label": "］" }
           ]
         }
       },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbols/cjk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbols/cjk.json
@@ -8,15 +8,13 @@
       },
       "half": { "code": 64, "label": "@" }
     },
-    { "code": 12306, "label": "〒", "popup": {
-        "main": { "code": 12320, "label": "〠" }
-      }
-    },
     {
       "$": "char_width_selector",
       "full": { "code": 65283, "label": "＃", "popup": {
           "main": { "code": 35, "label": "#" },
           "relevant": [
+            { "code": 12306, "label": "〒"},
+            { "code": 12320, "label": "〠" },
             { "code": 8470, "label": "№" }
           ]
         }
@@ -24,6 +22,8 @@
       "half": { "code": 35, "label": "#", "popup": {
           "main": { "code": 65283, "label": "＃" },
           "relevant": [
+            { "code": 12306, "label": "〒"},
+            { "code": 12320, "label": "〠" },
             { "code": 8470, "label": "№" }
           ]
         }
@@ -99,14 +99,18 @@
       "full": { "code": 65291, "label": "＋", "popup": {
           "main": { "code": 43, "label": "+" },
           "relevant": [
-            { "code": 177, "label": "±" }
+            { "code":   177, "label": "±" },
+            { "code":    61, "label": "=" },
+            { "code": 65309, "label": "＝" }
           ]
         }
       },
       "half": { "code": 43, "label": "+", "popup": {
           "main": { "code": 65291, "label": "＋" },
           "relevant": [
-            { "code": 177, "label": "±" }
+            { "code":   177, "label": "±" },
+            { "code":    61, "label": "=" },
+            { "code": 65309, "label": "＝" }
           ]
         }
       }
@@ -117,7 +121,8 @@
           "main": { "code": 12302, "label": "『" },
           "relevant": [
             { "code": 12304, "label": "【" },
-            { "code": 12310, "label": "〖" }
+            { "code": 12310, "label": "〖" },
+            { "code": 65288, "label": "（" }
           ]
         }
       },
@@ -126,7 +131,9 @@
           "relevant": [
             { "code": 12303, "label": "』" },
             { "code": 12304, "label": "【" },
-            { "code": 12310, "label": "〖" }
+            { "code": 12310, "label": "〖" },
+            { "code":    40, "label": "(" },
+            { "code":    91, "label": "[" }
           ]
         }
       }
@@ -137,7 +144,8 @@
           "main": { "code": 12303, "label": "』" },
           "relevant": [
             { "code": 12305, "label": "】" },
-            { "code": 12311, "label": "〗" }
+            { "code": 12311, "label": "〗" },
+            { "code": 65289, "label": "）" }
           ]
         }
       },
@@ -146,7 +154,9 @@
           "relevant": [
             { "code": 12303, "label": "』" },
             { "code": 12305, "label": "】" },
-            { "code": 12311, "label": "〗" }
+            { "code": 12311, "label": "〗" },
+            { "code":    41, "label": ")" },
+            { "code":    93, "label": "]" }
           ]
         }
       }

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbols2/cjk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbols2/cjk.json
@@ -54,7 +54,9 @@
           ]
         } }
     },
-    { "code": 8730, "label": "√" },
+    { "code": 8730, "label": "√", "popup": {
+      "main": { "code": 10003, "label": "✓" }
+    } },
     { "code":  960, "label": "π", "popup": {
       "main": { "code":  928, "label": "Π" },
       "relevant": [
@@ -104,7 +106,7 @@
         { "code":   61, "label": "=", "popup": {
           "main": { "code": 8800, "label": "≠" },
           "relevant": [
-            { "code":   61, "label": "=" },
+            { "code": 65309, "label": "＝" },
             { "code": 8734, "label": "∞" },
             { "code": 8776, "label": "≈" }
           ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbols2Mod/cjk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbols2Mod/cjk.json
@@ -6,15 +6,28 @@
   ],
   [
     { "code": -201, "label": "view_characters", "type": "system_gui" },
-    { "code": 12296, "label": "〈", "popup": {
-      "main": { "code": 12298, "label": "《" },
-      "relevant": [
-        { "code":  8804, "label": "≤" },
-        { "code":  8249, "label": "‹" },
-        { "code": 10216, "label": "⟨" },
-        { "code": 65308, "label": "＜" }
-      ]
-    } },
+    { "$": "char_width_selector",
+      "full": { "code": 12296, "label": "〈", "popup": {
+        "main": { "code": 12298, "label": "《" },
+        "relevant": [
+          { "code":    60, "label": "<" },
+          { "code":  8804, "label": "≤" },
+          { "code":  8249, "label": "‹" },
+          { "code": 10216, "label": "⟨" },
+          { "code": 65308, "label": "＜" }
+        ]
+      } },
+      "half": { "code":    60, "label": "<", "popup": {
+        "main": { "code": 12298, "label": "《" },
+        "relevant": [
+          { "code": 12296, "label": "〈" },
+          { "code":  8804, "label": "≤" },
+          { "code":  8249, "label": "‹" },
+          { "code": 10216, "label": "⟨" },
+          { "code": 65308, "label": "＜" }
+        ]
+      } }
+    },
     { "code": -205, "label": "view_numeric_advanced", "type": "system_gui" },
     { "code": 12288, "label": "空白" },
     { "code": -9701, "label": "char_width_switcher", "type": "system_gui", "popup": {
@@ -24,15 +37,28 @@
         ]
       }
     },
-    { "code": 12297, "label": "〉", "popup": {
-      "main": { "code": 12299, "label": "》" },
-      "relevant": [
-        { "code":    62, "label": ">" },
-        { "code":  8805, "label": "≥" },
-        { "code": 10217, "label": "⟩" },
-        { "code": 65310, "label": "＞" }
-      ]
-    } },
+    { "$": "char_width_selector",
+      "full": { "code": 12297, "label": "〉", "popup": {
+        "main": { "code": 12299, "label": "》" },
+        "relevant": [
+          { "code":    62, "label": ">" },
+          { "code":  8805, "label": "≥" },
+          { "code":  8250, "label": "›" },
+          { "code": 10217, "label": "⟩" },
+          { "code": 65310, "label": "＞" }
+        ]
+      } },
+      "half": { "code":    62, "label": ">", "popup": {
+        "main": { "code": 12299, "label": "》" },
+        "relevant": [
+          { "code": 12297, "label": "〉" },
+          { "code":  8805, "label": "≥" },
+          { "code":  8250, "label": "›" },
+          { "code": 10217, "label": "⟩" },
+          { "code": 65310, "label": "＞" }
+        ]
+      } }
+    },
     { "code":   10, "label": "enter", "groupId": 3, "type": "enter_editing" }
   ]
 ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbolsMod/cjk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbolsMod/cjk.json
@@ -8,11 +8,17 @@
     { "code": -201, "label": "view_characters", "type": "system_gui" },
     { "$": "char_width_selector",
       "full": { "code": 12289, "label": "、", "popup": {
-          "main": { "code": 65292, "label": "，" }
+          "main": { "code":   65292, "label": "，" },
+          "relevant": [
+            { "code":   44, "label": "," }
+          ]
         }
       },
       "half": { "code": 65380, "label": "､", "popup": {
-          "main": { "code":   44, "label": "," }
+          "main": { "code":   44, "label": "," },
+          "relevant": [
+            { "code":   65292, "label": "，" }
+          ]
         }
       }
     },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -31,6 +31,7 @@
     { "id": "bg", "authors": [ "iorvethe" ] },
     { "id": "bn-BD", "authors": [ "iamrasel" ] },
     { "id": "ca", "authors": [ "mikelloc" ] },
+    { "id": "cjk", "authors": [ "moonbeamcelery" ] },
     { "id": "ckb", "authors": [ "GoRaN" ] },
     { "id": "cs", "authors": [ "stefan-misik" ] },
     { "id": "da", "authors": [ "patrickgold" ] },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -656,7 +656,7 @@
         "suggestion": "org.florisboard.nlp.providers.han.shape"
       },
       "currencySet": "org.florisboard.currencysets:yen",
-      "popupMapping": "org.florisboard.localization:en",
+      "popupMapping": "org.florisboard.localization:cjk",
       "preferred": {
         "characters": "org.florisboard.layouts:qwerty",
         "symbols": "org.florisboard.layouts:cjk",

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cjk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cjk.json
@@ -1,0 +1,118 @@
+{
+  "all": {
+    "a": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  257, "label": "ā" },
+        { "$": "auto_text_key", "code":  225, "label": "á" },
+        { "$": "auto_text_key", "code":  462, "label": "ǎ" },
+        { "$": "auto_text_key", "code":  224, "label": "à" },
+        { "$": "auto_text_key", "code":  230, "label": "æ" },
+        { "$": "auto_text_key", "code":  227, "label": "ã" },
+        { "$": "auto_text_key", "code":  229, "label": "å" },
+        { "$": "auto_text_key", "code":  226, "label": "â" },
+        { "$": "auto_text_key", "code":  228, "label": "ä" }
+      ]
+    },
+    "c": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  231, "label": "ç" }
+      ]
+    },
+    "e": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  275, "label": "ē" },
+        { "$": "auto_text_key", "code":  233, "label": "é" },
+        { "$": "auto_text_key", "code":  283, "label": "ě" },
+        { "$": "auto_text_key", "code":  232, "label": "è" },
+        { "$": "auto_text_key", "code":  234, "label": "ê" },
+        { "$": "auto_text_key", "code":  235, "label": "ë" }
+      ]
+    },
+    "i": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  299, "label": "ī" },
+        { "$": "auto_text_key", "code":  237, "label": "í" },
+        { "$": "auto_text_key", "code":  464, "label": "ǐ" },
+        { "$": "auto_text_key", "code":  236, "label": "ì" },
+        { "$": "auto_text_key", "code":  239, "label": "ï" },
+        { "$": "auto_text_key", "code":  238, "label": "î" }
+      ]
+    },
+    "n": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  241, "label": "ñ" },
+        { "$": "auto_text_key", "code":  324, "label": "ń" }
+      ]
+    },
+    "o": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  333, "label": "ō" },
+        { "$": "auto_text_key", "code":  243, "label": "ó" },
+        { "$": "auto_text_key", "code":  466, "label": "ǒ" },
+        { "$": "auto_text_key", "code":  242, "label": "ò" },
+        { "$": "auto_text_key", "code":  245, "label": "õ" },
+        { "$": "auto_text_key", "code":  339, "label": "œ" },
+        { "$": "auto_text_key", "code":  248, "label": "ø" },
+        { "$": "auto_text_key", "code":  246, "label": "ö" },
+        { "$": "auto_text_key", "code":  244, "label": "ô" }
+      ]
+    },
+    "s": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  223, "label": "ß" }
+      ]
+    },
+    "u": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  363, "label": "ū" },
+        { "$": "auto_text_key", "code":  250, "label": "ú" },
+        { "$": "auto_text_key", "code":  468, "label": "ǔ" },
+        { "$": "auto_text_key", "code":  249, "label": "ù" },
+        { "$": "auto_text_key", "code":  252, "label": "ü" },
+        { "$": "auto_text_key", "code":  252, "label": "ü" },
+        { "$": "auto_text_key", "code":  470, "label": "ǖ" },
+        { "$": "auto_text_key", "code":  472, "label": "ǘ" },
+        { "$": "auto_text_key", "code":  474, "label": "ǚ" },
+        { "$": "auto_text_key", "code":  476, "label": "ǜ" },
+        { "$": "auto_text_key", "code":  251, "label": "û" }
+      ]
+    },
+    "~right": {
+      "main": { "code":   44, "label": "," },
+      "relevant": [
+        { "code":   38, "label": "&" },
+        { "code":   37, "label": "%" },
+        { "code":   43, "label": "+" },
+        { "code":   34, "label": "\"" },
+        { "code":   45, "label": "-" },
+        { "code":   58, "label": ":" },
+        { "code":   39, "label": "'" },
+        { "code":   64, "label": "@" },
+        { "code":   59, "label": ";" },
+        { "code":   47, "label": "/" },
+        { "$": "layout_direction_selector",
+          "ltr": { "code":   40, "label": "(" },
+          "rtl": { "code":   41, "label": "(" }
+        },
+        { "$": "layout_direction_selector",
+          "ltr": { "code":   41, "label": ")" },
+          "rtl": { "code":   40, "label": ")" }
+        },
+        { "code":   35, "label": "#" },
+        { "code":   33, "label": "!" },
+        { "code":   63, "label": "?" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".com" },
+      "relevant": [
+        { "code": -255, "label": ".gov" },
+        { "code": -255, "label": ".edu" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".net" }
+      ]
+    }
+  }
+}

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cjk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cjk.json
@@ -69,7 +69,6 @@
         { "$": "auto_text_key", "code":  468, "label": "ǔ" },
         { "$": "auto_text_key", "code":  249, "label": "ù" },
         { "$": "auto_text_key", "code":  252, "label": "ü" },
-        { "$": "auto_text_key", "code":  252, "label": "ü" },
         { "$": "auto_text_key", "code":  470, "label": "ǖ" },
         { "$": "auto_text_key", "code":  472, "label": "ǘ" },
         { "$": "auto_text_key", "code":  474, "label": "ǚ" },


### PR DESCRIPTION
- fix full-width comma
- add () to first symbol screen popups
- merge postal sign with # popups
- add = to + popup
- add full-width = to half-width popup
- fix half-width <> and single guillemets ‹›
- add check mark to square root symbol popup
- Add [] to popups
- Add pinyin characters in popup mapping

TODO:
- Consider making the full- and half-width toggle instead have three states. Add a state that is full-width for punctuation but half-width for other characters.
- Actually test