### PR TITLE
Kevin van9/issue 2556 append action to row

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickActionsEditorPanel.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickActionsEditorPanel.kt
@@ -106,17 +106,20 @@ fun QuickActionsEditorPanel(modifier: Modifier = Modifier) {
     val headerStyle = FlorisImeTheme.style.get(FlorisImeUi.SmartbarActionsEditorHeader)
     val subheaderStyle = FlorisImeTheme.style.get(FlorisImeUi.SmartbarActionsEditorSubheader)
 
-    fun findItemForOffset(offset: IntOffset): LazyGridItemInfo? {
+    fun findItemForOffsetOrClosestInRow(offset: IntOffset): LazyGridItemInfo? {
+        var closestItemInRow: LazyGridItemInfo? = null
         // Using manual for loop with indices instead of firstOrNull() because this method gets
         // called a lot and firstOrNull allocates an iterator for each call
         for (index in gridState.layoutInfo.visibleItemsInfo.indices) {
             val item = gridState.layoutInfo.visibleItemsInfo[index]
-            if (offset.x in item.offset.x..(item.offset.x + item.size.width) &&
-                offset.y in item.offset.y..(item.offset.y + item.size.height)) {
-                return item
+            if (offset.y in item.offset.y..(item.offset.y + item.size.height)) {
+                if (offset.x in item.offset.x..(item.offset.x + item.size.width)) {
+                    return item
+                }
+                closestItemInRow = item
             }
         }
-        return null
+        return closestItemInRow
     }
 
     fun indexOfStickyAction(item: LazyGridItemInfo): Int {
@@ -159,7 +162,7 @@ fun QuickActionsEditorPanel(modifier: Modifier = Modifier) {
     }
 
     fun beginDragGesture(pos: IntOffset) {
-        val item = findItemForOffset(pos) ?: return
+        val item = findItemForOffsetOrClosestInRow(pos) ?: return
         val stickyActionIndex = indexOfStickyAction(item)
         val dynamicActionIndex = indexOfDynamicAction(item)
         val hiddenActionIndex = indexOfHiddenAction(item)
@@ -183,7 +186,7 @@ fun QuickActionsEditorPanel(modifier: Modifier = Modifier) {
         if (activeDragAction == null) return
         val pos = activeDragPosition + posChange
         activeDragPosition = pos
-        val item = findItemForOffset(pos) ?: return
+        val item = findItemForOffsetOrClosestInRow(pos) ?: return
         val stickyActionIndex = indexOfStickyAction(item)
         val dynamicActionIndex = indexOfDynamicAction(item)
         val hiddenActionIndex = indexOfHiddenAction(item)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/TextInputLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/TextInputLayout.kt
@@ -19,7 +19,6 @@ package dev.patrickgold.florisboard.ime.text
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
@@ -32,7 +31,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyboardLayout
 import dev.patrickgold.florisboard.ime.smartbar.Smartbar
@@ -67,7 +65,7 @@ fun TextInputLayout(
                         val indicatorStyle = FlorisImeTheme.style.get(FlorisImeUi.IncognitoModeIndicator)
                         Icon(
                             modifier = Modifier
-                                .requiredSize(192.dp)
+                                .matchParentSize()
                                 .align(Alignment.Center),
                             painter = painterResource(R.drawable.ic_incognito),
                             contentDescription = null,


### PR DESCRIPTION
Closes #2556 

Quick action item to swap with now includes the last item in the row.

To do this, items' y-offset bounds that contain the given offset are marked as being "close" and returned if no items' bounds explicitly contain the given offset