### PR TITLE
Update clipboard backup and restore behavior

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/BackupScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/BackupScreen.kt
@@ -25,13 +25,17 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.TriStateCheckbox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
@@ -86,10 +90,23 @@ object Backup {
         var clipboardTextItems by mutableStateOf(false)
         var clipboardImageItems by mutableStateOf(false)
         var clipboardVideoItems by mutableStateOf(false)
-        var clipboardData by mutableStateOf(false)
 
-        fun validateClipboardCheckbox(): Boolean {
-            return clipboardTextItems && clipboardImageItems && clipboardVideoItems
+        private var _clipboardData: MutableState<ToggleableState> = mutableStateOf(ToggleableState.Off)
+        val clipboardData: State<ToggleableState> = _clipboardData
+
+        fun updateCheckboxState() {
+            val newValue = if (
+                !clipboardVideoItems && !clipboardImageItems && !clipboardTextItems
+            ) {
+                ToggleableState.Off
+            } else if (
+                clipboardVideoItems && clipboardImageItems && clipboardTextItems
+            ) {
+                ToggleableState.On
+            } else {
+                ToggleableState.Indeterminate
+            }
+            _clipboardData.value = newValue
         }
 
         fun provideClipboardItems(): Boolean {
@@ -309,20 +326,23 @@ internal fun BackupFilesSelector(
             text = stringRes(R.string.backup_and_restore__back_up__files_ime_theme),
         )
 
-        CheckboxListItem(
+        TriStateCheckboxListItem(
             onClick = {
-                if (!filesSelector.clipboardData) {
-                    filesSelector.clipboardTextItems = true
+                if (
+                    filesSelector.clipboardData.value == ToggleableState.Off ||
+                    filesSelector.clipboardData.value == ToggleableState.Indeterminate
+                ) {
                     filesSelector.clipboardImageItems = true
                     filesSelector.clipboardVideoItems = true
+                    filesSelector.clipboardTextItems = true
                 } else {
-                    filesSelector.clipboardTextItems = false
                     filesSelector.clipboardImageItems = false
                     filesSelector.clipboardVideoItems = false
+                    filesSelector.clipboardTextItems = false
                 }
-                filesSelector.clipboardData = filesSelector.validateClipboardCheckbox()
+                filesSelector.updateCheckboxState()
             },
-            checked = filesSelector.clipboardTextItems && filesSelector.clipboardImageItems && filesSelector.clipboardVideoItems,
+            state = filesSelector.clipboardData.value,
             text = stringRes(R.string.backup_and_restore__back_up__files_clipboard_history)
         )
 
@@ -330,7 +350,7 @@ internal fun BackupFilesSelector(
         CheckboxListItem(
             onClick = {
                 filesSelector.clipboardTextItems = !filesSelector.clipboardTextItems
-                filesSelector.clipboardData = filesSelector.validateClipboardCheckbox()
+                filesSelector.updateCheckboxState()
             },
             checked = filesSelector.clipboardTextItems,
             text = stringRes(R.string.backup_and_restore__back_up__files_clipboard_history__clipboard_text_items),
@@ -339,7 +359,7 @@ internal fun BackupFilesSelector(
         CheckboxListItem(
             onClick = {
                 filesSelector.clipboardImageItems = !filesSelector.clipboardImageItems
-                filesSelector.clipboardData = filesSelector.validateClipboardCheckbox()
+                filesSelector.updateCheckboxState()
             },
             checked = filesSelector.clipboardImageItems,
             text = stringRes(R.string.backup_and_restore__back_up__files_clipboard_history__clipboard_image_items),
@@ -348,7 +368,7 @@ internal fun BackupFilesSelector(
         CheckboxListItem(
             onClick = {
                 filesSelector.clipboardVideoItems = !filesSelector.clipboardVideoItems
-                filesSelector.clipboardData = filesSelector.validateClipboardCheckbox()
+                filesSelector.updateCheckboxState()
             },
             checked = filesSelector.clipboardVideoItems,
             text = stringRes(R.string.backup_and_restore__back_up__files_clipboard_history__clipboard_video_items),
@@ -375,6 +395,30 @@ internal fun CheckboxListItem(
                 Checkbox(
                     checked = checked,
                     onCheckedChange = null,
+                )
+            }
+        },
+        text = text,
+    )
+}
+
+@Composable
+internal fun TriStateCheckboxListItem(
+    onClick: () -> Unit,
+    state: ToggleableState,
+    text: String,
+    isSecondaryListItem: Boolean = false
+) {
+    JetPrefListItem(
+        modifier = Modifier.rippleClickable(onClick = onClick),
+        icon = {
+            Row {
+                if (isSecondaryListItem) {
+                    Spacer(modifier = Modifier.width(40.dp))
+                }
+                TriStateCheckbox(
+                    state = state,
+                    onClick = null
                 )
             }
         },

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/BackupScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/BackupScreen.kt
@@ -343,7 +343,7 @@ internal fun BackupFilesSelector(
                 filesSelector.updateCheckboxState()
             },
             state = filesSelector.clipboardData.value,
-            text = stringRes(R.string.backup_and_restore__back_up__files_clipboard_history)
+            text = stringRes(R.string.backup_and_restore__back_up__files_clipboard_history),
         )
 
 
@@ -407,7 +407,7 @@ internal fun TriStateCheckboxListItem(
     onClick: () -> Unit,
     state: ToggleableState,
     text: String,
-    isSecondaryListItem: Boolean = false
+    isSecondaryListItem: Boolean = false,
 ) {
     JetPrefListItem(
         modifier = Modifier.rippleClickable(onClick = onClick),
@@ -418,7 +418,7 @@ internal fun TriStateCheckboxListItem(
                 }
                 TriStateCheckbox(
                     state = state,
-                    onClick = null
+                    onClick = null,
                 )
             }
         },

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/RestoreScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/RestoreScreen.kt
@@ -138,7 +138,10 @@ fun RestoreScreen() = FlorisScreen {
                 }
                 restoreWorkspace = workspace
             }.onFailure { error ->
-                context.showLongToast(R.string.backup_and_restore__restore__failure, "error_message" to error.localizedMessage)
+                context.showLongToast(
+                    R.string.backup_and_restore__restore__failure,
+                    "error_message" to error.localizedMessage
+                )
             }
         },
     )
@@ -176,15 +179,20 @@ fun RestoreScreen() = FlorisScreen {
                 srcDir.copyRecursively(dstDir, overwrite = true)
             }
         }
+        val clipboardManager = context.clipboardManager().value
+        if (shouldReset) {
+            clipboardManager.clearFullHistory()
+            ClipboardFileStorage.resetClipboardFileStorage(context)
+        }
+
         if (restoreFilesSelector.provideClipboardItems()) {
             val clipboardFilesDir = workspace.outputDir.subDir("clipboard")
-            val clipboardManager = context.clipboardManager().value
 
             if (restoreFilesSelector.clipboardTextItems) {
                 val clipboardItems = clipboardFilesDir.subFile(Backup.CLIPBOARD_TEXT_ITEMS_JSON_NAME)
                 if (clipboardItems.exists()) {
                     val clipboardItemsList = clipboardItems.readJson<List<ClipboardItem>>()
-                    clipboardManager.restoreHistory(shouldReset = shouldReset, items = clipboardItemsList.filter { it.type == ItemType.TEXT }, itemType = ItemType.TEXT)
+                    clipboardManager.restoreHistory(items = clipboardItemsList.filter { it.type == ItemType.TEXT })
                 }
             }
             if (restoreFilesSelector.clipboardImageItems) {
@@ -192,14 +200,18 @@ fun RestoreScreen() = FlorisScreen {
                 if (clipboardItems.exists()) {
                     val clipboardItemsList = clipboardItems.readJson<List<ClipboardItem>>()
                     for (item in clipboardItemsList.filter { it.type == ItemType.IMAGE }) {
-                        ClipboardFileStorage.instertFileFromBackup(
+                        ClipboardFileStorage.insertFileFromBackupIfNotExisting(
                             context,
                             clipboardFilesDir.subFile(
-                                relPath = "${ClipboardFileStorage.CLIPBOARD_FILES_PATH}/${item.uri!!.path!!.split('/').last()}"
+                                relPath = "${ClipboardFileStorage.CLIPBOARD_FILES_PATH}/${
+                                    item.uri!!.path!!.split(
+                                        '/'
+                                    ).last()
+                                }"
                             )
                         )
                     }
-                    clipboardManager.restoreHistory(shouldReset = shouldReset, items = clipboardItemsList.filter { it.type == ItemType.IMAGE }, itemType = ItemType.IMAGE)
+                    clipboardManager.restoreHistory(items = clipboardItemsList.filter { it.type == ItemType.IMAGE })
                 }
             }
             if (restoreFilesSelector.clipboardVideoItems) {
@@ -207,14 +219,18 @@ fun RestoreScreen() = FlorisScreen {
                 if (clipboardItems.exists()) {
                     val clipboardItemsList = clipboardItems.readJson<List<ClipboardItem>>()
                     for (item in clipboardItemsList.filter { it.type == ItemType.VIDEO }) {
-                        ClipboardFileStorage.instertFileFromBackup(
+                        ClipboardFileStorage.insertFileFromBackupIfNotExisting(
                             context,
                             clipboardFilesDir.subFile(
-                                relPath = "${ClipboardFileStorage.CLIPBOARD_FILES_PATH}/${item.uri!!.path!!.split('/').last()}"
+                                relPath = "${ClipboardFileStorage.CLIPBOARD_FILES_PATH}/${
+                                    item.uri!!.path!!.split(
+                                        '/'
+                                    ).last()
+                                }"
                             )
                         )
                     }
-                    clipboardManager.restoreHistory(shouldReset = shouldReset, items = clipboardItemsList.filter { it.type == ItemType.VIDEO }, itemType = ItemType.VIDEO)
+                    clipboardManager.restoreHistory(items = clipboardItemsList.filter { it.type == ItemType.VIDEO })
                 }
             }
         }
@@ -238,7 +254,11 @@ fun RestoreScreen() = FlorisScreen {
                             context.showLongToast(R.string.backup_and_restore__restore__success)
                             navController.navigateUp()
                         } catch (e: Throwable) {
-                            context.showLongToast(R.string.backup_and_restore__restore__failure, "error_message" to e.localizedMessage)
+                            e.printStackTrace()
+                            context.showLongToast(
+                                R.string.backup_and_restore__restore__failure,
+                                "error_message" to e.localizedMessage
+                            )
                         }
                     }
                 },
@@ -273,7 +293,10 @@ fun RestoreScreen() = FlorisScreen {
                 runCatching {
                     restoreDataFromFileSystemLauncher.launch("*/*")
                 }.onFailure { error ->
-                    context.showLongToast(R.string.backup_and_restore__restore__failure, "error_message" to error.localizedMessage)
+                    context.showLongToast(
+                        R.string.backup_and_restore__restore__failure,
+                        "error_message" to error.localizedMessage
+                    )
                 }
             },
             modifier = Modifier

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/RestoreScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/RestoreScreen.kt
@@ -140,7 +140,7 @@ fun RestoreScreen() = FlorisScreen {
             }.onFailure { error ->
                 context.showLongToast(
                     R.string.backup_and_restore__restore__failure,
-                    "error_message" to error.localizedMessage
+                    "error_message" to error.localizedMessage,
                 )
             }
         },
@@ -257,7 +257,7 @@ fun RestoreScreen() = FlorisScreen {
                             e.printStackTrace()
                             context.showLongToast(
                                 R.string.backup_and_restore__restore__failure,
-                                "error_message" to e.localizedMessage
+                                "error_message" to e.localizedMessage,
                             )
                         }
                     }
@@ -295,7 +295,7 @@ fun RestoreScreen() = FlorisScreen {
                 }.onFailure { error ->
                     context.showLongToast(
                         R.string.backup_and_restore__restore__failure,
-                        "error_message" to error.localizedMessage
+                        "error_message" to error.localizedMessage,
                     )
                 }
             },

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardFileStorage.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardFileStorage.kt
@@ -61,7 +61,28 @@ object ClipboardFileStorage {
         return context.clipboardFilesDir.subFile(id.toString())
     }
 
-    fun instertFileFromBackup(context: Context, file: FsFile) {
-        file.copyTo(context.clipboardFilesDir.subFile(file.name), overwrite = false)
+
+    /**
+     * Insert file from backup if not existing
+     *
+     * @param context the application context
+     * @param file the file to be inserted
+     */
+    fun insertFileFromBackupIfNotExisting(context: Context, file: FsFile) {
+        if (!context.clipboardFilesDir.subFile(file.name).isFile) {
+            file.copyTo(context.clipboardFilesDir.subFile(file.name), overwrite = false)
+        }
     }
+
+    /**
+     * Deletes all files from the clipboard subdirectory
+     *
+     * @param context the application context
+     */
+    fun resetClipboardFileStorage(context: Context) {
+        context.clipboardFilesDir.listFiles()?.forEach {
+            it.delete()
+        }
+    }
+
 }


### PR DESCRIPTION
# TriStateCheckbox
This PR fixes the Clipboard History Checkbox in the backup and restore screens to better reflect the selection of the items. 

A new Composable `TriStateCheckboxListItem` was added. 

#### Current behavior:
If nothing or not everything is selected, then everything is selected by pressing the checkbox. If all subitems are selected, everything is deselected by pressing the checkbox

# Clipboard History import error
This PR fixes a bug that was caused by adding clipboard media files that already existed. In addition, the clipboard history as well as the files are now reset correctly with erase and override.