### PR TITLE
Major rework of emoji history

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -31,7 +31,7 @@ import dev.patrickgold.florisboard.ime.keyboard.IncognitoMode
 import dev.patrickgold.florisboard.ime.keyboard.SpaceBarMode
 import dev.patrickgold.florisboard.ime.landscapeinput.LandscapeInputUiMode
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiHairStyle
-import dev.patrickgold.florisboard.ime.media.emoji.EmojiRecentlyUsedHelper
+import dev.patrickgold.florisboard.ime.media.emoji.EmojiHistory
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSkinTone
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSuggestionType
 import dev.patrickgold.florisboard.ime.nlp.SpellingLanguageMode
@@ -196,15 +196,6 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
 
     val emoji = Emoji()
     inner class Emoji {
-        val recentlyUsed = custom(
-            key = "emoji__recently_used",
-            default = emptyList(),
-            serializer = EmojiRecentlyUsedHelper.Serializer,
-        )
-        val recentlyUsedMaxSize = int(
-            key = "emoji__recently_used_max_size",
-            default = 90,
-        )
         val preferredSkinTone = enum(
             key = "emoji__preferred_skin_tone",
             default = EmojiSkinTone.DEFAULT,
@@ -212,6 +203,19 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
         val preferredHairStyle = enum(
             key = "emoji__preferred_hair_style",
             default = EmojiHairStyle.DEFAULT,
+        )
+        val historyEnabled = boolean(
+            key = "emoji__history_enabled",
+            default = true,
+        )
+        val historyData = custom(
+            key = "emoji__history_data",
+            default = emptyList(),
+            serializer = EmojiHistory.Serializer,
+        )
+        val historyMaxSize = int(
+            key = "emoji__history_max_size",
+            default = 90,
         )
         val suggestionEnabled = boolean(
             key = "emoji__suggestion_enabled",
@@ -733,10 +737,10 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
             // Migrate media prefs to emoji prefs
             // Keep migration rule until: 0.6 dev cycle
             "media__emoji_recently_used" -> {
-                entry.transform(key = "emoji__recently_used")
+                entry.transform(key = "emoji__history_data")
             }
             "media__emoji_recently_used_max_size" -> {
-                entry.transform(key = "emoji__recently_used_max_size")
+                entry.transform(key = "emoji__history_max_size")
             }
             "media__emoji_preferred_skin_tone" -> {
                 entry.transform(

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/EnumDisplayEntries.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/EnumDisplayEntries.kt
@@ -11,6 +11,7 @@ import dev.patrickgold.florisboard.ime.input.InputFeedbackActivationMode
 import dev.patrickgold.florisboard.ime.keyboard.IncognitoMode
 import dev.patrickgold.florisboard.ime.keyboard.SpaceBarMode
 import dev.patrickgold.florisboard.ime.landscapeinput.LandscapeInputUiMode
+import dev.patrickgold.florisboard.ime.media.emoji.EmojiHistory
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSkinTone
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSuggestionType
 import dev.patrickgold.florisboard.ime.nlp.SpellingLanguageMode
@@ -136,6 +137,30 @@ private val ENUM_DISPLAY_ENTRIES = mapOf<Pair<KClass<*>, String>, @Composable ()
                 label = stringRes(R.string.enum__display_language_names_in__native_locale),
                 description = stringRes(R.string.enum__display_language_names_in__native_locale__description),
                 showDescriptionOnlyIfSelected = true,
+            )
+        }
+    },
+    EmojiHistory.UpdateStrategy::class to DEFAULT to {
+        listPrefEntries {
+            entry(
+                key = EmojiHistory.UpdateStrategy.AUTO_SORT_PREPEND,
+                label = stringRes(R.string.enum__emoji_history_update_strategy__auto_sort_prepend),
+                description = stringRes(R.string.enum__emoji_history_update_strategy__auto_sort_prepend__description),
+            )
+            entry(
+                key = EmojiHistory.UpdateStrategy.AUTO_SORT_APPEND,
+                label = stringRes(R.string.enum__emoji_history_update_strategy__auto_sort_append),
+                description = stringRes(R.string.enum__emoji_history_update_strategy__auto_sort_append__description),
+            )
+            entry(
+                key = EmojiHistory.UpdateStrategy.MANUAL_SORT_PREPEND,
+                label = stringRes(R.string.enum__emoji_history_update_strategy__manual_sort_prepend),
+                description = stringRes(R.string.enum__emoji_history_update_strategy__manual_sort_prepend__description),
+            )
+            entry(
+                key = EmojiHistory.UpdateStrategy.MANUAL_SORT_APPEND,
+                label = stringRes(R.string.enum__emoji_history_update_strategy__manual_sort_append),
+                description = stringRes(R.string.enum__emoji_history_update_strategy__manual_sort_append__description),
             )
         }
     },

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Patrick Goldinger
+ * Copyright (C) 2024 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package dev.patrickgold.florisboard.app.settings.media
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.EmojiSymbols
+import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.runtime.Composable
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.enumDisplayEntriesOf
@@ -45,20 +46,31 @@ fun MediaScreen() = FlorisScreen {
             title = stringRes(R.string.prefs__media__emoji_preferred_skin_tone),
             entries = enumDisplayEntriesOf(EmojiSkinTone::class),
         )
-        DialogSliderPreference(
-            prefs.emoji.recentlyUsedMaxSize,
-            title = stringRes(R.string.prefs__media__emoji_recently_used_max_size),
-            valueLabel = { maxSize ->
-                if (maxSize == 0) {
-                    stringRes(R.string.general__unlimited)
-                } else {
-                    pluralsRes(R.plurals.unit__items__written, maxSize, "v" to maxSize)
-                }
-            },
-            min = 0,
-            max = 120,
-            stepIncrement = 1,
-        )
+
+        PreferenceGroup(title = stringRes(R.string.prefs__media__emoji_history__title)) {
+            SwitchPreference(
+                prefs.emoji.historyEnabled,
+                icon = Icons.Outlined.Schedule,
+                title = stringRes(R.string.prefs__media__emoji_history_enabled),
+                summary = stringRes(R.string.prefs__media__emoji_history_enabled__summary),
+            )
+            DialogSliderPreference(
+                prefs.emoji.historyMaxSize,
+                title = stringRes(R.string.prefs__media__emoji_history_max_size),
+                valueLabel = { maxSize ->
+                    if (maxSize == 0) {
+                        stringRes(R.string.general__unlimited)
+                    } else {
+                        pluralsRes(R.plurals.unit__items__written, maxSize, "v" to maxSize)
+                    }
+                },
+                min = 0,
+                max = 120,
+                stepIncrement = 1,
+                enabledIf = { prefs.emoji.historyEnabled.isTrue() },
+            )
+        }
+
         PreferenceGroup(title = stringRes(R.string.prefs__media__emoji_suggestion__title)) {
             SwitchPreference(
                 prefs.emoji.suggestionEnabled,
@@ -76,7 +88,9 @@ fun MediaScreen() = FlorisScreen {
                 prefs.emoji.suggestionUpdateHistory,
                 title = stringRes(R.string.prefs__media__emoji_suggestion_update_history),
                 summary = stringRes(R.string.prefs__media__emoji_suggestion_update_history__summary),
-                enabledIf = { prefs.emoji.suggestionEnabled.isTrue() },
+                enabledIf = {
+                    prefs.emoji.suggestionEnabled.isTrue() && prefs.emoji.historyEnabled.isTrue()
+                },
             )
             SwitchPreference(
                 prefs.emoji.suggestionCandidateShowName,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/media/MediaScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.runtime.Composable
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.enumDisplayEntriesOf
+import dev.patrickgold.florisboard.ime.media.emoji.EmojiHistory
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSkinTone
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSuggestionType
 import dev.patrickgold.florisboard.lib.compose.FlorisScreen
@@ -54,11 +55,26 @@ fun MediaScreen() = FlorisScreen {
                 title = stringRes(R.string.prefs__media__emoji_history_enabled),
                 summary = stringRes(R.string.prefs__media__emoji_history_enabled__summary),
             )
+            ListPreference(
+                prefs.emoji.historyPinnedUpdateStrategy,
+                title = stringRes(R.string.prefs__media__emoji_history_pinned_update_strategy),
+                entries = enumDisplayEntriesOf(EmojiHistory.UpdateStrategy::class),
+                enabledIf = { prefs.emoji.historyEnabled.isTrue() },
+            )
+            ListPreference(
+                prefs.emoji.historyRecentUpdateStrategy,
+                title = stringRes(R.string.prefs__media__emoji_history_recent_update_strategy),
+                entries = enumDisplayEntriesOf(EmojiHistory.UpdateStrategy::class),
+                enabledIf = { prefs.emoji.historyEnabled.isTrue() },
+            )
             DialogSliderPreference(
-                prefs.emoji.historyMaxSize,
+                primaryPref = prefs.emoji.historyPinnedMaxSize,
+                secondaryPref = prefs.emoji.historyRecentMaxSize,
                 title = stringRes(R.string.prefs__media__emoji_history_max_size),
+                primaryLabel = stringRes(R.string.emoji__history__pinned),
+                secondaryLabel = stringRes(R.string.emoji__history__recent),
                 valueLabel = { maxSize ->
-                    if (maxSize == 0) {
+                    if (maxSize == EmojiHistory.MaxSizeUnlimited) {
                         stringRes(R.string.general__unlimited)
                     } else {
                         pluralsRes(R.plurals.unit__items__written, maxSize, "v" to maxSize)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/Emoji.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/Emoji.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Patrick Goldinger
+ * Copyright (C) 2024 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,11 @@ import dev.patrickgold.florisboard.ime.keyboard.KeyData
 import dev.patrickgold.florisboard.ime.popup.PopupSet
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import java.util.stream.IntStream
 import kotlin.streams.toList
 
@@ -72,5 +77,17 @@ data class Emoji(val value: String, val name: String, val keywords: List<String>
 
     override fun toString(): String {
         return "Emoji { value=$value, name=$name, keywords=$keywords }"
+    }
+
+    object ValueOnlySerializer : KSerializer<Emoji> {
+        override val descriptor = PrimitiveSerialDescriptor("EmojiValueOnly", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: Emoji) {
+            encoder.encodeString(value.value)
+        }
+
+        override fun deserialize(decoder: Decoder): Emoji {
+            return Emoji(decoder.decodeString(), "", emptyList())
+        }
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiHistory.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiHistory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Patrick Goldinger
+ * Copyright (C) 2024 Patrick Goldinger
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,43 +17,206 @@
 package dev.patrickgold.florisboard.ime.media.emoji
 
 import dev.patrickgold.florisboard.app.AppPrefs
+import dev.patrickgold.florisboard.lib.devtools.flogError
 import dev.patrickgold.jetpref.datastore.model.PreferenceSerializer
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
-object EmojiHistory {
-    private const val DELIMITER = ";"
+@Serializable
+data class EmojiHistory(
+    val pinned: List<@Serializable(with = Emoji.ValueOnlySerializer::class) Emoji>,
+    val recent: List<@Serializable(with = Emoji.ValueOnlySerializer::class) Emoji>,
+) {
+    fun edit(): Editor {
+        return Editor(pinned.toMutableList(), recent.toMutableList())
+    }
 
+    data class Editor(
+        val pinned: MutableList<Emoji>,
+        val recent: MutableList<Emoji>,
+    ) {
+        fun build(): EmojiHistory {
+            return EmojiHistory(pinned.toList(), recent.toList())
+        }
+    }
+
+    enum class UpdateStrategy(val isAutomatic: Boolean, val isPrepend: Boolean) {
+        AUTO_SORT_PREPEND(isAutomatic = true, isPrepend = true),
+        AUTO_SORT_APPEND(isAutomatic = true, isPrepend = false),
+        MANUAL_SORT_PREPEND(isAutomatic = false, isPrepend = true),
+        MANUAL_SORT_APPEND(isAutomatic = false, isPrepend = false);
+    }
+
+    object Serializer : PreferenceSerializer<EmojiHistory> {
+        override fun serialize(value: EmojiHistory): String {
+            return Json.encodeToString(value)
+        }
+
+        override fun deserialize(value: String): EmojiHistory {
+            try {
+                return Json.decodeFromString(value)
+            } catch (e: Exception) {
+                flogError { "Failed to deserialize EmojiHistory: $e" }
+                return Empty
+            }
+        }
+    }
+
+    companion object {
+        val Empty = EmojiHistory(emptyList(), emptyList())
+
+        @Suppress("ConstPropertyName")
+        const val MaxSizeUnlimited: Int = 0
+    }
+}
+
+object EmojiHistoryHelper {
     private var emojiGuard = Mutex(locked = false)
 
-    suspend fun addEmoji(prefs: AppPrefs, emoji: Emoji) = emojiGuard.withLock {
+    suspend fun markEmojiUsed(prefs: AppPrefs, emoji: Emoji) = emojiGuard.withLock {
         if (!prefs.emoji.historyEnabled.get()) {
             return
         }
-        val maxSize = prefs.emoji.historyMaxSize.get().let { if (it == 0) Int.MAX_VALUE else it }
-        val list = prefs.emoji.historyData.get().toMutableList()
-        list.add(0, emoji)
-        prefs.emoji.historyData.set(list.distinctBy { it.value }.take(maxSize))
+
+        val dataMut = prefs.emoji.historyData.get().edit()
+        val pinnedUS = prefs.emoji.historyPinnedUpdateStrategy.get()
+        val recentUS = prefs.emoji.historyRecentUpdateStrategy.get()
+        val pinnedMaxSize = prefs.emoji.historyPinnedMaxSize.get().let { maxSize ->
+            if (maxSize == EmojiHistory.MaxSizeUnlimited) Int.MAX_VALUE else maxSize
+        }
+        val recentMaxSize = prefs.emoji.historyRecentMaxSize.get().let { maxSize ->
+            if (maxSize == EmojiHistory.MaxSizeUnlimited) Int.MAX_VALUE else maxSize
+        }
+
+        val pinnedIndex = dataMut.pinned.indexOf(emoji)
+        if (pinnedIndex != -1) {
+            if (pinnedUS.isAutomatic) {
+                dataMut.pinned.removeAt(pinnedIndex)
+                dataMut.pinned.addWithStrategy(pinnedUS, emoji)
+            } else {
+                // manual sort, keep item in place
+            }
+        } else {
+            val recentIndex = dataMut.recent.indexOf(emoji)
+            if (recentIndex != -1) {
+                if (recentUS.isAutomatic) {
+                    dataMut.recent.removeAt(recentIndex)
+                    dataMut.recent.addWithStrategy(recentUS, emoji)
+                } else {
+                    // manual sort, keep item in place
+                }
+            } else {
+                dataMut.recent.addWithStrategy(recentUS, emoji)
+            }
+        }
+
+        prefs.emoji.historyData.set(
+            EmojiHistory(
+                pinned = dataMut.pinned.takeWithStrategy(pinnedUS, pinnedMaxSize),
+                recent = dataMut.recent.takeWithStrategy(recentUS, recentMaxSize),
+            )
+        )
+    }
+
+    suspend fun pinEmoji(prefs: AppPrefs, emoji: Emoji) = emojiGuard.withLock {
+        if (!prefs.emoji.historyEnabled.get()) {
+            return
+        }
+
+        val dataMut = prefs.emoji.historyData.get().edit()
+        val pinnedUS = prefs.emoji.historyPinnedUpdateStrategy.get()
+
+        val recentIndex = dataMut.recent.indexOf(emoji)
+        if (recentIndex != -1) {
+            dataMut.recent.removeAt(recentIndex)
+            dataMut.pinned.addWithStrategy(pinnedUS, emoji)
+        }
+
+        prefs.emoji.historyData.set(dataMut.build())
+    }
+
+    suspend fun unpinEmoji(prefs: AppPrefs, emoji: Emoji) = emojiGuard.withLock {
+        if (!prefs.emoji.historyEnabled.get()) {
+            return
+        }
+
+        val dataMut = prefs.emoji.historyData.get().edit()
+        val recentUS = prefs.emoji.historyRecentUpdateStrategy.get()
+
+        val pinnedIndex = dataMut.pinned.indexOf(emoji)
+        if (pinnedIndex != -1) {
+            dataMut.pinned.removeAt(pinnedIndex)
+            dataMut.recent.addWithStrategy(recentUS, emoji)
+        }
+
+        prefs.emoji.historyData.set(dataMut.build())
+    }
+
+    suspend fun moveEmoji(prefs: AppPrefs, emoji: Emoji, offset: Int) = emojiGuard.withLock {
+        if (!prefs.emoji.historyEnabled.get() || offset == 0) {
+            return
+        }
+
+        val dataMut = prefs.emoji.historyData.get().edit()
+
+        val pinnedIndex = dataMut.pinned.indexOf(emoji)
+        if (pinnedIndex != -1) {
+            val newIndex = (pinnedIndex + offset).coerceIn(0, dataMut.pinned.size)
+            // Add first because removal messes up the index
+            dataMut.pinned.add(newIndex, emoji)
+            dataMut.pinned.removeAt(pinnedIndex)
+        } else {
+            val recentIndex = dataMut.recent.indexOf(emoji)
+            if (recentIndex != -1) {
+                val newIndex = (recentIndex + offset).coerceIn(0, dataMut.recent.size)
+                // Add first because removal messes up the index
+                dataMut.recent.add(newIndex, emoji)
+                dataMut.recent.removeAt(recentIndex)
+            }
+        }
+
+        prefs.emoji.historyData.set(dataMut.build())
     }
 
     suspend fun removeEmoji(prefs: AppPrefs, emoji: Emoji) = emojiGuard.withLock {
         if (!prefs.emoji.historyEnabled.get()) {
             return
         }
-        val list = prefs.emoji.historyData.get().toMutableList()
-        list.remove(emoji)
-        prefs.emoji.historyData.set(list.distinctBy { it.value })
-    }
 
-    object Serializer : PreferenceSerializer<List<Emoji>> {
-        override fun serialize(value: List<Emoji>): String {
-            return value.joinToString(DELIMITER) { it.value }
+        val dataMut = prefs.emoji.historyData.get().edit()
+
+        val pinnedIndex = dataMut.pinned.indexOf(emoji)
+        if (pinnedIndex != -1) {
+            dataMut.pinned.removeAt(pinnedIndex)
+        } else {
+            val recentIndex = dataMut.recent.indexOf(emoji)
+            if (recentIndex != -1) {
+                dataMut.recent.removeAt(recentIndex)
+            }
         }
 
-        override fun deserialize(value: String): List<Emoji> {
-            return value.split(DELIMITER).mapNotNull { rawValue ->
-                rawValue.trim().let { if (it.isBlank()) null else Emoji(it.trim(), "", emptyList()) }
-            }
+        prefs.emoji.historyData.set(dataMut.build())
+    }
+
+    private fun MutableList<Emoji>.addWithStrategy(strategy: EmojiHistory.UpdateStrategy, emoji: Emoji) {
+        if (strategy.isPrepend) {
+            add(0, emoji)
+        } else {
+            add(emoji)
+        }
+    }
+
+    private fun MutableList<Emoji>.takeWithStrategy(
+        strategy: EmojiHistory.UpdateStrategy,
+        n: Int,
+    ): List<Emoji> {
+        return if (strategy.isPrepend) {
+            take(n)
+        } else {
+            takeLast(n)
         }
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiHistory.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiHistory.kt
@@ -164,17 +164,11 @@ object EmojiHistoryHelper {
 
         val pinnedIndex = dataMut.pinned.indexOf(emoji)
         if (pinnedIndex != -1) {
-            val newIndex = (pinnedIndex + offset).coerceIn(0, dataMut.pinned.size)
-            // Add first because removal messes up the index
-            dataMut.pinned.add(newIndex, emoji)
-            dataMut.pinned.removeAt(pinnedIndex)
+            dataMut.pinned.move(pinnedIndex, offset)
         } else {
             val recentIndex = dataMut.recent.indexOf(emoji)
             if (recentIndex != -1) {
-                val newIndex = (recentIndex + offset).coerceIn(0, dataMut.recent.size)
-                // Add first because removal messes up the index
-                dataMut.recent.add(newIndex, emoji)
-                dataMut.recent.removeAt(recentIndex)
+                dataMut.recent.move(recentIndex, offset)
             }
         }
 
@@ -217,6 +211,16 @@ object EmojiHistoryHelper {
             take(n)
         } else {
             takeLast(n)
+        }
+    }
+
+    private fun MutableList<Emoji>.move(itemIndex: Int, offset: Int) {
+        val newIndex = (itemIndex + offset).coerceIn(0..<size)
+        val item = removeAt(itemIndex)
+        if (newIndex == size) {
+            add(item)
+        } else {
+            add(newIndex, item)
         }
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiHistory.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiHistory.kt
@@ -30,15 +30,10 @@ object EmojiHistory {
         if (!prefs.emoji.historyEnabled.get()) {
             return
         }
-        val maxSize = prefs.emoji.historyMaxSize.get()
+        val maxSize = prefs.emoji.historyMaxSize.get().let { if (it == 0) Int.MAX_VALUE else it }
         val list = prefs.emoji.historyData.get().toMutableList()
         list.add(0, emoji)
-        if (maxSize > 0) {
-            while (list.size > maxSize) {
-                list.removeLast()
-            }
-        }
-        prefs.emoji.historyData.set(list.distinctBy { it.value })
+        prefs.emoji.historyData.set(list.distinctBy { it.value }.take(maxSize))
     }
 
     suspend fun removeEmoji(prefs: AppPrefs, emoji: Emoji) = emojiGuard.withLock {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiPaletteView.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiPaletteView.kt
@@ -257,7 +257,7 @@ fun EmojiPaletteView(
                         .padding(all = 8.dp),
                 ) {
                     Text(
-                        text = stringRes(R.string.emoji__recently_used__phone_locked_message),
+                        text = stringRes(R.string.emoji__history__phone_locked_message),
                         color = contentColor,
                     )
                 }
@@ -268,12 +268,12 @@ fun EmojiPaletteView(
                         .padding(all = 8.dp),
                 ) {
                     Text(
-                        text = stringRes(R.string.emoji__recently_used__empty_message),
+                        text = stringRes(R.string.emoji__history__empty_message),
                         color = contentColor,
                     )
                     Text(
                         modifier = Modifier.padding(top = 8.dp),
-                        text = stringRes(R.string.emoji__recently_used__removal_tip),
+                        text = stringRes(R.string.emoji__history__usage_tip),
                         color = contentColor,
                         fontStyle = FontStyle.Italic,
                     )
@@ -528,6 +528,10 @@ private fun EmojiHistoryPopup(
     val popupStyle = FlorisImeTheme.style.get(element = FlorisImeUi.EmojiKeyPopup)
     val emojiKeyHeight = FlorisImeSizing.smartbarHeight
     val context = LocalContext.current
+    val pinnedUS by prefs.emoji.historyPinnedUpdateStrategy.observeAsState()
+    val recentUS by prefs.emoji.historyRecentUpdateStrategy.observeAsState()
+    val showMoveLeft = isCurrentlyPinned && !pinnedUS.isAutomatic || !recentUS.isAutomatic
+    val showMoveRight = isCurrentlyPinned && !pinnedUS.isAutomatic || !recentUS.isAutomatic
 
     @Composable
     fun Action(icon: ImageVector, action: suspend () -> Unit) {
@@ -586,12 +590,28 @@ private fun EmojiHistoryPopup(
                         },
                     )
                 }
+                if (showMoveLeft) {
+                    Action(
+                        icon = Icons.AutoMirrored.Default.KeyboardArrowLeft,
+                        action = {
+                            EmojiHistoryHelper.moveEmoji(prefs, emoji, -1)
+                        },
+                    )
+                }
+                if (showMoveRight) {
+                    Action(
+                        icon = Icons.AutoMirrored.Default.KeyboardArrowRight,
+                        action = {
+                            EmojiHistoryHelper.moveEmoji(prefs, emoji, 1)
+                        },
+                    )
+                }
                 Action(
                     icon = Icons.Outlined.Delete,
                     action = {
                         EmojiHistoryHelper.removeEmoji(prefs, emoji)
                         context.showShortToast(
-                            R.string.emoji__recently_used__removal_success_message,
+                            R.string.emoji__history__removal_success_message,
                             "emoji" to emoji.value,
                         )
                     },

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
@@ -92,7 +92,7 @@ class EmojiSuggestionProvider(private val context: Context) : SuggestionProvider
         if (!updateHistory || candidate !is EmojiSuggestionCandidate) {
             return
         }
-        EmojiHistory.addEmoji(prefs, candidate.emoji)
+        EmojiHistoryHelper.markEmojiUsed(prefs, candidate.emoji)
     }
 
     override suspend fun notifySuggestionReverted(subtype: Subtype, candidate: SuggestionCandidate) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
@@ -92,7 +92,7 @@ class EmojiSuggestionProvider(private val context: Context) : SuggestionProvider
         if (!updateHistory || candidate !is EmojiSuggestionCandidate) {
             return
         }
-        EmojiRecentlyUsedHelper.addEmoji(prefs, candidate.emoji)
+        EmojiHistory.addEmoji(prefs, candidate.emoji)
     }
 
     override suspend fun notifySuggestionReverted(subtype: Subtype, candidate: SuggestionCandidate) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/LazyGrid.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/LazyGrid.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Patrick Goldinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.lib.compose
+
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridItemScope
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.runtime.Composable
+
+fun LazyGridScope.header(
+    key: Any? = null,
+    content: @Composable LazyGridItemScope.() -> Unit,
+) {
+    item(key, span = { GridItemSpan(this.maxLineSpan) }, content = content)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,10 +44,10 @@
     <string name="emoji__category__objects" comment="Emoji category name">Objects</string>
     <string name="emoji__category__symbols" comment="Emoji category name">Symbols</string>
     <string name="emoji__category__flags" comment="Emoji category name">Flags</string>
-    <string name="emoji__recently_used__empty_message" comment="Message if no recently used emojis exist">No recently used emojis found. Once you start typing emojis they will automatically appear here.</string>
-    <string name="emoji__recently_used__phone_locked_message" comment="Message to show if phone is locked">To access your emoji history, please first unlock your device.</string>
-    <string name="emoji__recently_used__removal_tip" comment="Feature discoverability for removal of recently used emojis">Pro tip: Long press recently used emojis to remove them from this view again!</string>
-    <string name="emoji__recently_used__removal_success_message" comment="Toast message if user has long pressed emoji in recently used collection to remove it">Removed {emoji} from recently used emojis</string>
+    <string name="emoji__history__empty_message" comment="Message if the emoji history is empty">No recently used emojis found. Once you start typing emojis they will automatically appear here.</string>
+    <string name="emoji__history__phone_locked_message" comment="Message to show if phone is locked">To access your emoji history, please first unlock your device.</string>
+    <string name="emoji__history__usage_tip" comment="Feature discoverability for actions of emoji history">Pro tip: Long press emojis in the emoji history to pin or remove them!</string>
+    <string name="emoji__history__removal_success_message" comment="Toast message if user has used the delete action on an emoji in the emoji history">Removed {emoji} from emoji history</string>
     <string name="emoji__history__pinned">Pinned</string>
     <string name="emoji__history__recent">Recent</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,9 +15,12 @@
     <string name="media__tab__emojis" comment="Tab description for emojis in the media UI">Emojis</string>
     <string name="media__tab__emoticons" comment="Tab description for emoticons in the media UI">Emoticons</string>
     <string name="media__tab__kaomoji" comment="Tab description for kaomoji in the media UI">Kaomoji</string>
-    <string name="prefs__media__emoji_recently_used_max_size">Emoji history max size</string>
     <string name="prefs__media__emoji_preferred_skin_tone">Preferred emoji skin tone</string>
     <string name="prefs__media__emoji_preferred_hair_style">Preferred emoji hair style</string>
+    <string name="prefs__media__emoji_history__title" comment="Preference group title">Emoji history</string>
+    <string name="prefs__media__emoji_history_enabled" comment="Preference title">Enable emoji history</string>
+    <string name="prefs__media__emoji_history_enabled__summary" comment="Preference summary">Retain recently used emojis for quick access</string>
+    <string name="prefs__media__emoji_history_max_size">Maximum items to keep</string>
     <string name="prefs__media__emoji_suggestion__title" comment="Preference group title">Emoji suggestions</string>
     <string name="prefs__media__emoji_suggestion_enabled" comment="Preference title">Enable emoji suggestions</string>
     <string name="prefs__media__emoji_suggestion_enabled__summary" comment="Preference summary">Provide emoji suggestions while you type</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="prefs__media__emoji_history__title" comment="Preference group title">Emoji history</string>
     <string name="prefs__media__emoji_history_enabled" comment="Preference title">Enable emoji history</string>
     <string name="prefs__media__emoji_history_enabled__summary" comment="Preference summary">Retain recently used emojis for quick access</string>
+    <string name="prefs__media__emoji_history_pinned_update_strategy" comment="Preference title">Update strategy (Pinned)</string>
+    <string name="prefs__media__emoji_history_recent_update_strategy" comment="Preference title">Update strategy (Recent)</string>
     <string name="prefs__media__emoji_history_max_size">Maximum items to keep</string>
     <string name="prefs__media__emoji_suggestion__title" comment="Preference group title">Emoji suggestions</string>
     <string name="prefs__media__emoji_suggestion_enabled" comment="Preference title">Enable emoji suggestions</string>
@@ -46,6 +48,8 @@
     <string name="emoji__recently_used__phone_locked_message" comment="Message to show if phone is locked">To access your emoji history, please first unlock your device.</string>
     <string name="emoji__recently_used__removal_tip" comment="Feature discoverability for removal of recently used emojis">Pro tip: Long press recently used emojis to remove them from this view again!</string>
     <string name="emoji__recently_used__removal_success_message" comment="Toast message if user has long pressed emoji in recently used collection to remove it">Removed {emoji} from recently used emojis</string>
+    <string name="emoji__history__pinned">Pinned</string>
+    <string name="emoji__history__recent">Recent</string>
 
     <!-- Quick action strings -->
     <string name="quick_action__arrow_up" maxLength="12">Arrow up</string>
@@ -805,6 +809,15 @@
     <string name="enum__display_language_names_in__system_locale__description" comment="Enum value description">Language names across the app and keyboard UI are displayed in the locale which is set for the whole device</string>
     <string name="enum__display_language_names_in__native_locale" comment="Enum value label">Native locale</string>
     <string name="enum__display_language_names_in__native_locale__description" comment="Enum value description">Language names across the app and keyboard UI are displayed in the locale referred by itself</string>
+
+    <string name="enum__emoji_history_update_strategy__auto_sort_prepend" comment="Enum value label">Auto sort (prepend)</string>
+    <string name="enum__emoji_history_update_strategy__auto_sort_prepend__description" comment="Enum value description">Automatically reorder emojis on emoji usage. New emojis are added to the start.</string>
+    <string name="enum__emoji_history_update_strategy__auto_sort_append" comment="Enum value label">Auto sort (append)</string>
+    <string name="enum__emoji_history_update_strategy__auto_sort_append__description" comment="Enum value description">Automatically reorder emojis on emoji usage. New emojis are added to the end.</string>
+    <string name="enum__emoji_history_update_strategy__manual_sort_prepend" comment="Enum value label">Manual sort (prepend)</string>
+    <string name="enum__emoji_history_update_strategy__manual_sort_prepend__description" comment="Enum value description">Do not automatically reorder emojis on emoji usage. New emojis are added to the start.</string>
+    <string name="enum__emoji_history_update_strategy__manual_sort_append" comment="Enum value label">Manual sort (append)</string>
+    <string name="enum__emoji_history_update_strategy__manual_sort_append__description" comment="Enum value description">Do not automatically reorder emojis on emoji usage. New emojis are added to the end.</string>
 
     <string name="enum__emoji_skin_tone__default" comment="Enum value label">{emoji} Default skin tone</string>
     <string name="enum__emoji_skin_tone__light_skin_tone" comment="Enum value label">{emoji} Light skin tone</string>


### PR DESCRIPTION
This PR's main goal is to fully rework the internal behavior of the emoji history and to add a few new fetaures. List of changes:

- Add ability to enable/disable emoji history (closes #1990)
- Add ability to pin emojis in emoji history (closes #2273)
- Add ability to manually reorder emojis in history (closes #1975)
- Fix emoji history update bug if items is max size (closes #2129)
- Rewrite emoji history logic and data class

#### Screenshot of the new emoji history settings:

![image](https://github.com/user-attachments/assets/7a80c794-7b3f-4ff7-9b0b-fdc1f2621e17)

#### Screenshot of the updated emoji history:

![image](https://github.com/user-attachments/assets/cbf907ad-862c-423a-9b5d-ead06b454ad9)
