### PR TITLE
fix addon store link pointing to incorrect url

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Want to contribute to FlorisBoard? That's great to hear! There are lots of
 different ways to help out, please see the [contribution guidelines](CONTRIBUTING.md) for more info.
 
 ## Addons Store
-The official [Addons Store](https://beta.addons.florisboard.com) offers the possibility for the community to share and download FlorisBoard extensions.
+The official [Addons Store](https://beta.addons.florisboard.org) offers the possibility for the community to share and download FlorisBoard extensions.
 Instructions on how to publish addons can be found [here](https://github.com/florisboard/florisboard/wiki/How-to-publish-on-FlorisBoard-Addons).
 
 Many thanks to Ali ([@4H1R](https://github.com/4H1R)) for implementing the store!


### PR DESCRIPTION
Closes: #2537 