### PR TITLE
Fix migration in clipboard database

### DIFF
--- a/app/schemas/dev.patrickgold.florisboard.ime.clipboard.provider.ClipboardHistoryDatabase/3.json
+++ b/app/schemas/dev.patrickgold.florisboard.ime.clipboard.provider.ClipboardHistoryDatabase/3.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 3,
-    "identityHash": "282a1b421e498fd0e21c055b6a4315e0",
+    "identityHash": "145ca5bf4bff8e98f71ebc70ab3b495b",
     "entities": [
       {
         "tableName": "clipboard_history",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` INTEGER NOT NULL, `text` TEXT, `uri` TEXT, `creationTimestampMs` INTEGER NOT NULL, `isPinned` INTEGER NOT NULL, `mimeTypes` TEXT NOT NULL, `isSensitive` INTEGER NOT NULL, `isRemoteDevice` INTEGER NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` INTEGER NOT NULL, `text` TEXT, `uri` TEXT, `creationTimestampMs` INTEGER NOT NULL, `isPinned` INTEGER NOT NULL, `mimeTypes` TEXT NOT NULL, `isSensitive` INTEGER NOT NULL DEFAULT 0, `isRemoteDevice` INTEGER NOT NULL DEFAULT 0)",
         "fields": [
           {
             "fieldPath": "id",
@@ -54,13 +54,15 @@
             "fieldPath": "isSensitive",
             "columnName": "isSensitive",
             "affinity": "INTEGER",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0"
           },
           {
             "fieldPath": "isRemoteDevice",
             "columnName": "isRemoteDevice",
             "affinity": "INTEGER",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0"
           }
         ],
         "primaryKey": {
@@ -86,7 +88,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '282a1b421e498fd0e21c055b6a4315e0')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '145ca5bf4bff8e98f71ebc70ab3b495b')"
     ]
   }
 }

--- a/app/schemas/dev.patrickgold.florisboard.ime.clipboard.provider.ClipboardHistoryDatabase/4.json
+++ b/app/schemas/dev.patrickgold.florisboard.ime.clipboard.provider.ClipboardHistoryDatabase/4.json
@@ -1,0 +1,94 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "145ca5bf4bff8e98f71ebc70ab3b495b",
+    "entities": [
+      {
+        "tableName": "clipboard_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` INTEGER NOT NULL, `text` TEXT, `uri` TEXT, `creationTimestampMs` INTEGER NOT NULL, `isPinned` INTEGER NOT NULL, `mimeTypes` TEXT NOT NULL, `isSensitive` INTEGER NOT NULL DEFAULT 0, `isRemoteDevice` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "creationTimestampMs",
+            "columnName": "creationTimestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeTypes",
+            "columnName": "mimeTypes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "isSensitive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isRemoteDevice",
+            "columnName": "isRemoteDevice",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clipboard_history__id",
+            "unique": false,
+            "columnNames": [
+              "_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clipboard_history__id` ON `${TABLE_NAME}` (`_id`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '145ca5bf4bff8e98f71ebc70ab3b495b')"
+    ]
+  }
+}

--- a/app/schemas/dev.patrickgold.florisboard.ime.clipboard.provider.ClipboardHistoryDatabase/4.json
+++ b/app/schemas/dev.patrickgold.florisboard.ime.clipboard.provider.ClipboardHistoryDatabase/4.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 4,
-    "identityHash": "145ca5bf4bff8e98f71ebc70ab3b495b",
+    "identityHash": "1dd181d116dcb4530fb5b33451ea9ab5",
     "entities": [
       {
         "tableName": "clipboard_history",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` INTEGER NOT NULL, `text` TEXT, `uri` TEXT, `creationTimestampMs` INTEGER NOT NULL, `isPinned` INTEGER NOT NULL, `mimeTypes` TEXT NOT NULL, `isSensitive` INTEGER NOT NULL DEFAULT 0, `isRemoteDevice` INTEGER NOT NULL DEFAULT 0)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` INTEGER NOT NULL, `text` TEXT, `uri` TEXT, `creationTimestampMs` INTEGER NOT NULL, `isPinned` INTEGER NOT NULL, `mimeTypes` TEXT NOT NULL, `is_sensitive` INTEGER NOT NULL DEFAULT 0, `is_remote_device` INTEGER NOT NULL DEFAULT 0)",
         "fields": [
           {
             "fieldPath": "id",
@@ -52,14 +52,14 @@
           },
           {
             "fieldPath": "isSensitive",
-            "columnName": "isSensitive",
+            "columnName": "is_sensitive",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
           },
           {
             "fieldPath": "isRemoteDevice",
-            "columnName": "isRemoteDevice",
+            "columnName": "is_remote_device",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
@@ -88,7 +88,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '145ca5bf4bff8e98f71ebc70ab3b495b')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1dd181d116dcb4530fb5b33451ea9ab5')"
     ]
   }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.database.getStringOrNull
 import androidx.lifecycle.LiveData
+import androidx.room.AutoMigration
 import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Database
@@ -88,8 +89,10 @@ data class ClipboardItem @OptIn(ExperimentalSerializationApi::class) constructor
     val isPinned: Boolean,
     val mimeTypes: Array<String>,
     @EncodeDefault
+    @ColumnInfo(defaultValue = "0")
     val isSensitive: Boolean = false,
     @EncodeDefault
+    @ColumnInfo(defaultValue = "0")
     val isRemoteDevice: Boolean = false,
 ) {
     companion object {
@@ -332,7 +335,13 @@ interface ClipboardHistoryDao {
     fun deleteAllUnpinned()
 }
 
-@Database(entities = [ClipboardItem::class], version = 3)
+@Database(
+    entities = [ClipboardItem::class],
+    version = 3,
+    autoMigrations = [
+        AutoMigration(from = 2, to = 3)
+    ],
+)
 @TypeConverters(Converters::class)
 abstract class ClipboardHistoryDatabase : RoomDatabase() {
     abstract fun clipboardItemDao(): ClipboardHistoryDao

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
@@ -337,9 +337,10 @@ interface ClipboardHistoryDao {
 
 @Database(
     entities = [ClipboardItem::class],
-    version = 3,
+    version = 4,
     autoMigrations = [
-        AutoMigration(from = 2, to = 3)
+        AutoMigration(from = 2, to = 4),
+        AutoMigration(from = 3, to = 4)
     ],
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
@@ -39,11 +39,13 @@ import androidx.room.Entity
 import androidx.room.Insert
 import androidx.room.PrimaryKey
 import androidx.room.Query
+import androidx.room.RenameColumn
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverter
 import androidx.room.TypeConverters
 import androidx.room.Update
+import androidx.room.migration.AutoMigrationSpec
 import dev.patrickgold.florisboard.R
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -89,10 +91,10 @@ data class ClipboardItem @OptIn(ExperimentalSerializationApi::class) constructor
     val isPinned: Boolean,
     val mimeTypes: Array<String>,
     @EncodeDefault
-    @ColumnInfo(defaultValue = "0")
+    @ColumnInfo(name = "is_sensitive", defaultValue = "0")
     val isSensitive: Boolean = false,
     @EncodeDefault
-    @ColumnInfo(defaultValue = "0")
+    @ColumnInfo(name= "is_remote_device", defaultValue = "0")
     val isRemoteDevice: Boolean = false,
 ) {
     companion object {
@@ -340,12 +342,24 @@ interface ClipboardHistoryDao {
     version = 4,
     autoMigrations = [
         AutoMigration(from = 2, to = 4),
-        AutoMigration(from = 3, to = 4)
+        AutoMigration(from = 3, to = 4, spec = ClipboardHistoryDatabase.MIGRATE_3_TO_4::class),
     ],
 )
 @TypeConverters(Converters::class)
 abstract class ClipboardHistoryDatabase : RoomDatabase() {
     abstract fun clipboardItemDao(): ClipboardHistoryDao
+
+    @RenameColumn(
+        tableName = CLIPBOARD_HISTORY_TABLE,
+        fromColumnName = "isSensitive",
+        toColumnName = "is_sensitive",
+    )
+    @RenameColumn(
+        tableName = CLIPBOARD_HISTORY_TABLE,
+        fromColumnName = "isRemoteDevice",
+        toColumnName = "is_remote_device",
+    )
+    class MIGRATE_3_TO_4 : AutoMigrationSpec
 
     companion object {
         fun new(context: Context): ClipboardHistoryDatabase {


### PR DESCRIPTION
This PR fixes the missing items in the clipboard database after updating to 0.4.2 by adding a migration (version 2 -> 3) to the clipboard database