### PR TITLE
Fix Rust Cargo.lock file getting rewritten during build

### DIFF
--- a/lib/native/build.gradle.kts
+++ b/lib/native/build.gradle.kts
@@ -68,7 +68,7 @@ android {
 
 tasks.named("clean") {
     doLast {
-        delete("src/main/rust/target", "src/main/rust/Cargo.lock")
+        delete("src/main/rust/target")
     }
 }
 

--- a/lib/native/src/main/rust/CMakeLists.txt
+++ b/lib/native/src/main/rust/CMakeLists.txt
@@ -45,7 +45,7 @@ add_custom_target(
 )
 add_custom_target(
     fl_native_rust_build ALL
-    COMMAND ${CARGO_EXECUTABLE} rustc --release --target ${RUST_TARGET} --
+    COMMAND ${CARGO_EXECUTABLE} rustc --release --locked --target ${RUST_TARGET} --
         -C linker="${LLVM_TOOLCHAIN}/${ANDROID_TARGET}${CMAKE_ANDROID_API}-clang"
     DEPENDS setup_rust_target
     BYPRODUCTS ${FL_NATIVE_RUST_PATH}


### PR DESCRIPTION
Cargo.lock was accidentally cleaned every build time which caused rustc to rewrite the Cargo.lock file, now the lock file is only updated when the dependencies are updated with cargo.