### PR TITLE
Switch to sliding navigation animation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,10 +42,11 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/floris_app_icon"
         android:label="@string/floris_app_name"
+        android:enableOnBackInvokedCallback="true"
         android:roundIcon="@mipmap/floris_app_icon_round"
         android:supportsRtl="true"
         android:theme="@style/FlorisAppTheme"
-        tools:targetApi="s">
+        tools:targetApi="tiramisu">
 
         <!-- Allow app to be profiled for benchmarking and baseline profile generation -->
         <profileable android:shell="true"/>

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/Routes.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/Routes.kt
@@ -17,8 +17,13 @@
 package dev.patrickgold.florisboard.app
 
 import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideIn
+import androidx.compose.animation.slideOut
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntOffset
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -174,6 +179,18 @@ object Routes {
             modifier = modifier,
             navController = navController,
             startDestination = startDestination,
+            enterTransition = {
+                slideIn { IntOffset(it.width, 0) } + fadeIn()
+            },
+            exitTransition = {
+                slideOut { IntOffset(-it.width, 0) } + fadeOut()
+            },
+            popEnterTransition = {
+                slideIn { IntOffset(-it.width, 0) } + fadeIn()
+            },
+            popExitTransition = {
+                slideOut { IntOffset(it.width, 0) } + fadeOut()
+            }
         ) {
             composable(Setup.Screen) { SetupScreen() }
 


### PR DESCRIPTION
Closes: #2526 
This PR replaces the animation that is played during settings navigation. Now it is the same as in the android settings.
In addition, predictive back was prepared with the `android:enableOnBackInvokedCallback="true"` manifest flag.