### PR TITLE
Fix uppercase behaviour with telex

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/composing/Composer.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/composing/Composer.kt
@@ -58,8 +58,13 @@ class WithRules(
         for (key in ruleOrder) {
             if (str.lowercase().endsWith(key)) {
                 val value = rules.getValue(key)
-                val firstOfKey = str.takeLast(key.length).take(1)
-                return (key.length - 1) to (if (firstOfKey.uppercase() == firstOfKey) value.uppercase() else value)
+                val matchingPart = str.takeLast(key.length) // the part of the string that matches the key
+                val firstOfKey = matchingPart.take(1)
+                return (key.length - 1) to when {
+                    matchingPart.uppercase() == matchingPart -> value.uppercase()
+                    firstOfKey.uppercase() == firstOfKey -> value.replaceFirstChar(Char::titlecase)
+                    else -> value
+                }
             }
         }
         return 0 to toInsert


### PR DESCRIPTION
Basically in the current master code, when typing for example Anhs, 'A' is uppercase and this decides that the whole result of the rule will be uppercased (ÁNH), which is most likely not what the user intended. We only want the first character to be uppercased, so we can replace "value.uppercase()" with "value.replaceFirstChar(Char::titlecase)".
However, this fix would also mean that typing ANHS gives Ánh as a result, which is also most likely not what the user intended.

So the proper fix is a better case detection and management, such as
- If every character was uppercase, then uppercase the whole result (ANHS→ÁNH).
- Else if only the first character was uppercase, then only uppercase the first character in the result (Anhs→Ánh).
- Else if everything was lowercase, keep everything lowercase (anhs→ánh).
- Else, well this is a weird case and I guess anything is acceptable for such a rare case? (aNhs→ánh for example).

Closes #2260.