### PR TITLE
Major rework of emoji suggestions

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -225,6 +225,10 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
             key = "emoji__suggestion_update_history",
             default = true,
         )
+        val suggestionCandidateShowName = boolean(
+            key = "emoji__suggestion_candidate_show_name",
+            default = false,
+        )
         val suggestionQueryMinLength = int(
             key = "emoji__suggestion_query_min_length",
             default = 3,
@@ -232,10 +236,6 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
         val suggestionCandidateMaxCount = int(
             key = "emoji__suggestion_candidate_max_count",
             default = 5,
-        )
-        val suggestionCandidateShowName = boolean(
-            key = "emoji__suggestion_candidate_show_name",
-            default = true,
         )
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -221,6 +221,10 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
             key = "emoji__suggestion_type",
             default = EmojiSuggestionType.LEADING_COLON,
         )
+        val suggestionUpdateHistory = boolean(
+            key = "emoji__suggestion_update_history",
+            default = true,
+        )
         val suggestionQueryMinLength = int(
             key = "emoji__suggestion_query_min_length",
             default = 3,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -229,6 +229,10 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
             key = "emoji__suggestion_candidate_max_count",
             default = 5,
         )
+        val suggestionCandidateShowName = boolean(
+            key = "emoji__suggestion_candidate_show_name",
+            default = true,
+        )
     }
 
     val gestures = Gestures()

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -33,6 +33,7 @@ import dev.patrickgold.florisboard.ime.landscapeinput.LandscapeInputUiMode
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiHairStyle
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiRecentlyUsedHelper
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSkinTone
+import dev.patrickgold.florisboard.ime.media.emoji.EmojiSuggestionType
 import dev.patrickgold.florisboard.ime.nlp.SpellingLanguageMode
 import dev.patrickgold.florisboard.ime.onehanded.OneHandedMode
 import dev.patrickgold.florisboard.ime.smartbar.CandidatesDisplayMode
@@ -190,6 +191,43 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
         val enableFlorisUserDictionary = boolean(
             key = "suggestion__enable_floris_user_dictionary",
             default = true,
+        )
+    }
+
+    val emoji = Emoji()
+    inner class Emoji {
+        val recentlyUsed = custom(
+            key = "emoji__recently_used",
+            default = emptyList(),
+            serializer = EmojiRecentlyUsedHelper.Serializer,
+        )
+        val recentlyUsedMaxSize = int(
+            key = "emoji__recently_used_max_size",
+            default = 90,
+        )
+        val preferredSkinTone = enum(
+            key = "emoji__preferred_skin_tone",
+            default = EmojiSkinTone.DEFAULT,
+        )
+        val preferredHairStyle = enum(
+            key = "emoji__preferred_hair_style",
+            default = EmojiHairStyle.DEFAULT,
+        )
+        val suggestionEnabled = boolean(
+            key = "emoji__suggestion_enabled",
+            default = true,
+        )
+        val suggestionType = enum(
+            key = "emoji__suggestion_type",
+            default = EmojiSuggestionType.LEADING_COLON,
+        )
+        val suggestionQueryMinLength = int(
+            key = "emoji__suggestion_query_min_length",
+            default = 3,
+        )
+        val suggestionCandidateMaxCount = int(
+            key = "emoji__suggestion_candidate_max_count",
+            default = 5,
         )
     }
 
@@ -530,27 +568,6 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
         )
     }
 
-    val media = Media()
-    inner class Media {
-        val emojiRecentlyUsed = custom(
-            key = "media__emoji_recently_used",
-            default = emptyList(),
-            serializer = EmojiRecentlyUsedHelper.Serializer,
-        )
-        val emojiRecentlyUsedMaxSize = int(
-            key = "media__emoji_recently_used_max_size",
-            default = 90,
-        )
-        val emojiPreferredSkinTone = enum(
-            key = "media__emoji_preferred_skin_tone",
-            default = EmojiSkinTone.DEFAULT,
-        )
-        val emojiPreferredHairStyle = enum(
-            key = "media__emoji_preferred_hair_style",
-            default = EmojiHairStyle.DEFAULT,
-        )
-    }
-
     val smartbar = Smartbar()
     inner class Smartbar {
         val enabled = boolean(
@@ -683,8 +700,7 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
             "gestures__space_bar_swipe_right", "gestures__space_bar_long_press", "gestures__delete_key_swipe_left",
             "gestures__delete_key_long_press", "keyboard__hinted_number_row_mode", "keyboard__hinted_symbols_mode",
             "keyboard__utility_key_action", "keyboard__one_handed_mode", "keyboard__landscape_input_ui_mode",
-            "localization__display_language_names_in", "media__emoji_preferred_skin_tone",
-            "media__emoji_preferred_hair_style", "smartbar__primary_actions_row_type",
+            "localization__display_language_names_in", "smartbar__primary_actions_row_type",
             "smartbar__secondary_actions_placement", "smartbar__secondary_actions_row_type", "spelling__language_mode",
             "suggestion__display_mode", "theme__mode", "theme__editor_display_colors_as",
             "theme__editor_display_kbd_after_dialogs", "theme__editor_level",
@@ -704,6 +720,27 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
                 } else {
                     entry.reset()
                 }
+            }
+
+            // Migrate media prefs to emoji prefs
+            // Keep migration rule until: 0.6 dev cycle
+            "media__emoji_recently_used" -> {
+                entry.transform(key = "emoji__recently_used")
+            }
+            "media__emoji_recently_used_max_size" -> {
+                entry.transform(key = "emoji__recently_used_max_size")
+            }
+            "media__emoji_preferred_skin_tone" -> {
+                entry.transform(
+                    key = "emoji__preferred_skin_tone",
+                    rawValue = entry.rawValue.uppercase(), // keep until: 0.5 dev cycle
+                )
+            }
+            "media__emoji_preferred_hair_style" -> {
+                entry.transform(
+                    key = "emoji__preferred_hair_style",
+                    rawValue = entry.rawValue.uppercase(), // keep until: 0.5 dev cycle
+                )
             }
 
             // Default: keep entry

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/EnumDisplayEntries.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/EnumDisplayEntries.kt
@@ -12,6 +12,7 @@ import dev.patrickgold.florisboard.ime.keyboard.IncognitoMode
 import dev.patrickgold.florisboard.ime.keyboard.SpaceBarMode
 import dev.patrickgold.florisboard.ime.landscapeinput.LandscapeInputUiMode
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSkinTone
+import dev.patrickgold.florisboard.ime.media.emoji.EmojiSuggestionType
 import dev.patrickgold.florisboard.ime.nlp.SpellingLanguageMode
 import dev.patrickgold.florisboard.ime.onehanded.OneHandedMode
 import dev.patrickgold.florisboard.ime.smartbar.CandidatesDisplayMode
@@ -181,6 +182,20 @@ private val ENUM_DISPLAY_ENTRIES = mapOf<Pair<KClass<*>, String>, @Composable ()
                     R.string.enum__emoji_skin_tone__dark_skin_tone,
                     "emoji" to "\uD83D\uDC4B\uD83C\uDFFF" // 👋🏿
                 ),
+            )
+        }
+    },
+    EmojiSuggestionType::class to DEFAULT to {
+        listPrefEntries {
+            entry(
+                key = EmojiSuggestionType.LEADING_COLON,
+                label = stringRes(R.string.enum__emoji_suggestion_type__leading_colon),
+                description = stringRes(R.string.enum__emoji_suggestion_type__leading_colon__description),
+            )
+            entry(
+                key = EmojiSuggestionType.INLINE_TEXT,
+                label = stringRes(R.string.enum__emoji_suggestion_type__inline_text),
+                description = stringRes(R.string.enum__emoji_suggestion_type__inline_text__description),
             )
         }
     },

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
@@ -16,32 +16,37 @@
 
 package dev.patrickgold.florisboard.app.settings.media
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.EmojiSymbols
 import androidx.compose.runtime.Composable
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.enumDisplayEntriesOf
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSkinTone
+import dev.patrickgold.florisboard.ime.media.emoji.EmojiSuggestionType
 import dev.patrickgold.florisboard.lib.compose.FlorisScreen
 import dev.patrickgold.florisboard.lib.compose.pluralsRes
 import dev.patrickgold.florisboard.lib.compose.stringRes
 import dev.patrickgold.jetpref.datastore.ui.DialogSliderPreference
 import dev.patrickgold.jetpref.datastore.ui.ExperimentalJetPrefDatastoreUi
 import dev.patrickgold.jetpref.datastore.ui.ListPreference
+import dev.patrickgold.jetpref.datastore.ui.PreferenceGroup
+import dev.patrickgold.jetpref.datastore.ui.SwitchPreference
 
 @OptIn(ExperimentalJetPrefDatastoreUi::class)
 @Composable
 fun MediaScreen() = FlorisScreen {
     title = stringRes(R.string.settings__media__title)
     previewFieldVisible = true
-    iconSpaceReserved = false
+    iconSpaceReserved = true
 
     content {
         ListPreference(
-            prefs.media.emojiPreferredSkinTone,
+            prefs.emoji.preferredSkinTone,
             title = stringRes(R.string.prefs__media__emoji_preferred_skin_tone),
             entries = enumDisplayEntriesOf(EmojiSkinTone::class),
         )
         DialogSliderPreference(
-            prefs.media.emojiRecentlyUsedMaxSize,
+            prefs.emoji.recentlyUsedMaxSize,
             title = stringRes(R.string.prefs__media__emoji_recently_used_max_size),
             valueLabel = { maxSize ->
                 if (maxSize == 0) {
@@ -54,5 +59,41 @@ fun MediaScreen() = FlorisScreen {
             max = 120,
             stepIncrement = 1,
         )
+        PreferenceGroup(title = stringRes(R.string.prefs__media__emoji_suggestion__title)) {
+            SwitchPreference(
+                prefs.emoji.suggestionEnabled,
+                icon = Icons.Outlined.EmojiSymbols,
+                title = stringRes(R.string.prefs__media__emoji_suggestion_enabled),
+                summary = stringRes(R.string.prefs__media__emoji_suggestion_enabled__summary),
+            )
+            ListPreference(
+                prefs.emoji.suggestionType,
+                title = stringRes(R.string.prefs__media__emoji_suggestion_type),
+                entries = enumDisplayEntriesOf(EmojiSuggestionType::class),
+                enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
+            )
+            DialogSliderPreference(
+                prefs.emoji.suggestionQueryMinLength,
+                title = stringRes(R.string.prefs__media__emoji_suggestion_query_min_length),
+                valueLabel = { length ->
+                    pluralsRes(R.plurals.unit__characters__written, length, "v" to length)
+                },
+                min = 1,
+                max = 5,
+                stepIncrement = 1,
+                enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
+            )
+            DialogSliderPreference(
+                prefs.emoji.suggestionCandidateMaxCount,
+                title = stringRes(R.string.prefs__media__emoji_suggestion_candidate_max_count),
+                valueLabel = { count ->
+                    pluralsRes(R.plurals.unit__candidates__written, count, "v" to count)
+                },
+                min = 1,
+                max = 10,
+                stepIncrement = 1,
+                enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
@@ -94,6 +94,12 @@ fun MediaScreen() = FlorisScreen {
                 stepIncrement = 1,
                 enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
             )
+            SwitchPreference(
+                prefs.emoji.suggestionCandidateShowName,
+                title = stringRes(R.string.prefs__media__emoji_suggestion_candidate_show_name),
+                summary = stringRes(R.string.prefs__media__emoji_suggestion_candidate_show_name__summary),
+                enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
+            )
         }
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
@@ -72,6 +72,18 @@ fun MediaScreen() = FlorisScreen {
                 entries = enumDisplayEntriesOf(EmojiSuggestionType::class),
                 enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
             )
+            SwitchPreference(
+                prefs.emoji.suggestionUpdateHistory,
+                title = stringRes(R.string.prefs__media__emoji_suggestion_update_history),
+                summary = stringRes(R.string.prefs__media__emoji_suggestion_update_history__summary),
+                enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
+            )
+            SwitchPreference(
+                prefs.emoji.suggestionCandidateShowName,
+                title = stringRes(R.string.prefs__media__emoji_suggestion_candidate_show_name),
+                summary = stringRes(R.string.prefs__media__emoji_suggestion_candidate_show_name__summary),
+                enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
+            )
             DialogSliderPreference(
                 prefs.emoji.suggestionQueryMinLength,
                 title = stringRes(R.string.prefs__media__emoji_suggestion_query_min_length),
@@ -92,12 +104,6 @@ fun MediaScreen() = FlorisScreen {
                 min = 1,
                 max = 10,
                 stepIncrement = 1,
-                enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
-            )
-            SwitchPreference(
-                prefs.emoji.suggestionCandidateShowName,
-                title = stringRes(R.string.prefs__media__emoji_suggestion_candidate_show_name),
-                summary = stringRes(R.string.prefs__media__emoji_suggestion_candidate_show_name__summary),
                 enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
             )
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiData.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiData.kt
@@ -99,7 +99,7 @@ data class EmojiData(
                             val emoji = Emoji(
                                 value = data[0].trim(),
                                 name = base?.name ?: data[1].trim(),
-                                keywords = data[2].split("|").map { it.trim() }
+                                keywords = data[2].split("|").map { it.trim() },
                             )
                             if (emojiEditorList != null) {
                                 emojiEditorList!!.add(emoji)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiData.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiData.kt
@@ -95,9 +95,10 @@ data class EmojiData(
                         // Assume it is a data line
                         val data = line.split(";")
                         if (data.size == 3) {
+                            val base = emojiEditorList?.first()
                             val emoji = Emoji(
                                 value = data[0].trim(),
-                                name = data[1].trim(),
+                                name = base?.name ?: data[1].trim(),
                                 keywords = data[2].split("|").map { it.trim() }
                             )
                             if (emojiEditorList != null) {
@@ -113,6 +114,14 @@ data class EmojiData(
 
             for (category in byCategory.keys) {
                 for (emojiSet in byCategory[category]!!) {
+                    if (emojiSet.emojis.size == 1) {
+                        // No variations provided, we fallback to using the base for all skin tones
+                        val base = emojiSet.emojis.first()
+                        for (skinTone in EmojiSkinTone.entries) {
+                            bySkinTone[skinTone]!!.add(base)
+                        }
+                        continue
+                    }
                     for (emoji in emojiSet.emojis) {
                         bySkinTone[emoji.skinTone]!!.add(emoji)
                     }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiPaletteView.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiPaletteView.kt
@@ -154,7 +154,7 @@ fun EmojiPaletteView(
     val lazyListState = rememberLazyGridState()
     val scope = rememberCoroutineScope()
 
-    val preferredSkinTone by prefs.media.emojiPreferredSkinTone.observeAsState()
+    val preferredSkinTone by prefs.emoji.preferredSkinTone.observeAsState()
     val fontSizeMultiplier = prefs.keyboard.fontSizeMultiplier()
     val emojiKeyStyle = FlorisImeTheme.style.get(element = FlorisImeUi.EmojiKey)
     val emojiKeyFontSize = emojiKeyStyle.fontSize.spSize(default = EmojiDefaultFontSize) safeTimes fontSizeMultiplier
@@ -179,7 +179,7 @@ fun EmojiPaletteView(
                 // Purposely using remember here to prevent recomposition, as this would cause rapid
                 // emoji changes for the user when in recently used category.
                 remember(recentlyUsedVersion) {
-                    prefs.media.emojiRecentlyUsed.get().map { EmojiSet(listOf(it)) }
+                    prefs.emoji.recentlyUsed.get().map { EmojiSet(listOf(it)) }
                 }
             } else {
                 emojiMappings[activeCategory]!!

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiRecentlyUsedHelper.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiRecentlyUsedHelper.kt
@@ -27,21 +27,21 @@ object EmojiRecentlyUsedHelper {
     private var emojiGuard = Mutex(locked = false)
 
     suspend fun addEmoji(prefs: AppPrefs, emoji: Emoji) = emojiGuard.withLock {
-        val maxSize = prefs.media.emojiRecentlyUsedMaxSize.get()
-        val list = prefs.media.emojiRecentlyUsed.get().toMutableList()
+        val maxSize = prefs.emoji.recentlyUsedMaxSize.get()
+        val list = prefs.emoji.recentlyUsed.get().toMutableList()
         list.add(0, emoji)
         if (maxSize > 0) {
             while (list.size > maxSize) {
                 list.removeLast()
             }
         }
-        prefs.media.emojiRecentlyUsed.set(list.distinctBy { it.value })
+        prefs.emoji.recentlyUsed.set(list.distinctBy { it.value })
     }
 
     suspend fun removeEmoji(prefs: AppPrefs, emoji: Emoji) = emojiGuard.withLock {
-        val list = prefs.media.emojiRecentlyUsed.get().toMutableList()
+        val list = prefs.emoji.recentlyUsed.get().toMutableList()
         list.remove(emoji)
-        prefs.media.emojiRecentlyUsed.set(list.distinctBy { it.value })
+        prefs.emoji.recentlyUsed.set(list.distinctBy { it.value })
     }
 
     object Serializer : PreferenceSerializer<List<Emoji>> {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
@@ -65,6 +65,7 @@ class EmojiSuggestionProvider(private val context: Context) : SuggestionProvider
         isPrivateSession: Boolean
     ): List<SuggestionCandidate> {
         val preferredSkinTone = prefs.emoji.preferredSkinTone.get()
+        val showName = prefs.emoji.suggestionCandidateShowName.get()
         val query = validateInputQuery(content.composingText) ?: return emptyList()
         val emojis = cachedEmojiMappings.get(subtype.primaryLocale)?.get(preferredSkinTone) ?: emptyList()
         val candidates = withContext(Dispatchers.Default) {
@@ -74,7 +75,7 @@ class EmojiSuggestionProvider(private val context: Context) : SuggestionProvider
                         emoji.keywords.any { it.contains(query, ignoreCase = true) }
                 }
                 .limit(maxCandidateCount.toLong())
-                .map { EmojiSuggestionCandidate(it) }
+                .map { EmojiSuggestionCandidate(it, showName) }
                 .collect(Collectors.toList())
         }
         return candidates

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.patrickgold.florisboard.ime.media.emoji
 
 import kotlinx.coroutines.Dispatchers
@@ -13,10 +29,6 @@ import dev.patrickgold.florisboard.ime.nlp.SuggestionProvider
 import dev.patrickgold.florisboard.lib.FlorisLocale
 import io.github.reactivecircus.cache4k.Cache
 
-const val EMOJI_SUGGESTION_INDICATOR = ':'
-const val EMOJI_SUGGESTION_MAX_COUNT = 5
-private const val EMOJI_SUGGESTION_QUERY_MIN_LENGTH = 3
-
 /**
  * Provides emoji suggestions within a text input context.
  *
@@ -30,7 +42,7 @@ class EmojiSuggestionProvider(private val context: Context) : SuggestionProvider
     override val providerId = "org.florisboard.nlp.providers.emoji"
 
     private val prefs by florisPreferenceModel()
-    private val lettersRegex = "^:[A-Za-z]*$".toRegex()
+    private val lettersRegex = "^[A-Za-z]*$".toRegex()
 
     private val cachedEmojiMappings = Cache.Builder().build<FlorisLocale, EmojiDataBySkinTone>()
 
@@ -52,7 +64,7 @@ class EmojiSuggestionProvider(private val context: Context) : SuggestionProvider
         allowPossiblyOffensive: Boolean,
         isPrivateSession: Boolean
     ): List<SuggestionCandidate> {
-        val preferredSkinTone = prefs.media.emojiPreferredSkinTone.get()
+        val preferredSkinTone = prefs.emoji.preferredSkinTone.get()
         val query = validateInputQuery(content.composingText) ?: return emptyList()
         val emojis = cachedEmojiMappings.get(subtype.primaryLocale)?.get(preferredSkinTone) ?: emptyList()
         val candidates = withContext(Dispatchers.Default) {
@@ -90,15 +102,18 @@ class EmojiSuggestionProvider(private val context: Context) : SuggestionProvider
      * Validates the user input query for emoji suggestions.
      */
     private fun validateInputQuery(composingText: CharSequence): String? {
-        if (!composingText.startsWith(EMOJI_SUGGESTION_INDICATOR)) {
+        val prefix = prefs.emoji.suggestionType.get().prefix
+        val queryMinLength = prefs.emoji.suggestionQueryMinLength.get() + prefix.length
+        if (prefix.isNotEmpty() && !composingText.startsWith(prefix)) {
             return null
         }
-        if (composingText.length <= EMOJI_SUGGESTION_QUERY_MIN_LENGTH) {
+        if (composingText.length < queryMinLength) {
             return null
         }
-        if (!lettersRegex.matches(composingText)) {
+        val emojiPartialName = composingText.substring(prefix.length)
+        if (!lettersRegex.matches(emojiPartialName)) {
             return null
         }
-        return composingText.substring(1)
+        return emojiPartialName
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionType.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionType.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.media.emoji
+
+enum class EmojiSuggestionType(val prefix: String) {
+    LEADING_COLON(":"),
+    INLINE_TEXT(""),
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
@@ -20,7 +20,7 @@ import android.icu.text.BreakIterator
 import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.editor.EditorContent
 import dev.patrickgold.florisboard.ime.editor.EditorRange
-import dev.patrickgold.florisboard.ime.media.emoji.EMOJI_SUGGESTION_INDICATOR
+import dev.patrickgold.florisboard.ime.media.emoji.EmojiSuggestionType
 
 /**
  * Base interface for any NLP provider implementation. NLP providers maintain their own internal state and only receive
@@ -221,7 +221,7 @@ interface SuggestionProvider : NlpProvider {
                     // Include Emoji indicator in local composing. This is required so that emoji suggestion indicator'
                     // can be detected in the composing text.
                     (pos - 1).takeIf { updatedPos ->
-                        textBeforeSelection.getOrNull(updatedPos) == EMOJI_SUGGESTION_INDICATOR
+                        textBeforeSelection.getOrNull(updatedPos) == EmojiSuggestionType.LEADING_COLON.prefix.first()
                     } ?: pos
                 }
                 EditorRange(start, end)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/SuggestionCandidate.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/SuggestionCandidate.kt
@@ -157,6 +157,7 @@ data class ClipboardSuggestionCandidate(
  */
 data class EmojiSuggestionCandidate(
     val emoji: Emoji,
+    val showName: Boolean,
     override val confidence: Double = 1.0,
     override val isEligibleForAutoCommit: Boolean = false,
     override val isEligibleForUserRemoval: Boolean = false,
@@ -164,5 +165,5 @@ data class EmojiSuggestionCandidate(
     override val sourceProvider: SuggestionProvider? = null,
 ) : SuggestionCandidate {
     override val text = emoji.value
-    override val secondaryText = emoji.name
+    override val secondaryText = if (showName) emoji.name else null
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,12 @@
     <string name="prefs__media__emoji_recently_used_max_size">Emoji history max size</string>
     <string name="prefs__media__emoji_preferred_skin_tone">Preferred emoji skin tone</string>
     <string name="prefs__media__emoji_preferred_hair_style">Preferred emoji hair style</string>
+    <string name="prefs__media__emoji_suggestion__title" comment="Preference group title">Emoji suggestions</string>
+    <string name="prefs__media__emoji_suggestion_enabled" comment="Preference title">Display emoji suggestions</string>
+    <string name="prefs__media__emoji_suggestion_enabled__summary" comment="Preference summary">Provide emoji suggestions while you type</string>
+    <string name="prefs__media__emoji_suggestion_type" comment="Preference title">Trigger type</string>
+    <string name="prefs__media__emoji_suggestion_query_min_length" comment="Preference title">Minimum query length</string>
+    <string name="prefs__media__emoji_suggestion_candidate_max_count" comment="Preference title">Maximum candidate count</string>
 
     <!-- Emoji strings -->
     <string name="emoji__category__smileys_emotion" comment="Emoji category name">Smileys &amp; Emotions</string>
@@ -806,6 +812,11 @@
     <string name="enum__emoji_hair_style__white_hair" comment="Enum value label">{emoji} White hair</string>
     <string name="enum__emoji_hair_style__bald" comment="Enum value label">{emoji} Bald</string>
 
+    <string name="enum__emoji_suggestion_type__leading_colon">Leading colon</string>
+    <string name="enum__emoji_suggestion_type__leading_colon__description" comment="Keep the :emoji_name while translating, this is a syntax guide">Suggest emojis using the :emoji_name syntax</string>
+    <string name="enum__emoji_suggestion_type__inline_text">Inline text</string>
+    <string name="enum__emoji_suggestion_type__inline_text__description">Suggest emojis simply by typing the emoji name as a word</string>
+
     <string name="enum__extended_actions_placement__above_candidates" comment="Enum value label">Above candidates</string>
     <string name="enum__extended_actions_placement__above_candidates__description" comment="Enum value description">Places the extended actions row between the app UI and the candidate row</string>
     <string name="enum__extended_actions_placement__below_candidates" comment="Enum value label">Below candidates</string>
@@ -945,6 +956,14 @@
     <plurals name="unit__items__written">
         <item quantity="one">{v} item</item>
         <item quantity="other">{v} items</item>
+    </plurals>
+    <plurals name="unit__characters__written">
+        <item quantity="one">{v} character</item>
+        <item quantity="other">{v} characters</item>
+    </plurals>
+    <plurals name="unit__candidates__written">
+        <item quantity="one">{v} candidate</item>
+        <item quantity="other">{v} candidates</item>
     </plurals>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,11 +19,13 @@
     <string name="prefs__media__emoji_preferred_skin_tone">Preferred emoji skin tone</string>
     <string name="prefs__media__emoji_preferred_hair_style">Preferred emoji hair style</string>
     <string name="prefs__media__emoji_suggestion__title" comment="Preference group title">Emoji suggestions</string>
-    <string name="prefs__media__emoji_suggestion_enabled" comment="Preference title">Display emoji suggestions</string>
+    <string name="prefs__media__emoji_suggestion_enabled" comment="Preference title">Enable emoji suggestions</string>
     <string name="prefs__media__emoji_suggestion_enabled__summary" comment="Preference summary">Provide emoji suggestions while you type</string>
     <string name="prefs__media__emoji_suggestion_type" comment="Preference title">Trigger type</string>
     <string name="prefs__media__emoji_suggestion_query_min_length" comment="Preference title">Minimum query length</string>
     <string name="prefs__media__emoji_suggestion_candidate_max_count" comment="Preference title">Maximum candidate count</string>
+    <string name="prefs__media__emoji_suggestion_candidate_show_name" comment="Preference title">Emoji name visibility</string>
+    <string name="prefs__media__emoji_suggestion_candidate_show_name__summary" comment="Preference summary">Show emoji name below suggested emoji</string>
 
     <!-- Emoji strings -->
     <string name="emoji__category__smileys_emotion" comment="Emoji category name">Smileys &amp; Emotions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,10 +22,12 @@
     <string name="prefs__media__emoji_suggestion_enabled" comment="Preference title">Enable emoji suggestions</string>
     <string name="prefs__media__emoji_suggestion_enabled__summary" comment="Preference summary">Provide emoji suggestions while you type</string>
     <string name="prefs__media__emoji_suggestion_type" comment="Preference title">Trigger type</string>
+    <string name="prefs__media__emoji_suggestion_update_history" comment="Preference title">Update emoji history</string>
+    <string name="prefs__media__emoji_suggestion_update_history__summary" comment="Preference summary">Accepting suggested emojis adds them to the emoji history</string>
+    <string name="prefs__media__emoji_suggestion_candidate_show_name" comment="Preference title">Show emoji name</string>
+    <string name="prefs__media__emoji_suggestion_candidate_show_name__summary" comment="Preference summary">Emoji suggestions display their name alongside the emoji</string>
     <string name="prefs__media__emoji_suggestion_query_min_length" comment="Preference title">Minimum query length</string>
     <string name="prefs__media__emoji_suggestion_candidate_max_count" comment="Preference title">Maximum candidate count</string>
-    <string name="prefs__media__emoji_suggestion_candidate_show_name" comment="Preference title">Emoji name visibility</string>
-    <string name="prefs__media__emoji_suggestion_candidate_show_name__summary" comment="Preference summary">Show emoji name below suggested emoji</string>
 
     <!-- Emoji strings -->
     <string name="emoji__category__smileys_emotion" comment="Emoji category name">Smileys &amp; Emotions</string>


### PR DESCRIPTION
This PR is a major rework of the emoji suggestions, the main goal of this is to make the UX for configuring the emoji suggestions better and to improve behavior.

List of changes:
- Add separate toggle for enabling emoji suggestions.
  - This now allows using emoji suggestions _independently_ of the normal typing suggestions being enabled/disabled
- Add trigger type option, allowing toggling between leading colon (`:emoji_name`) syntax inline word detection method
- Add toggle for allowing automatic updates of the emoji recently used history if an emoji suggestion is accepted. Defaults to true
- Add toggle allowing showing/hiding the emoji name below the suggested emoji in the Smartbar
- Allow configuring internal minimum query length and maximum candidate count parameters
- Fix emoji data parsing for non-default variants (closes #2604)
- Other small bug fixes

Screenshot of the new Media screen:

![image](https://github.com/user-attachments/assets/9520b3f9-0b86-4e94-8f88-2283d429fa76)
