### PR TITLE
Add neo keyboard layout variant: mine

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/mine.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/mine.json
@@ -1,0 +1,45 @@
+[
+  [
+    { "$": "auto_text_key", "code":  106, "label": "j" },
+    { "$": "auto_text_key", "code":  108, "label": "l" },
+    { "$": "auto_text_key", "code":  117, "label": "u" },
+    { "$": "auto_text_key", "code":   97, "label": "a" },
+    { "$": "auto_text_key", "code":  113, "label": "q" },
+    { "$": "auto_text_key", "code":  119, "label": "w" },
+    { "$": "auto_text_key", "code":   98, "label": "b" },
+    { "$": "auto_text_key", "code":  100, "label": "d" },
+    { "$": "auto_text_key", "code":  103, "label": "g" },
+    { "$": "auto_text_key", "code":  121, "label": "y" },
+    { "$": "auto_text_key", "code":  122, "label": "z" },
+    { "$": "case_selector",
+      "lower": {
+        "code":  223, "label": "ß"
+      },
+      "upper": {
+        "code": 7838, "label": "ẞ"
+      }
+    }
+  ],
+  [
+    { "$": "auto_text_key", "code":   99, "label": "c" },
+    { "$": "auto_text_key", "code":  114, "label": "r" },
+    { "$": "auto_text_key", "code":  105, "label": "i" },
+    { "$": "auto_text_key", "code":  101, "label": "e" },
+    { "$": "auto_text_key", "code":  111, "label": "o" },
+    { "$": "auto_text_key", "code":  109, "label": "m" },
+    { "$": "auto_text_key", "code":  110, "label": "n" },
+    { "$": "auto_text_key", "code":  116, "label": "t" },
+    { "$": "auto_text_key", "code":  115, "label": "s" },
+    { "$": "auto_text_key", "code":  104, "label": "h" }
+  ],
+  [
+    { "$": "auto_text_key", "code":  118, "label": "v" },
+    { "$": "auto_text_key", "code":  120, "label": "x" },
+    { "$": "auto_text_key", "code":  252, "label": "ü" },
+    { "$": "auto_text_key", "code":  228, "label": "ä" },
+    { "$": "auto_text_key", "code":  246, "label": "ö" },
+    { "$": "auto_text_key", "code":  112, "label": "p" },
+    { "$": "auto_text_key", "code":  102, "label": "f" },
+    { "$": "auto_text_key", "code":  107, "label": "k" }
+  ]
+]


### PR DESCRIPTION
Thank you very much for your great work on this project!

This patch adds the current version of neo's `mine` layout. It is based on the the `bone.json` and the values are adapted according to https://neo-layout.org/Layouts/mine/.

Notes:

1. This layout misses the last key on the middle row, as that's an accent key in mine's original version.
   How are cases like this handled in other layouts?
1. There is a `neobone` localization (extension). 
   As `mine` also belongs to the neo family do I also need to create an `neomine` extension?