### PR TITLE
Disable compose strong skipping mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
 import java.io.ByteArrayOutputStream
 
 plugins {
@@ -159,6 +160,12 @@ android {
             it.useJUnitPlatform()
         }
     }
+}
+
+composeCompiler {
+    // DO NOT ENABLE STRONG SKIPPING! This project currently relies on
+    // recomposition on parent state change to update the UI correctly.
+    featureFlags.add(ComposeFeatureFlag.StrongSkipping.disabled())
 }
 
 tasks.withType<Test> {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
@@ -316,7 +316,7 @@ fun TextKeyboardLayout(
         val debugShowTouchBoundaries by prefs.devtools.showKeyTouchBoundaries.observeAsState()
         for (textKey in keyboard.keys()) {
             TextKeyButton(
-                textKey, desiredKey, evaluator, fontSizeMultiplier, isSmartbarKeyboard,
+                textKey, evaluator, fontSizeMultiplier, isSmartbarKeyboard,
                 debugShowTouchBoundaries,
             )
         }
@@ -336,7 +336,6 @@ fun TextKeyboardLayout(
 @Composable
 private fun TextKeyButton(
     key: TextKey,
-    desiredKey: TextKey,
     evaluator: ComputingEvaluator,
     fontSizeMultiplier: Float,
     isSmartbarKey: Boolean,
@@ -359,9 +358,7 @@ private fun TextKeyButton(
         KeyCode.VIEW_NUMERIC_ADVANCED -> 0.55f
         else -> 1.0f
     }
-    val size = remember(desiredKey) {
-        key.visibleBounds.size.toDpSize()
-    }
+    val size = key.visibleBounds.size.toDpSize()
     Box(
         modifier = Modifier
             .requiredSize(size)


### PR DESCRIPTION
This PR disables [compose strong skipping mode](https://developer.android.com/develop/ui/compose/performance/stability/strongskipping), which causes all sorts of state bugs in FlorisBoard. Long-term goal is to support strong-skipping, but for now keep it disabled.

Closes #2629 