### PR TITLE
Rework version name handling in Gradle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ val projectBuildToolsVersion: String by project
 val projectNdkVersion: String by project
 val projectVersionCode: String by project
 val projectVersionName: String by project
-val projectVersionNameSuffix: String by project
+val projectVersionNameSuffix = projectVersionName.substringAfter("-", "")
 
 android {
     namespace = "dev.patrickgold.florisboard"
@@ -59,7 +59,7 @@ android {
         minSdk = projectMinSdk.toInt()
         targetSdk = projectTargetSdk.toInt()
         versionCode = projectVersionCode.toInt()
-        versionName = projectVersionName
+        versionName = projectVersionName.substringBefore("-")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -106,7 +106,7 @@ android {
     buildTypes {
         named("debug") {
             applicationIdSuffix = ".debug"
-            versionNameSuffix = "-debug-${getGitCommitHash(short = true)}"
+            versionNameSuffix = "-debug+${getGitCommitHash(short = true)}"
 
             isDebuggable = true
             isJniDebuggable = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,4 @@ projectBuildToolsVersion=34.0.0
 projectNdkVersion=26.1.10909125
 
 projectVersionCode=97
-projectVersionName=0.4.0
-projectVersionNameSuffix=-rc02
+projectVersionName=0.4.0-rc02


### PR DESCRIPTION
The version suffix is now encoded in `versionName` instead of being in a separate gradle.properties value to ease handling in bash scripts