### PR TITLE
Add missing `udm` popup mapping

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -72,6 +72,7 @@
     { "id": "sr", "authors": [ "hedidnothingwrong", "GrbavaCigla" ] },
     { "id": "sv", "authors": [ "patrickgold" ] },
     { "id": "tr", "authors": [ "kisekinopureya", "patrickgold", "dvrnynr" ] },
+    { "id": "udm", "authors": [ "vorgoron" ] },
     { "id": "uk", "authors": [ "williamtheaker", "33kk", "honsiorovskyi" ] },
     { "id": "uk-cyr-ext", "authors": [ "williamtheaker", "33kk", "honsiorovskyi" ] },
     { "id": "ur-PK", "authors": [ "mubashir-rehman", "mirfatif" ] },


### PR DESCRIPTION
When selecting the Udmurt subtype preset, Florisboard does not find the `udm` popup mapping, even though the files for it exist in the repo.

From what I can gather, this should partly fix #2441. Users affected with the issue may need re-adding the Udmurt subtype preset or manually editing their keyboard layout to use the `udm` popup mapping.