### PR TITLE
Integrate WhisperAI for speech-to-text

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2021 Patrick Goldinger
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version .0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -125,6 +125,8 @@ import org.florisboard.lib.android.showShortToast
 import org.florisboard.lib.android.systemServiceOrNull
 import org.florisboard.lib.kotlin.collectLatestIn
 import java.lang.ref.WeakReference
+
+import dev.patrickgold.florisboard.whisper.WhisperToInput // P4da1
 
 /**
  * Global weak reference for the [FlorisImeService] class. This is needed as certain actions (request hide, switch to
@@ -649,6 +651,10 @@ class FlorisImeService : LifecycleInputMethodService() {
         if (keyboardManager.onHardwareKeyDown(keyCode, event)) true
         else super.onKeyDown(keyCode, event)
 
+    private fun handleMicButtonPress() { // P5db1
+        val whisperToInput = WhisperToInput(this)
+        whisperToInput.startListening()
+    }
 
     private inner class ComposeInputView : AbstractComposeView(this) {
         init {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -79,6 +79,8 @@ import org.florisboard.lib.kotlin.collectIn
 import org.florisboard.lib.kotlin.collectLatestIn
 import java.lang.ref.WeakReference
 
+import dev.patrickgold.florisboard.whisper.WhisperToInput
+
 private val DoubleSpacePeriodMatcher = """([^.!?‽\s]\s)""".toRegex()
 
 class KeyboardManager(context: Context) : InputKeyEventReceiver {
@@ -672,6 +674,11 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
         activeState.isCharHalfWidth = true
     }
 
+    private fun handleMicButtonPress() {
+        val whisperToInput = WhisperToInput(appContext)
+        whisperToInput.startListening()
+    }
+
     override fun onInputKeyDown(data: KeyData) {
         when (data.code) {
             KeyCode.ARROW_DOWN,
@@ -731,7 +738,7 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             KeyCode.IME_UI_MODE_TEXT -> activeState.imeUiMode = ImeUiMode.TEXT
             KeyCode.IME_UI_MODE_MEDIA -> activeState.imeUiMode = ImeUiMode.MEDIA
             KeyCode.IME_UI_MODE_CLIPBOARD -> activeState.imeUiMode = ImeUiMode.CLIPBOARD
-            KeyCode.VOICE_INPUT -> FlorisImeService.switchToVoiceInputMethod()
+            KeyCode.VOICE_INPUT -> handleMicButtonPress()
             KeyCode.KANA_SWITCHER -> handleKanaSwitch()
             KeyCode.KANA_HIRA -> handleKanaHira()
             KeyCode.KANA_KATA -> handleKanaKata()

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickAction.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickAction.kt
@@ -29,6 +29,8 @@ import dev.patrickgold.florisboard.lib.compose.stringRes
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+import dev.patrickgold.florisboard.whisper.WhisperToInput
+
 @Serializable
 sealed class QuickAction {
     open fun onPointerDown(context: Context) = Unit
@@ -52,11 +54,19 @@ sealed class QuickAction {
                 data.code != KeyCode.TOGGLE_ACTIONS_OVERFLOW && data.code != KeyCode.CLIPBOARD_SELECT_ALL) {
                 keyboardManager.activeState.isActionsOverflowVisible = false
             }
+            if (data.code == KeyCode.VOICE_INPUT) {
+                handleMicButtonPress(context)
+            }
         }
 
         override fun onPointerCancel(context: Context) {
             val keyboardManager by context.keyboardManager()
             keyboardManager.inputEventDispatcher.sendCancel(data)
+        }
+
+        private fun handleMicButtonPress(context: Context) {
+            val whisperToInput = WhisperToInput(context)
+            whisperToInput.startListening()
         }
     }
 


### PR DESCRIPTION
Integrate the whisper-to-input project for speech-to-text functionality when the mic button is pressed in Florisboard.

* **FlorisImeService.kt**
  - Import the necessary classes from the whisper-to-input project.
  - Add a method to handle the mic button press and trigger the whisper-to-input project.
* **KeyboardManager.kt**
  - Import the necessary classes from the whisper-to-input project.
  - Add a method to handle the mic button press and trigger the whisper-to-input project.
  - Update the `onInputKeyDown` method to call the new method when the mic button is pressed.
* **QuickAction.kt**
  - Import the necessary classes from the whisper-to-input project.
  - Add a method to handle the mic button press and trigger the whisper-to-input project.
  - Update the `onPointerUp` method to call the new method when the mic button is pressed.

