### PR TITLE
Remove trailing comma to comply with the JSON spec

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/sl-SI.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/sl-SI.json
@@ -2,7 +2,7 @@
   "all": {
     "c": {
       "relevant": [
-        { "$": "auto_text_key", "code":  269, "label": "č" },
+        { "$": "auto_text_key", "code":  269, "label": "č" }
       ]
     },
     "s": {


### PR DESCRIPTION
This PR fixes a problem in Slovenian popup mapping. There was a trailing comma in the JSON file, which meant that the popup mapping could not be used.