### PR TITLE
Fix Bengali 'র‌্য' in Keyboard Layout to Use ZWJ (U+200D) as per Unicode Standard

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/bn-BD.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/bn-BD.json
@@ -72,7 +72,7 @@
     "র": {
       "main": { "$": "auto_text_key", "code":  2482, "label": "ল" },
       "relevant": [
-        { "code": -255, "label": "র‌্য" }
+        { "code": -255, "label": "র‍্য" }
       ]
     },
     "ন": {


### PR DESCRIPTION
This pull request addresses an issue in the keyboard layout where the Bengali 'র‌্য' was incorrectly defined using Zero Width Non-Joiner (ZWNJ, U+200C) instead of Zero Width Joiner (ZWJ, U+200D).

Updated the layout to conform to the Unicode Standard, which specifies the use of ZWJ for forming 'র‌্য'.