### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,7 +25,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,10 +36,12 @@ jobs:
 
       - name: Set up CMake and Ninja
         uses: lukka/get-cmake@latest
+
       - name: Build with Gradle
         # MUST call gradlew separately because of an OSS license plugin issue.
         # See https://github.com/google/play-services-plugins/issues/199
         run: ./gradlew clean && ./gradlew assembleDebug
+
       - uses: actions/upload-artifact@v4
         with:
           name: app-debug.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,11 +28,12 @@ jobs:
       - uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: '17'
           distribution: temurin
           cache: gradle
+
       - name: Set up CMake and Ninja
         uses: lukka/get-cmake@latest
       - name: Build with Gradle

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -40,7 +40,7 @@ jobs:
         # MUST call gradlew separately because of an OSS license plugin issue.
         # See https://github.com/google/play-services-plugins/issues/199
         run: ./gradlew clean && ./gradlew assembleDebug
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: app-debug.apk
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -24,5 +24,5 @@ jobs:
           download_translations: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CROWDIN_PROJECT_ID: ${{ secrets.FSEC_CROWDIN_PROJECT_ID }}
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.FSEC_CROWDIN_PERSONAL_TOKEN }}
+          FSEC_CROWDIN_PROJECT_ID: ${{ secrets.FSEC_CROWDIN_PROJECT_ID }}
+          FSEC_CROWDIN_PERSONAL_TOKEN: ${{ secrets.FSEC_CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -13,7 +13,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        
       - name: Upload
         uses: crowdin/github-action@1.4.0
         with:

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Upload
-        uses: crowdin/github-action@1.4.0
+        uses: crowdin/github-action@v2
         with:
           config: "crowdin.yml"
           upload_sources: true
@@ -24,5 +24,5 @@ jobs:
           download_translations: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FSEC_CROWDIN_PROJECT_ID: ${{ secrets.FSEC_CROWDIN_PROJECT_ID }}
-          FSEC_CROWDIN_PERSONAL_TOKEN: ${{ secrets.FSEC_CROWDIN_PERSONAL_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.FSEC_CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.FSEC_CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
This PR updates the Github Actions used in the `build` and `upload-to-crowdin` action to the latest (major) versions. This removes the dependency on Node.JS 16, which [was deprecated by GitHub](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/). Therefore, there should not be [deprecation warnings](https://github.com/florisboard/florisboard/actions/runs/9943663479) in action runs anymore. 