### PR TITLE
Upgrade traget SDK to 34 and cleanup code base

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ src=".github/repo_icon.png" alt="App icon">
 devices. It aims at being modern, user-friendly and customizable while
 fully respecting your privacy. Currently in early-beta state.
 
+*Note: Due to various reasons development has been quite stuck in the past year, but things are slowly improving again and new releases/features will follow in the near future, please see the [roadmap](ROADMAP.md) for details!*
+
 <table>
 <tr>
 <th align="center" width="50%">
@@ -18,10 +20,10 @@ fully respecting your privacy. Currently in early-beta state.
 </tr>
 <tr>
 <td valign="top">
-<p><i>Major versions only, 1 release per 1-5 months</i><br><br>Updates are more polished, new features are matured and tested through to ensure a stable experience.</p>
+<p><i>Major versions only</i><br><br>Updates are more polished, new features are matured and tested through to ensure a stable experience.</p>
 </td>
 <td valign="top">
-<p><i>Beta versions, up to 1-2 releases per week</i><br><br>Updates contain new features that may not be fully matured yet and bugs are more likely to occur. Allows you to give early feedback.</p>
+<p><i>Alpha/Beta versions</i><br><br>Updates contain new features that may not be fully matured yet and bugs are more likely to occur. Allows you to give early feedback.</p>
 </td>
 </tr>
 <tr>
@@ -62,10 +64,8 @@ Beginning with v0.6.0 FlorisBoard will enter the public beta on Google Play.
 - Advanced theming support and customization
 - Integrated extension support (still evolving)
 - Emoji keyboard
-- Spell checking service
-- Glide typing (currently English only)
 
-Word suggestions are not included in the current releases and are a major goal for the v0.4.0 milestone.
+Word suggestions/spell checking are not included in the current releases and are a major goal for the v0.5.0 milestone.
 
 Feature roadmap: See [ROADMAP.md](ROADMAP.md)
 
@@ -97,8 +97,6 @@ to get more information on this topic.
   [Kotlin](https://github.com/Kotlin)
 * [ICU4C](https://github.com/unicode-org/icu) by
   [The Unicode Consortium](https://github.com/unicode-org)
-* [Nuspell](https://github.com/nuspell/nuspell) by
-  [Nuspell](https://github.com/nuspell)
 
 Many thanks to [Nikolay Anzarov](https://www.behance.net/nikolayanzarov) ([@BloodRaven0](https://github.com/BloodRaven0)) for designing and providing the main app icons to this project!
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,11 +29,20 @@ plugins {
     alias(libs.plugins.mikepenz.aboutlibraries)
 }
 
+val projectMinSdk: String by project
+val projectTargetSdk: String by project
+val projectCompileSdk: String by project
+val projectBuildToolsVersion: String by project
+val projectNdkVersion: String by project
+val projectVersionCode: String by project
+val projectVersionName: String by project
+val projectVersionNameSuffix: String by project
+
 android {
     namespace = "dev.patrickgold.florisboard"
-    compileSdk = 33
-    buildToolsVersion = "33.0.2"
-    ndkVersion = "26.1.10909125"
+    compileSdk = projectCompileSdk.toInt()
+    buildToolsVersion = projectBuildToolsVersion
+    ndkVersion = projectNdkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -51,10 +60,10 @@ android {
 
     defaultConfig {
         applicationId = "dev.patrickgold.florisboard"
-        minSdk = 24
-        targetSdk = 33
-        versionCode = 90
-        versionName = "0.4.0"
+        minSdk = projectMinSdk.toInt()
+        targetSdk = projectTargetSdk.toInt()
+        versionCode = projectVersionCode.toInt()
+        versionName = projectVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -139,7 +148,7 @@ android {
 
         create("beta") {
             applicationIdSuffix = ".beta"
-            versionNameSuffix = "-alpha04"
+            versionNameSuffix = projectVersionNameSuffix
 
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             isMinifyEnabled = true
@@ -152,6 +161,8 @@ android {
         }
 
         named("release") {
+            versionNameSuffix = projectVersionNameSuffix
+
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             isMinifyEnabled = true
             isShrinkResources = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-// Suppress needed until https://youtrack.jetbrains.com/issue/KTIJ-19369 is fixed
-@file:Suppress("DSL_SCOPE_VIOLATION")
-
 import java.io.ByteArrayOutputStream
 import java.io.File
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
@@ -203,7 +203,7 @@ class ThemeManager(context: Context) {
         val chipStyle = style.getStatic(FlorisImeUi.SmartbarSharedActionsToggle)
         val bgColor = chipStyle.background.solidColor(context)
         val fgColor = chipStyle.foreground.solidColor(context)
-        val bgDrawableId = R.drawable.autofill_inline_suggestion_chip_background
+        val bgDrawableId = androidx.autofill.R.drawable.autofill_inline_suggestion_chip_background
         val stylesBuilder = UiVersions.newStylesBuilder()
         val suggestionStyle = InlineSuggestionUi.newStyleBuilder()
             .setSingleIconChipStyle(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-// Suppress needed until https://youtrack.jetbrains.com/issue/KTIJ-19369 is fixed
-@file:Suppress("DSL_SCOPE_VIOLATION")
-
 plugins {
     alias(libs.plugins.agp.application) apply false
     alias(libs.plugins.agp.test) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,9 @@ org.gradle.warning.mode=all
 
 ### FlorisBoard-specific flags ###
 projectMinSdk=24
-projectTargetSdk=33
-projectCompileSdk=33
-projectBuildToolsVersion=33.0.2
+projectTargetSdk=34
+projectCompileSdk=34
+projectBuildToolsVersion=34.0.0
 projectNdkVersion=26.1.10909125
 
 projectVersionCode=90

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 android.defaults.buildfeatures.buildconfig=true
-android.nonFinalResIds=false
-android.nonTransitiveRClass=false
+android.nonFinalResIds=true
+android.nonTransitiveRClass=true
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,19 @@
-# Use AndroidX package structure - https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
-# Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Set max Gradle JVM memory to 4 Gigabytes
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true
 org.gradle.warning.mode=all
+
+### FlorisBoard-specific flags ###
+projectMinSdk=24
+projectTargetSdk=33
+projectCompileSdk=33
+projectBuildToolsVersion=33.0.2
+projectNdkVersion=26.1.10909125
+
+projectVersionCode=90
+projectVersionName=0.4.0
+projectVersionNameSuffix=-alpha04

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=4159b938ec734a8388ce03f52aa8f3c7ed0d31f5438622545de4f83a89b79788
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades the target SDK to 34 to comply with Google's guidelines. Additionally we migrate to using non-transitive R-classes, other dependencies are upgraded and some minor cleanup is done.