### PR TITLE
Add Diktor layout

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -462,7 +462,7 @@
         "direction": "rtl"
       },
       {
-	"id": "diktor",
+        "id": "diktor",
         "label": "Diktor",
         "authors": [ "kuroya2mouse" ],
         "direction": "ltr"

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -111,6 +111,13 @@
         "direction": "ltr"
       },
       {
+        "id": "diktor",
+        "label": "Diktor",
+        "authors": [ "kuroya2mouse" ],
+        "direction": "ltr",
+        "modifier": "org.florisboard.layouts:diktor"
+      },
+      {
         "id": "dvorak",
         "label": "Dvorak",
         "authors": [ "patrickgold" ],
@@ -453,6 +460,12 @@
         "label": "Arabic",
         "authors": [ "HeiWiper" ],
         "direction": "rtl"
+      },
+      {
+	"id": "diktor",
+        "label": "Diktor",
+        "authors": [ "kuroya2mouse" ],
+        "direction": "ltr"
       },
       {
         "id": "dvorak",

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/diktor.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/diktor.json
@@ -1,0 +1,49 @@
+[
+  [
+    { "$": "auto_text_key", "code":  1094, "label": "ц" },
+    { "$": "auto_text_key", "code":  1100, "label": "ь" },
+    { "$": "auto_text_key", "code":  1103, "label": "я" },
+    { "$": "case_selector",
+      "lower": { "code":   44, "label": ",", "popup": {
+        "relevant": [
+          { "code":   46, "label": "." }
+        ]
+      } },
+      "upper": { "code":   46, "label": ".", "popup": {
+        "relevant": [
+          { "code":   44, "label": "," }
+        ]
+      } }
+    },
+    { "$": "auto_text_key", "code":  1079, "label": "з" },
+    { "$": "auto_text_key", "code":  1074, "label": "в" },
+    { "$": "auto_text_key", "code":  1082, "label": "к" },
+    { "$": "auto_text_key", "code":  1076, "label": "д" },
+    { "$": "auto_text_key", "code":  1095, "label": "ч" },
+    { "$": "auto_text_key", "code":  1096, "label": "ш" },
+    { "$": "auto_text_key", "code":  1097, "label": "щ" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1091 , "label": "у" },
+    { "$": "auto_text_key", "code": 1080 , "label": "и" },
+    { "$": "auto_text_key", "code": 1077 , "label": "е" },
+    { "$": "auto_text_key", "code": 1086 , "label": "о" },
+    { "$": "auto_text_key", "code": 1072 , "label": "а" },
+    { "$": "auto_text_key", "code": 1083 , "label": "л" },
+    { "$": "auto_text_key", "code": 1085 , "label": "н" },
+    { "$": "auto_text_key", "code": 1090 , "label": "т" },
+    { "$": "auto_text_key", "code": 1089 , "label": "с" },
+    { "$": "auto_text_key", "code": 1088 , "label": "р" },
+    { "$": "auto_text_key", "code": 1081 , "label": "й" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1101 , "label": "э" },
+    { "$": "auto_text_key", "code": 1093 , "label": "х" },
+    { "$": "auto_text_key", "code": 1099 , "label": "ы" },
+    { "$": "auto_text_key", "code": 1102 , "label": "ю" },
+    { "$": "auto_text_key", "code": 1073 , "label": "б" },
+    { "$": "auto_text_key", "code": 1084 , "label": "м" },
+    { "$": "auto_text_key", "code": 1087 , "label": "п" },
+    { "$": "auto_text_key", "code": 1075 , "label": "г" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/charactersMod/diktor.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/charactersMod/diktor.json
@@ -1,0 +1,16 @@
+[
+  [
+    { "code":  -11, "label": "shift", "type": "modifier" },
+    { "code":    0, "type": "placeholder" },
+    { "code":   -7, "label": "delete", "type": "enter_editing" }
+  ],
+  [
+    { "code": -202, "label": "view_symbols", "type": "system_gui" },
+    { "$": "auto_text_key", "code":  1092, "label": "ф", "groupId": 1 },
+    { "code": -227, "label": "language_switch", "type": "system_gui" },
+    { "code": -212, "label": "ime_ui_mode_media", "type": "system_gui" },
+    { "code":   32, "label": "space" },
+    { "$": "auto_text_key", "code":  1078, "label": "ж", "groupId": 2 },
+    { "code":   10, "label": "enter", "groupId": 3, "type": "enter_editing" }
+  ]
+]


### PR DESCRIPTION
Diktor is an ergonomic layout for Russian language. (Russian analog of Dvorak)

https://olegp.name/software/diktor-keyboard-layout/geocities/
https://github.com/mshkrebtan/diktor

![Screenshot_20240620-011553_FlorisBoard Beta](https://github.com/florisboard/florisboard/assets/108447847/0e3a2709-84d9-4e37-9e42-cd12feddf0e3)

(I created this merge request because i'm so bored to inject diktor.json in every new update)