### PR TITLE
Remove redundant Kashida key in Persian layout

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/charactersMod/persian.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/charactersMod/persian.json
@@ -14,7 +14,6 @@
     { "code": -212, "label": "ime_ui_mode_media", "type": "system_gui" },
     { "code":   32, "label": "space" },
     { "code": 8204, "label": "half_space" },
-    { "code": 1600, "label": "kashida" },
     { "code":   46, "label": ".", "groupId": 2 },
     { "code":   10, "label": "enter", "groupId": 3, "type": "enter_editing" }
   ]


### PR DESCRIPTION
There is a Kashida(code: 1600) key inside
the popup of Dot key(code: 46). The Kashida is
a very low use character in Persian writing, so
removing it from the main layout improves the
layout usability by increasing the width of the
Space-bar.