### PR TITLE
Localize debug log screen and add option for preformatted exporting

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/ExportDebugLogScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/ExportDebugLogScreen.kt
@@ -16,6 +16,8 @@
 
 package dev.patrickgold.florisboard.app.devtools
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -35,19 +37,21 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.sp
+import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.florisPreferenceModel
 import dev.patrickgold.florisboard.clipboardManager
-import org.florisboard.lib.android.showShortToast
 import dev.patrickgold.florisboard.lib.compose.FlorisButton
 import dev.patrickgold.florisboard.lib.compose.FlorisScreen
 import dev.patrickgold.florisboard.lib.compose.florisHorizontalScroll
 import dev.patrickgold.florisboard.lib.compose.florisScrollbar
+import dev.patrickgold.florisboard.lib.compose.stringRes
 import dev.patrickgold.florisboard.lib.devtools.Devtools
+import org.florisboard.lib.android.showShortToast
 
-// TODO: This screen is just a quick thrown-together thing and needs further enhancing in the UI and in localization
+// TODO: This screen is just a quick thrown-together thing and needs further enhancing in the UI
 @Composable
 fun ExportDebugLogScreen() = FlorisScreen {
-    title = "Debug log"
+    title = stringRes(R.string.devtools__debuglog__title)
     scrollable = false
 
     val prefs by florisPreferenceModel()
@@ -55,21 +59,36 @@ fun ExportDebugLogScreen() = FlorisScreen {
     val clipboardManager by context.clipboardManager()
 
     var debugLog by remember { mutableStateOf<List<String>?>(null) }
+    var formattedDebugLog by remember { mutableStateOf<List<String>?>(null) }
 
     LaunchedEffect(Unit) {
         debugLog = Devtools.generateDebugLog(context, prefs, includeLogcat = true).lines()
+        formattedDebugLog = Devtools.generateDebugLogForGithub(context, prefs, includeLogcat = true).lines()
     }
 
     bottomBar {
-        FlorisButton(
-            onClick = {
-                clipboardManager.addNewPlaintext(debugLog!!.joinToString("\n"))
-                context.showShortToast("Copied debug log to clipboard")
-            },
-            modifier = Modifier.fillMaxWidth(),
-            text = "Export (copy to clipboard)",
-            enabled = debugLog != null,
-        )
+        Row(
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            FlorisButton(
+                onClick = {
+                    clipboardManager.addNewPlaintext(debugLog!!.joinToString("\n"))
+                    context.showShortToast(context.getString(R.string.devtools__debuglog__copied_to_clipboard))
+                },
+                modifier = Modifier,
+                text = stringRes(R.string.devtools__debuglog__copy_log),
+                enabled = debugLog != null,
+            )
+            FlorisButton(
+                onClick = {
+                    clipboardManager.addNewPlaintext(formattedDebugLog!!.joinToString("\n"))
+                    context.showShortToast(context.getString(R.string.devtools__debuglog__copied_to_clipboard))
+                },
+                text = stringRes(R.string.devtools__debuglog__copy_for_github),
+                enabled = debugLog != null,
+            )
+        }
     }
 
     content {
@@ -86,7 +105,7 @@ fun ExportDebugLogScreen() = FlorisScreen {
                 val log = debugLog
                 if (log == null) {
                     item {
-                        Text("Loading...")
+                        Text(stringRes(R.string.devtools__debuglog__loading))
                     }
                 } else {
                     items(log) { logLine ->

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/ExportDebugLogScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/devtools/ExportDebugLogScreen.kt
@@ -69,7 +69,7 @@ fun ExportDebugLogScreen() = FlorisScreen {
     bottomBar {
         Row(
             horizontalArrangement = Arrangement.SpaceEvenly,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
             FlorisButton(
                 onClick = {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
@@ -23,10 +23,10 @@ import android.os.Debug
 import dev.patrickgold.florisboard.BuildConfig
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.AppPrefs
-import org.florisboard.lib.android.systemService
 import dev.patrickgold.florisboard.lib.titlecase
 import dev.patrickgold.florisboard.lib.util.TimeUtils
 import dev.patrickgold.florisboard.lib.util.UnitUtils
+import org.florisboard.lib.android.systemService
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -45,6 +45,36 @@ object Devtools {
             if (includeLogcat) {
                 appendLine()
                 append(generateLogcatDump())
+            }
+        }
+    }
+
+    fun generateDebugLogForGithub(context: Context, prefs: AppPrefs? = null, includeLogcat: Boolean = false): String {
+        return buildString {
+            appendLine("<details>")
+            appendLine("<summary>Detailed info (Debug log header)</summary>")
+            appendLine()
+            appendLine("```")
+            append(generateSystemInfoLog(context))
+            appendLine()
+            append(generateAppInfoLog(context))
+            if (prefs != null) {
+                appendLine()
+                append(generateFeatureConfigLog(prefs))
+            }
+            appendLine()
+            appendLine("```")
+            appendLine("</details>")
+            if (includeLogcat) {
+                appendLine()
+                appendLine("<details>")
+                appendLine("<summary>Debug log content</summary>")
+                appendLine()
+                appendLine("```")
+                append(generateLogcatDump())
+                appendLine()
+                appendLine("```")
+                appendLine("</details>")
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -617,7 +617,7 @@
     <string name="devtools__debuglog__title">Debug log</string>
     <string name="devtools__debuglog__copied_to_clipboard">Copied debug log to clipboard</string>
     <string name="devtools__debuglog__copy_log">Copy log</string>
-    <string name="devtools__debuglog__copy_for_github">Copy for GitHub formatted log</string>
+    <string name="devtools__debuglog__copy_for_github">Copy log (GitHub formatting)</string>
     <string name="devtools__debuglog__loading">Loading…</string>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -614,6 +614,11 @@
     <string name="devtools__android_settings_secure__title" comment="Title of Android settings (secure) screen">Secure Android settings</string>
     <string name="devtools__android_settings_system__title" comment="Title of Android settings (system) screen">System Android settings</string>
     <string name="devtools__android_locales__title" comment="Title of Android locales screen">System locales</string>
+    <string name="devtools__debuglog__title">Debug log</string>
+    <string name="devtools__debuglog__copied_to_clipboard">Copied debug log to clipboard</string>
+    <string name="devtools__debuglog__copy_log">Copy log</string>
+    <string name="devtools__debuglog__copy_for_github">Copy for GitHub formatted log</string>
+    <string name="devtools__debuglog__loading">Loading…</string>
 
 
     <!-- Extension strings -->


### PR DESCRIPTION
This PR adds a button that copies the debuglog already preformatted for github to the clipboard.
In addition the stringres for the ExportDebugLogScreen were added.