### PR TITLE
Add Bengali (bn) to non-capitalization languages

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/FlorisLocale.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/FlorisLocale.kt
@@ -217,7 +217,7 @@ class FlorisLocale private constructor(val base: Locale) {
      */
     val supportsCapitalization: Boolean
         get() = when (language) {
-            "zh", "ko", "th" -> false
+            "zh", "ko", "th", "bn" -> false
             else -> true
         }
 


### PR DESCRIPTION
This pull request improves language handling by including Bengali (bn) in the list of languages without a capitalization concept. Bengali does not distinguish between uppercase and lowercase letters.