### PR TITLE
Add subtypes and installed extensions to debug logs

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
@@ -37,7 +37,7 @@ import java.io.InputStreamReader
 object Devtools {
     fun generateDebugLog(context: Context, prefs: AppPrefs? = null, includeLogcat: Boolean = false): String {
         return buildString {
-            generateDebugLogHeader(context, prefs)
+            append(generateDebugLogHeader(context, prefs))
             if (includeLogcat) {
                 appendLine()
                 append(generateLogcatDump())
@@ -67,7 +67,7 @@ object Devtools {
             appendLine("<summary>Detailed info (Debug log header)</summary>")
             appendLine()
             appendLine("```")
-            generateDebugLogHeader(context, prefs)
+            append(generateDebugLogHeader(context, prefs))
             appendLine()
             appendLine("```")
             appendLine("</details>")
@@ -139,7 +139,7 @@ object Devtools {
             if (withTitle) appendLine("======= ACTIVE SUBTYPE CONFIG =======")
             context.subtypeManager().value.let { subtypeManager ->
                 append("Active Subtype      : ").appendLine(subtypeManager.activeSubtype.toShortString())
-                append("Enabled Subtypes    : ")
+                appendLine("Enabled Subtypes    : ")
                 subtypeManager.subtypes.forEach { subtype ->
                     append("    ").appendLine(subtype.toShortString())
                 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
@@ -23,9 +23,11 @@ import android.os.Debug
 import dev.patrickgold.florisboard.BuildConfig
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.AppPrefs
+import dev.patrickgold.florisboard.extensionManager
 import dev.patrickgold.florisboard.lib.titlecase
 import dev.patrickgold.florisboard.lib.util.TimeUtils
 import dev.patrickgold.florisboard.lib.util.UnitUtils
+import dev.patrickgold.florisboard.subtypeManager
 import org.florisboard.lib.android.systemService
 import java.io.BufferedReader
 import java.io.IOException
@@ -35,6 +37,16 @@ import java.io.InputStreamReader
 object Devtools {
     fun generateDebugLog(context: Context, prefs: AppPrefs? = null, includeLogcat: Boolean = false): String {
         return buildString {
+            generateDebugLogHeader(context, prefs)
+            if (includeLogcat) {
+                appendLine()
+                append(generateLogcatDump())
+            }
+        }
+    }
+
+    fun generateDebugLogHeader(context: Context, prefs: AppPrefs? = null): String {
+        return buildString {
             append(generateSystemInfoLog(context))
             appendLine()
             append(generateAppInfoLog(context))
@@ -42,10 +54,10 @@ object Devtools {
                 appendLine()
                 append(generateFeatureConfigLog(prefs))
             }
-            if (includeLogcat) {
-                appendLine()
-                append(generateLogcatDump())
-            }
+            appendLine()
+            append(generateExtensionConfigLog(context))
+            appendLine()
+            append(generateActiveSubtypeConfigLog(context))
         }
     }
 
@@ -55,13 +67,7 @@ object Devtools {
             appendLine("<summary>Detailed info (Debug log header)</summary>")
             appendLine()
             appendLine("```")
-            append(generateSystemInfoLog(context))
-            appendLine()
-            append(generateAppInfoLog(context))
-            if (prefs != null) {
-                appendLine()
-                append(generateFeatureConfigLog(prefs))
-            }
+            generateDebugLogHeader(context, prefs)
             appendLine()
             appendLine("```")
             appendLine("</details>")
@@ -115,6 +121,30 @@ object Devtools {
             append("Inline autofill enabled     : ").appendLine(prefs.suggestion.api30InlineSuggestionsEnabled.get())
             append("Glide enabled               : ").appendLine(prefs.glide.enabled.get())
             append("Internal clipboard enabled  : ").appendLine(prefs.clipboard.useInternalClipboard.get())
+        }
+    }
+
+    fun generateExtensionConfigLog(context: Context, withTitle: Boolean = true): String {
+        return buildString {
+            if (withTitle) appendLine("======= EXTENSION CONFIG =======")
+            appendLine("Theme extensions    : ")
+            context.extensionManager().value.themes.value?.forEach { append("    ").appendLine(it.meta.id) }
+            appendLine("Language Packs      : ")
+            context.extensionManager().value.languagePacks.value?.forEach { append("    ").appendLine(it.meta.id) }
+        }
+    }
+
+    fun generateActiveSubtypeConfigLog(context: Context, withTitle: Boolean = true): String {
+        return buildString {
+            if (withTitle) appendLine("======= ACTIVE SUBTYPE CONFIG =======")
+            context.subtypeManager().value.let { subtypeManager ->
+                append("Active Subtype      : ").appendLine(subtypeManager.activeSubtype.toShortString())
+                append("Enabled Subtypes    : ")
+                subtypeManager.subtypes.forEach { subtype ->
+                    append("    ").appendLine(subtype.toShortString())
+                }
+            }
+
         }
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/devtools/Devtools.kt
@@ -138,8 +138,10 @@ object Devtools {
         return buildString {
             if (withTitle) appendLine("======= ACTIVE SUBTYPE CONFIG =======")
             context.subtypeManager().value.let { subtypeManager ->
-                append("Active Subtype      : ").appendLine(subtypeManager.activeSubtype.toShortString())
-                appendLine("Enabled Subtypes    : ")
+                appendLine("Active Subtype      : ")
+                append("    ")
+                appendLine(subtypeManager.activeSubtype.toShortString())
+                appendLine("Installed Subtypes    : ")
                 subtypeManager.subtypes.forEach { subtype ->
                     append("    ").appendLine(subtype.toShortString())
                 }


### PR DESCRIPTION
This PR adds two new information groups to the debug log. Installed theme extensions (can be expanded with more extension types in the future) and the currently selected and installed subtypes. These changes were made to create a better and more accurate environment for debugging bugs, and to better understand possible configuration-specific bugs.