### PR TITLE
Fix utility key action not correctly applied

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -142,7 +142,13 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             prefs.keyboard.utilityKeyEnabled.observeForever {
                 updateActiveEvaluators()
             }
+            prefs.keyboard.utilityKeyAction.observeForever {
+                updateActiveEvaluators()
+            }
             activeState.collectLatestIn(scope) {
+                updateActiveEvaluators()
+            }
+            subtypeManager.subtypesFlow.collectLatestIn(scope) {
                 updateActiveEvaluators()
             }
             subtypeManager.activeSubtypeFlow.collectLatestIn(scope) {


### PR DESCRIPTION
Closes #2586
Closes #2587

This PR addresses both the issue that the utility key action pref was not observed and that subtype list changes did not properly propagate to the evaluator, causing the evaluate**() methods to be always 1 behind.