### PR TITLE
Implement #2173

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/onehanded/OneHandedPanel.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/onehanded/OneHandedPanel.kt
@@ -19,6 +19,8 @@ package dev.patrickgold.florisboard.ime.onehanded
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
@@ -29,6 +31,7 @@ import androidx.compose.ui.res.painterResource
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.florisPreferenceModel
 import dev.patrickgold.florisboard.ime.input.LocalInputFeedbackController
+import dev.patrickgold.florisboard.ime.keyboard.FlorisImeSizing
 import dev.patrickgold.florisboard.ime.theme.FlorisImeTheme
 import dev.patrickgold.florisboard.ime.theme.FlorisImeUi
 import dev.patrickgold.florisboard.lib.compose.stringRes
@@ -53,20 +56,26 @@ fun RowScope.OneHandedPanel(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceEvenly,
     ) {
-        IconButton(onClick = {
-            inputFeedbackController.keyPress()
-            prefs.keyboard.oneHandedMode.set(OneHandedMode.OFF)
-        }) {
+        IconButton(
+            onClick = {
+                inputFeedbackController.keyPress()
+                prefs.keyboard.oneHandedMode.set(OneHandedMode.OFF)
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
             Icon(
                 painter = painterResource(R.drawable.ic_zoom_out_map),
                 contentDescription = stringRes(R.string.one_handed__close_btn_content_description),
                 tint = oneHandedPanelStyle.foreground.solidColor(context),
             )
         }
-        IconButton(onClick = {
-            inputFeedbackController.keyPress()
-            prefs.keyboard.oneHandedMode.set(panelSide)
-        }) {
+        IconButton(
+            onClick = {
+                inputFeedbackController.keyPress()
+                prefs.keyboard.oneHandedMode.set(panelSide)
+            },
+            modifier = Modifier.height(FlorisImeSizing.keyboardUiHeight()).fillMaxWidth()
+        ) {
             Icon(
                 painter = painterResource(
                     if (panelSide == OneHandedMode.START) {


### PR DESCRIPTION
Closes: #2173 The arrow-button now extends to the full width and height of the free space in one-handed mode.