### PR TITLE
Fix incognito icon messing up landscape input height

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/TextInputLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/TextInputLayout.kt
@@ -19,7 +19,6 @@ package dev.patrickgold.florisboard.ime.text
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
@@ -32,7 +31,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyboardLayout
 import dev.patrickgold.florisboard.ime.smartbar.Smartbar
@@ -67,7 +65,7 @@ fun TextInputLayout(
                         val indicatorStyle = FlorisImeTheme.style.get(FlorisImeUi.IncognitoModeIndicator)
                         Icon(
                             modifier = Modifier
-                                .requiredSize(192.dp)
+                                .matchParentSize()
                                 .align(Alignment.Center),
                             painter = painterResource(R.drawable.ic_incognito),
                             contentDescription = null,


### PR DESCRIPTION
Closes #2573

Original behavior: Incognito icon stretches the box as mentioned by @kizaski
![original](https://github.com/user-attachments/assets/a9f05040-0afa-469d-baf8-53ce9f5ed458)


matchParentSize will resize the icon to fit the box.
![matchParentSize](https://github.com/user-attachments/assets/b63a8c2b-fb85-4ebf-b111-7e02d4e3c47e)


Keeping requiredSize alongside matchParentSize will result in behavior as shown below
![+requiredSize](https://github.com/user-attachments/assets/7e488021-7e75-4c1d-a9dc-626912e423aa)
