### PR TITLE
Change files of Udmurt subtype

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/udmurt_compact.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/udmurt_compact.json
@@ -9,11 +9,7 @@
     { "$": "auto_text_key", "code":  1075, "label": "г" },
     { "$": "auto_text_key", "code":  1096, "label": "ш" },
     { "$": "auto_text_key", "code":  1097, "label": "щ" },
-    { "$": "auto_text_key", "code":  1079, "label": "з", "popup": {
-      "relevant": [
-        { "code": 1247, "label": "ӟ" }
-      ]
-    } },
+    { "$": "auto_text_key", "code":  1079, "label": "з" },
     { "$": "auto_text_key", "code":  1093, "label": "х" }
   ],
   [
@@ -23,34 +19,18 @@
     { "$": "auto_text_key", "code": 1072 , "label": "а" },
     { "$": "auto_text_key", "code": 1087 , "label": "п" },
     { "$": "auto_text_key", "code": 1088 , "label": "р" },
-    { "$": "auto_text_key", "code": 1086 , "label": "о", "popup": {
-      "relevant": [
-        { "code": 1255, "label": "ӧ" }
-      ]
-    } },
+    { "$": "auto_text_key", "code": 1086 , "label": "о" },
     { "$": "auto_text_key", "code": 1083 , "label": "л" },
     { "$": "auto_text_key", "code": 1076 , "label": "д" },
-    { "$": "auto_text_key", "code": 1078 , "label": "ж", "popup": {
-      "relevant": [
-        { "code": 1245, "label": "ӝ" }
-      ]
-    } },
+    { "$": "auto_text_key", "code": 1078 , "label": "ж" },
     { "$": "auto_text_key", "code": 1101 , "label": "э" }
   ],
   [
     { "$": "auto_text_key", "code": 1103 , "label": "я" },
-    { "$": "auto_text_key", "code": 1095 , "label": "ч", "popup": {
-      "relevant": [
-        { "code": 1269, "label": "ӵ" }
-      ]
-    } },
+    { "$": "auto_text_key", "code": 1095 , "label": "ч" },
     { "$": "auto_text_key", "code": 1089 , "label": "с" },
     { "$": "auto_text_key", "code": 1084 , "label": "м" },
-    { "$": "auto_text_key", "code": 1080 , "label": "и", "popup": {
-      "relevant": [
-        { "code": 1253, "label": "ӥ" }
-      ]
-    } },
+    { "$": "auto_text_key", "code": 1080 , "label": "и" },
     { "$": "auto_text_key", "code": 1090 , "label": "т" },
     { "$": "auto_text_key", "code": 1100 , "label": "ь" },
     { "$": "auto_text_key", "code": 1073 , "label": "б" },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/udmurt_compact.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/udmurt_compact.json
@@ -9,7 +9,7 @@
     { "$": "auto_text_key", "code":  1075, "label": "г" },
     { "$": "auto_text_key", "code":  1096, "label": "ш" },
     { "$": "auto_text_key", "code":  1097, "label": "щ" },
-    { "code":  1079, "label": "з", "popup": {
+    { "$": "auto_text_key", "code":  1079, "label": "з", "popup": {
       "relevant": [
         { "code": 1247, "label": "ӟ" }
       ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -72,6 +72,7 @@
     { "id": "sr", "authors": [ "hedidnothingwrong", "GrbavaCigla" ] },
     { "id": "sv", "authors": [ "patrickgold" ] },
     { "id": "tr", "authors": [ "kisekinopureya", "patrickgold", "dvrnynr" ] },
+    { "id": "udm", "authors": [ "vorgoron" ] },
     { "id": "uk", "authors": [ "williamtheaker", "33kk", "honsiorovskyi" ] },
     { "id": "uk-cyr-ext", "authors": [ "williamtheaker", "33kk", "honsiorovskyi" ] },
     { "id": "ur-PK", "authors": [ "mubashir-rehman", "mirfatif" ] },


### PR DESCRIPTION
There are some issues with the Udmurt subtype that this pull request tries to fix:

- When selecting the Udmurt subtype preset, Florisboard does not find and select the `udm` popup mapping.
- The key `з` stays lowercase, even when the keyboard is shifted/caps-locked.
- Popups stay lowercase, even when the keyboard is shifted/caps-locked.
    - When you try to fix this bullet point, some popup characters appear twice. (This pull request also fixes that.)

Fixes #2441