### PR TITLE
Fix transparent navigation bar color on older api levels

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/apptheme/Theme.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/apptheme/Theme.kt
@@ -18,17 +18,13 @@ package dev.patrickgold.florisboard.app.apptheme
 
 import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/FlorisScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/FlorisScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -41,6 +42,7 @@ import dev.patrickgold.florisboard.app.LocalNavController
 import dev.patrickgold.florisboard.app.florisPreferenceModel
 import dev.patrickgold.jetpref.datastore.ui.PreferenceLayout
 import dev.patrickgold.jetpref.datastore.ui.PreferenceUiContent
+import org.florisboard.lib.android.AndroidVersion
 
 @Composable
 fun FlorisScreen(builder: @Composable FlorisScreenScope.() -> Unit) {
@@ -122,12 +124,18 @@ private class FlorisScreenScopeImpl : FlorisScreenScope {
     fun Render() {
         val context = LocalContext.current
         val previewFieldController = LocalPreviewFieldController.current
+        val colorScheme = MaterialTheme.colorScheme
 
         SideEffect {
             val window = (context as Activity).window
             previewFieldController?.isVisible = previewFieldVisible
             window.statusBarColor = Color.Transparent.toArgb()
-            window.navigationBarColor = Color.Transparent.toArgb()
+            if (AndroidVersion.ATLEAST_API29_Q) {
+                window.navigationBarColor = Color.Transparent.toArgb()
+                window.isNavigationBarContrastEnforced = true
+            } else {
+                window.navigationBarColor = colorScheme.scrim.toArgb()
+            }
         }
 
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()


### PR DESCRIPTION
The system-navigation-bar color was adjusted so that it is usable on older API versions. Below is a comparison table showing the change. 

> [!NOTE]
> Even though the black navigation bar is probably not the cleanest solution, it is now much more usable. I also made sure not to use any deprecated functions in my implementation, which made the whole thing a bit more difficult and that's why I chose this solution

| API Level | Previously | Now |
|--------|--------|--------|
| 24 | ![Screenshot_20240816_002511](https://github.com/user-attachments/assets/a22a30dc-1d0d-4151-97d5-225af59180c8) | ![Screenshot_20240816_002404](https://github.com/user-attachments/assets/64aa48dc-8f06-4130-974c-22ac745cbb1b) |
| 26 | ![Screenshot_20240816_003138](https://github.com/user-attachments/assets/3a03cad7-65c5-4049-b5d6-44b934bb66e6) | ![Screenshot_20240816_002319](https://github.com/user-attachments/assets/f6a28174-859d-49b6-9aff-9c4e7b3df667) |
| 29 | ![Screenshot_20240816_003138](https://github.com/user-attachments/assets/3a03cad7-65c5-4049-b5d6-44b934bb66e6) | ![Screenshot_20240816_002327](https://github.com/user-attachments/assets/e14cf510-9c74-4b00-9688-c8c57500a0f0) |