### PR TITLE
Implement custom material you colors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
 import java.io.ByteArrayOutputStream
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
 
 plugins {
     alias(libs.plugins.agp.application)
@@ -202,6 +202,7 @@ dependencies {
     implementation(libs.patrickgold.jetpref.material.ui)
 
     implementation(project(":lib:android"))
+    implementation(project(":lib:color"))
     implementation(project(":lib:kotlin"))
     implementation(project(":lib:native"))
     implementation(project(":lib:snygg"))

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -712,6 +712,14 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
             default = extCoreTheme("floris_night"),
             serializer = ExtensionComponentName.Serializer,
         )
+        val accentColor = custom(
+            key = "theme__accent_color",
+            default = when (AndroidVersion.ATLEAST_API31_S) {
+                true -> Color.Unspecified
+                false -> DEFAULT_GREEN
+            },
+            serializer = ColorPreferenceSerializer,
+        )
         //val sunriseTime = localTime(
         //    key = "theme__sunrise_time",
         //    default = LocalTime.of(6, 0),

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -18,6 +18,7 @@ package dev.patrickgold.florisboard.app
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import dev.patrickgold.florisboard.app.settings.theme.DisplayColorsAs
 import dev.patrickgold.florisboard.app.settings.theme.DisplayKbdAfterDialogs
@@ -47,6 +48,7 @@ import dev.patrickgold.florisboard.ime.text.key.KeyHintMode
 import dev.patrickgold.florisboard.ime.text.key.UtilityKeyAction
 import dev.patrickgold.florisboard.ime.theme.ThemeMode
 import dev.patrickgold.florisboard.ime.theme.extCoreTheme
+import dev.patrickgold.florisboard.lib.compose.ColorPreferenceSerializer
 import dev.patrickgold.florisboard.lib.ext.ExtensionComponentName
 import dev.patrickgold.florisboard.lib.observeAsTransformingState
 import dev.patrickgold.florisboard.lib.util.VersionName
@@ -57,7 +59,9 @@ import dev.patrickgold.jetpref.datastore.model.PreferenceType
 import dev.patrickgold.jetpref.datastore.model.observeAsState
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.florisboard.lib.android.AndroidVersion
 import org.florisboard.lib.android.isOrientationPortrait
+import org.florisboard.lib.color.DEFAULT_GREEN
 import org.florisboard.lib.snygg.SnyggLevel
 
 fun florisPreferenceModel() = JetPref.getOrCreatePreferenceModel(AppPrefs::class, ::AppPrefs)
@@ -69,9 +73,13 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
             key = "advanced__settings_theme",
             default = AppTheme.AUTO,
         )
-        val useMaterialYou = boolean(
-            key = "advanced__use_material_you",
-            default = true,
+        val accentColor = custom(
+            key = "advanced__accent_color",
+            default = when (AndroidVersion.ATLEAST_API31_S) {
+                true -> Color.Unspecified
+                false -> DEFAULT_GREEN
+            },
+            serializer = ColorPreferenceSerializer,
         )
         val settingsLanguage = string(
             key = "advanced__settings_language",

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/FlorisAppActivity.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/FlorisAppActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.isUnspecified
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
@@ -117,8 +118,8 @@ class FlorisAppActivity : ComponentActivity() {
             AppVersionUtils.updateVersionOnInstallAndLastUse(this, prefs)
             setContent {
                 ProvideLocalizedResources(resourcesContext) {
-                    val useMaterialYou by prefs.advanced.useMaterialYou.observeAsState()
-                    FlorisAppTheme(theme = appTheme, isMaterialYouAware = useMaterialYou) {
+                    val accentColor by prefs.advanced.accentColor.observeAsState()
+                    FlorisAppTheme(theme = appTheme, isMaterialYouAware = accentColor.isUnspecified) {
                         Surface(color = MaterialTheme.colorScheme.background) {
                             AppContent()
                         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/apptheme/Theme.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/apptheme/Theme.kt
@@ -17,19 +17,24 @@
 package dev.patrickgold.florisboard.app.apptheme
 
 import android.app.Activity
+import android.content.Context
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import dev.patrickgold.florisboard.app.AppTheme
+import dev.patrickgold.florisboard.app.florisPreferenceModel
+import dev.patrickgold.jetpref.datastore.model.observeAsState
 import org.florisboard.lib.android.AndroidVersion
+import org.florisboard.lib.color.ColorMappings
 
 /*private val AmoledDarkColorPalette = darkColorScheme(
     primary = Green500,
@@ -70,170 +75,93 @@ private val LightColorPalette = lightColorScheme(
     */
 )*/
 
-private val lightScheme = lightColorScheme(
-    primary = primaryLight,
-    onPrimary = onPrimaryLight,
-    primaryContainer = primaryContainerLight,
-    onPrimaryContainer = onPrimaryContainerLight,
-    secondary = secondaryLight,
-    onSecondary = onSecondaryLight,
-    secondaryContainer = secondaryContainerLight,
-    onSecondaryContainer = onSecondaryContainerLight,
-    tertiary = tertiaryLight,
-    onTertiary = onTertiaryLight,
-    tertiaryContainer = tertiaryContainerLight,
-    onTertiaryContainer = onTertiaryContainerLight,
-    error = errorLight,
-    onError = onErrorLight,
-    errorContainer = errorContainerLight,
-    onErrorContainer = onErrorContainerLight,
-    background = backgroundLight,
-    onBackground = onBackgroundLight,
-    surface = surfaceLight,
-    onSurface = onSurfaceLight,
-    surfaceVariant = surfaceVariantLight,
-    onSurfaceVariant = onSurfaceVariantLight,
-    outline = outlineLight,
-    outlineVariant = outlineVariantLight,
-    scrim = scrimLight,
-    inverseSurface = inverseSurfaceLight,
-    inverseOnSurface = inverseOnSurfaceLight,
-    inversePrimary = inversePrimaryLight,
-    surfaceDim = surfaceDimLight,
-    surfaceBright = surfaceBrightLight,
-    surfaceContainerLowest = surfaceContainerLowestLight,
-    surfaceContainerLow = surfaceContainerLowLight,
-    surfaceContainer = surfaceContainerLight,
-    surfaceContainerHigh = surfaceContainerHighLight,
-    surfaceContainerHighest = surfaceContainerHighestLight,
-)
 
-private val darkScheme = darkColorScheme(
-    primary = primaryDark,
-    onPrimary = onPrimaryDark,
-    primaryContainer = primaryContainerDark,
-    onPrimaryContainer = onPrimaryContainerDark,
-    secondary = secondaryDark,
-    onSecondary = onSecondaryDark,
-    secondaryContainer = secondaryContainerDark,
-    onSecondaryContainer = onSecondaryContainerDark,
-    tertiary = tertiaryDark,
-    onTertiary = onTertiaryDark,
-    tertiaryContainer = tertiaryContainerDark,
-    onTertiaryContainer = onTertiaryContainerDark,
-    error = errorDark,
-    onError = onErrorDark,
-    errorContainer = errorContainerDark,
-    onErrorContainer = onErrorContainerDark,
-    background = backgroundDark,
-    onBackground = onBackgroundDark,
-    surface = surfaceDark,
-    onSurface = onSurfaceDark,
-    surfaceVariant = surfaceVariantDark,
-    onSurfaceVariant = onSurfaceVariantDark,
-    outline = outlineDark,
-    outlineVariant = outlineVariantDark,
-    scrim = scrimDark,
-    inverseSurface = inverseSurfaceDark,
-    inverseOnSurface = inverseOnSurfaceDark,
-    inversePrimary = inversePrimaryDark,
-    surfaceDim = surfaceDimDark,
-    surfaceBright = surfaceBrightDark,
-    surfaceContainerLowest = surfaceContainerLowestDark,
-    surfaceContainerLow = surfaceContainerLowDark,
-    surfaceContainer = surfaceContainerDark,
-    surfaceContainerHigh = surfaceContainerHighDark,
-    surfaceContainerHighest = surfaceContainerHighestDark,
-)
+@Composable
+fun getColorScheme(
+    context: Context,
+    isMaterialYouAware: Boolean,
+    themeColor: Color,
+    theme: AppTheme,
+): ColorScheme {
+    val isDark = isSystemInDarkTheme()
 
-private val amoledScheme = darkScheme.copy(
-    background = amoledDark,
-    surface = amoledDark
-)
+    return when (theme) {
+
+        AppTheme.AUTO -> {
+            if (isMaterialYouAware && AndroidVersion.ATLEAST_API31_S) {
+                when {
+                    isDark -> dynamicDarkColorScheme(context)
+                    else -> dynamicLightColorScheme(context)
+                }
+            } else {
+                ColorMappings.getColorSchemeOrDefault(themeColor, isDark, true)
+            }
+        }
+
+        AppTheme.DARK -> {
+            if (isMaterialYouAware && AndroidVersion.ATLEAST_API31_S) {
+                dynamicDarkColorScheme(context)
+            } else {
+                ColorMappings.getColorSchemeOrDefault(themeColor, isDark = true, settings = true)
+            }
+        }
+
+        AppTheme.LIGHT -> {
+            if (isMaterialYouAware && AndroidVersion.ATLEAST_API31_S) {
+                dynamicLightColorScheme(context)
+            } else {
+                ColorMappings.getColorSchemeOrDefault(themeColor, isDark = false, settings = true)
+            }
+        }
+
+        AppTheme.AMOLED_DARK -> {
+            if (isMaterialYouAware && AndroidVersion.ATLEAST_API31_S) {
+                dynamicDarkColorScheme(context).amoled()
+            } else {
+                ColorMappings.getColorSchemeOrDefault(themeColor, isDark = true, settings = true).amoled()
+            }
+        }
+
+        AppTheme.AUTO_AMOLED -> {
+            if (isMaterialYouAware && AndroidVersion.ATLEAST_API31_S) {
+                when {
+                    isDark -> dynamicDarkColorScheme(context).amoled()
+                    else -> dynamicLightColorScheme(context)
+                }
+            } else {
+                with(ColorMappings.getColorSchemeOrDefault(themeColor, isDark, true)) {
+                    if (isDark) amoled() else this
+                }
+            }
+        }
+    }
+}
+
+fun ColorScheme.amoled(): ColorScheme {
+    return this.copy(background = Color.Black, surface = Color.Black)
+}
 
 @Composable
 fun FlorisAppTheme(
     theme: AppTheme,
     isMaterialYouAware: Boolean,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
+    val prefs by florisPreferenceModel()
+    val accent by prefs.advanced.accentColor.observeAsState()
 
-    val colors = if (AndroidVersion.ATLEAST_API31_S) {
-        when (theme) {
-            AppTheme.AUTO -> when {
-                isMaterialYouAware -> when {
-                    isSystemInDarkTheme() -> dynamicDarkColorScheme(LocalContext.current)
-                    else -> dynamicLightColorScheme(LocalContext.current)
-                }
-
-                else -> {
-                    when {
-                        isSystemInDarkTheme() -> darkScheme
-                        else -> lightScheme
-                    }
-                }
-            }
-
-            AppTheme.AUTO_AMOLED -> when {
-                isMaterialYouAware -> when {
-                    isSystemInDarkTheme() -> dynamicDarkColorScheme(LocalContext.current).copy(
-                        background = amoledDark,
-                        surface = amoledDark,
-                    )
-
-                    else -> dynamicLightColorScheme(LocalContext.current)
-                }
-
-                else -> {
-                    when {
-                        isSystemInDarkTheme() -> amoledScheme
-                        else -> lightScheme
-                    }
-                }
-            }
-
-            AppTheme.LIGHT -> when {
-                isMaterialYouAware -> dynamicLightColorScheme(LocalContext.current)
-                else -> lightScheme
-            }
-
-            AppTheme.DARK -> when {
-                isMaterialYouAware -> dynamicDarkColorScheme(LocalContext.current)
-                else -> darkScheme
-            }
-
-            AppTheme.AMOLED_DARK -> when {
-                isMaterialYouAware -> dynamicDarkColorScheme(LocalContext.current).copy(
-                    background = amoledDark,
-                    surface = amoledDark,
-                )
-
-                else -> amoledScheme
-            }
-        }
-    } else {
-        when (theme) {
-            AppTheme.AUTO -> when {
-                isSystemInDarkTheme() -> darkScheme
-                else -> lightScheme
-            }
-
-            AppTheme.AUTO_AMOLED -> when {
-                isSystemInDarkTheme() -> darkScheme
-                else -> lightScheme
-            }
-
-            AppTheme.LIGHT -> lightScheme
-            AppTheme.DARK -> darkScheme
-            AppTheme.AMOLED_DARK -> amoledScheme
-        }
-    }
+    val colors = getColorScheme(
+        context = LocalContext.current,
+        theme = theme,
+        isMaterialYouAware = isMaterialYouAware,
+        themeColor = accent,
+    )
 
     val darkTheme =
         theme == AppTheme.DARK
-        || theme == AppTheme.AMOLED_DARK
-        || (theme == AppTheme.AUTO && isSystemInDarkTheme())
-        || (theme == AppTheme.AUTO_AMOLED && isSystemInDarkTheme())
+            || theme == AppTheme.AMOLED_DARK
+            || (theme == AppTheme.AUTO && isSystemInDarkTheme())
+            || (theme == AppTheme.AUTO_AMOLED && isSystemInDarkTheme())
 
     val view = LocalView.current
     if (!view.isInEditMode) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/AdvancedScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/AdvancedScreen.kt
@@ -19,13 +19,15 @@ package dev.patrickgold.florisboard.app.settings.advanced
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Adb
 import androidx.compose.material.icons.filled.Archive
-import androidx.compose.material.icons.filled.FormatPaint
+import androidx.compose.material.icons.filled.FormatColorFill
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Preview
 import androidx.compose.material.icons.filled.SettingsBackupRestore
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.AppTheme
 import dev.patrickgold.florisboard.app.LocalNavController
@@ -34,16 +36,20 @@ import dev.patrickgold.florisboard.app.enumDisplayEntriesOf
 import dev.patrickgold.florisboard.ime.core.DisplayLanguageNamesIn
 import dev.patrickgold.florisboard.ime.keyboard.IncognitoMode
 import dev.patrickgold.florisboard.lib.FlorisLocale
-import org.florisboard.lib.android.AndroidVersion
 import dev.patrickgold.florisboard.lib.compose.FlorisScreen
 import dev.patrickgold.florisboard.lib.compose.stringRes
 import dev.patrickgold.jetpref.datastore.model.observeAsState
+import dev.patrickgold.jetpref.datastore.ui.ColorPickerPreference
 import dev.patrickgold.jetpref.datastore.ui.ListPreference
 import dev.patrickgold.jetpref.datastore.ui.Preference
 import dev.patrickgold.jetpref.datastore.ui.PreferenceGroup
 import dev.patrickgold.jetpref.datastore.ui.SwitchPreference
+import dev.patrickgold.jetpref.datastore.ui.isMaterialYou
 import dev.patrickgold.jetpref.datastore.ui.listPrefEntries
 import dev.patrickgold.jetpref.datastore.ui.vectorResource
+import org.florisboard.lib.android.AndroidVersion
+import org.florisboard.lib.color.ColorMappings
+
 
 @Composable
 fun AdvancedScreen() = FlorisScreen {
@@ -51,6 +57,7 @@ fun AdvancedScreen() = FlorisScreen {
     previewFieldVisible = false
 
     val navController = LocalNavController.current
+    val context = LocalContext.current
 
     content {
         ListPreference(
@@ -59,13 +66,21 @@ fun AdvancedScreen() = FlorisScreen {
             title = stringRes(R.string.pref__advanced__settings_theme__label),
             entries = enumDisplayEntriesOf(AppTheme::class),
         )
-        SwitchPreference(
-            pref = prefs.advanced.useMaterialYou,
-            icon = Icons.Default.FormatPaint,
-            title = stringRes(R.string.pref__advanced__settings_material_you__label),
-            visibleIf = {
-                AndroidVersion.ATLEAST_API31_S
-            },
+        ColorPickerPreference(
+            pref = prefs.advanced.accentColor,
+            title = stringRes(R.string.pref__advanced__settings_accent_color__label),
+            defaultValueLabel = stringRes(R.string.action__default),
+            icon = Icons.Default.FormatColorFill,
+            defaultColors = ColorMappings.colors,
+            showAlphaSlider = false,
+            enableAdvancedLayout = false,
+            colorOverride = {
+                if (it.isMaterialYou(context)) {
+                    Color.Unspecified
+                } else {
+                    it
+                }
+            }
         )
         ListPreference(
             prefs.advanced.settingsLanguage,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/theme/ThemeScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/theme/ThemeScreen.kt
@@ -19,12 +19,14 @@ package dev.patrickgold.florisboard.app.settings.theme
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BrightnessAuto
+import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import dev.patrickgold.florisboard.R
@@ -41,8 +43,11 @@ import dev.patrickgold.florisboard.lib.compose.stringRes
 import dev.patrickgold.florisboard.lib.ext.ExtensionComponentName
 import dev.patrickgold.florisboard.themeManager
 import dev.patrickgold.jetpref.datastore.model.observeAsState
+import dev.patrickgold.jetpref.datastore.ui.ColorPickerPreference
 import dev.patrickgold.jetpref.datastore.ui.ListPreference
 import dev.patrickgold.jetpref.datastore.ui.Preference
+import dev.patrickgold.jetpref.datastore.ui.isMaterialYou
+import org.florisboard.lib.color.ColorMappings
 
 @Composable
 fun ThemeScreen() = FlorisScreen {
@@ -107,6 +112,22 @@ fun ThemeScreen() = FlorisScreen {
             onClick = {
                 navController.navigate(Routes.Settings.ThemeManager(ThemeManagerScreenAction.SELECT_NIGHT))
             },
+        )
+        ColorPickerPreference(
+            pref = prefs.theme.accentColor,
+            title = stringRes(R.string.pref__theme__theme_accent_color__label),
+            defaultValueLabel = stringRes(R.string.action__default),
+            icon = Icons.Default.ColorLens,
+            defaultColors = ColorMappings.colors,
+            showAlphaSlider = false,
+            enableAdvancedLayout = false,
+            colorOverride = {
+                if (it.isMaterialYou(context)) {
+                    Color.Unspecified
+                } else {
+                    it
+                }
+            }
         )
 
         AddonManagementReferenceBox(type = ExtensionListScreenType.EXT_THEME)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/FlorisCopyToClipboardActivity.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/FlorisCopyToClipboardActivity.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.isUnspecified
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -121,8 +122,8 @@ class FlorisCopyToClipboardActivity : ComponentActivity() {
         setContent {
             ProvideLocalizedResources(this, forceLayoutDirection = LayoutDirection.Ltr) {
                 val theme by prefs.advanced.settingsTheme.observeAsState()
-                val isMaterialYouAware by prefs.advanced.useMaterialYou.observeAsState()
-                FlorisAppTheme(theme, isMaterialYouAware) {
+                val accentColor by prefs.advanced.accentColor.observeAsState()
+                FlorisAppTheme(theme, accentColor.isUnspecified) {
                     BottomSheet {
                         Row {
                             Text(
@@ -162,7 +163,9 @@ class FlorisCopyToClipboardActivity : ComponentActivity() {
             Column {
                 content()
                 Button(
-                    modifier = Modifier.align(Alignment.End).padding(16.dp),
+                    modifier = Modifier
+                        .align(Alignment.End)
+                        .padding(16.dp),
                     onClick = { finish() },
                     colors = ButtonDefaults.textButtonColors(
                         //containerColor = buttonContainer.background.solidColor(context = context),

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeTheme.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeTheme.kt
@@ -29,13 +29,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isUnspecified
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
+import dev.patrickgold.florisboard.app.florisPreferenceModel
 import dev.patrickgold.florisboard.ime.input.InputShiftState
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.lib.observeAsNonNullState
 import dev.patrickgold.florisboard.themeManager
+import dev.patrickgold.jetpref.datastore.model.observeAsState
 import org.florisboard.lib.android.AndroidVersion
+import org.florisboard.lib.color.ColorMappings
 import org.florisboard.lib.snygg.Snygg
 import org.florisboard.lib.snygg.SnyggStylesheet
 import org.florisboard.lib.snygg.ui.ProvideSnyggUiDefaults
@@ -112,20 +116,23 @@ fun FlorisImeTheme(content: @Composable () -> Unit) {
     val context = LocalContext.current
     val themeManager by context.themeManager()
 
+    val prefs by florisPreferenceModel()
+    val accentColor by prefs.theme.accentColor.observeAsState()
+
     val activeThemeInfo by themeManager.activeThemeInfo.observeAsNonNullState()
     val activeConfig = remember(activeThemeInfo) { activeThemeInfo.config }
     val activeStyle = remember(activeThemeInfo) { activeThemeInfo.stylesheet }
     val materialColors = if (activeConfig.isNightTheme) {
-        if (AndroidVersion.ATLEAST_API31_S) {
+        if (AndroidVersion.ATLEAST_API31_S && accentColor.isUnspecified) {
             dynamicDarkColorScheme(context)
         } else {
-            MaterialDarkFallbackPalette
+            ColorMappings.getColorSchemeOrDefault(accentColor, activeConfig.isNightTheme)
         }
     } else {
-        if (AndroidVersion.ATLEAST_API31_S) {
+        if (AndroidVersion.ATLEAST_API31_S && accentColor.isUnspecified) {
             dynamicLightColorScheme(context)
         } else {
-            MaterialLightFallbackPalette
+            ColorMappings.getColorSchemeOrDefault(accentColor, activeConfig.isNightTheme)
         }
     }
     MaterialTheme(materialColors) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
@@ -105,6 +105,9 @@ class ThemeManager(context: Context) {
         prefs.theme.mode.observeForever {
             updateActiveTheme()
         }
+        prefs.theme.accentColor.observeForever {
+            updateActiveTheme { MaterialYouColor.updateAccentColor(it) }
+        }
         prefs.theme.dayThemeId.observeForever {
             updateActiveTheme()
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/Color.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/Color.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.lib.compose
+
+import androidx.compose.ui.graphics.Color
+import dev.patrickgold.jetpref.datastore.model.PreferenceSerializer
+
+object ColorPreferenceSerializer : PreferenceSerializer<Color> {
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun deserialize(value: String): Color {
+        return Color(value.hexToULong())
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun serialize(value: Color): String = value.value.toHexString()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,9 @@
     <string name="pref__theme__sunset_time__label" comment="Label of the sunset time preference">Sunset time</string>
     <string name="pref__theme__day" comment="Label of the day group (day means light theme)">Day theme</string>
     <string name="pref__theme__night" comment="Label of the night group (night means dark theme)">Night theme</string>
+    <string name="pref__theme__theme_accent_color__label" comment="Label of accent color preference in Theme">
+        Accent color (Material you themes)
+    </string>
     <string name="settings__theme_manager__title_manage" comment="Title of the theme manager screen for managing installed and custom themes">Manage installed themes</string>
     <string name="pref__theme__source_assets" comment="Label for the theme source field">FlorisBoard App Assets</string>
     <string name="pref__theme__source_internal" comment="Label for the theme source field">Internal Storage</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -453,7 +453,9 @@
     <string name="pref__advanced__settings_theme__light" comment="Possible value of Settings theme preference in Advanced">Light</string>
     <string name="pref__advanced__settings_theme__dark" comment="Possible value of Settings theme preference in Advanced">Dark</string>
     <string name="pref__advanced__settings_theme__amoled_dark" comment="Possible value of Settings theme preference in Advanced">AMOLED Dark</string>
-    <string name="pref__advanced__settings_material_you__label" comment="Label of Material You preference in Advanced">Use Material You</string>
+    <string name="pref__advanced__settings_accent_color__label" comment="Label of accent color preference in Advanced">
+        Settings accent color
+    </string>
     <string name="pref__advanced__settings_language__label" comment="Label of Settings language preference in Advanced">Settings language</string>
     <string name="pref__advanced__show_app_icon__label" comment="Label of Show app icon preference in Advanced">Show app icon in launcher</string>
     <string name="pref__advanced__show_app_icon__summary_atleast_q" comment="Summary of Show app icon preference in Advanced for Android 10+">Always enabled on Android 10+ due to restrictions of the system</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ ksp = "2.0.20-1.0.25"
 mannodermaus-android-junit5 = "1.10.0.0"
 mikepenz-aboutlibraries = "10.10.0"
 patrickgold-compose-tooltip = "0.1.0"
-patrickgold-jetpref = "0.2.0-beta03"
+patrickgold-jetpref = "0.2.0-rc01"
 
 # Testing
 androidx-benchmark = "1.3.1"

--- a/lib/color/README.md
+++ b/lib/color/README.md
@@ -1,0 +1,16 @@
+# FlorisBoard Color Library
+
+This library manages the color schemes for the settings and snygg material you themes.
+
+### Generated color schemes
+
+The color schemes were generated using
+the [Material 3 Theme builder](https://material-foundation.github.io/material-theme-builder/)
+
+#### How to generate new Schemes
+
+1. Pick the accent color you would like to base your color scheme on.
+2. Select or pase the color in
+   the [Material 3 Theme builder](https://material-foundation.github.io/material-theme-builder/)
+3. Click on Pick your fonts (Leave the font empty we don't use them)
+4. Export the theme as Jetpack Compose theme and get the color information from the archive.

--- a/lib/color/build.gradle.kts
+++ b/lib/color/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+
+dependencies {
+    implementation(libs.androidx.compose.material3)
+
+    implementation(project(":lib:kotlin"))
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks {
+    compileKotlin {
+        compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+        compilerOptions.freeCompilerArgs = listOf(
+            "-opt-in=kotlin.contracts.ExperimentalContracts",
+            "-Xjvm-default=all-compatibility",
+        )
+    }
+    compileTestKotlin {
+        compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+    }
+}
+
+sourceSets {
+    maybeCreate("main").apply {
+        java.srcDir("src/main/kotlin")
+    }
+}
+

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/ColorMappings.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/ColorMappings.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
+import org.florisboard.lib.color.schemes.amberDarkScheme
+import org.florisboard.lib.color.schemes.amberLightScheme
+import org.florisboard.lib.color.schemes.blueDarkScheme
+import org.florisboard.lib.color.schemes.blueGrayDarkScheme
+import org.florisboard.lib.color.schemes.blueGrayLightScheme
+import org.florisboard.lib.color.schemes.blueLightScheme
+import org.florisboard.lib.color.schemes.brownDarkScheme
+import org.florisboard.lib.color.schemes.brownLightScheme
+import org.florisboard.lib.color.schemes.cyanDarkScheme
+import org.florisboard.lib.color.schemes.cyanLightScheme
+import org.florisboard.lib.color.schemes.deepPurpleDarkScheme
+import org.florisboard.lib.color.schemes.deepPurpleLightScheme
+import org.florisboard.lib.color.schemes.florisDefaultKeyboardDarkScheme
+import org.florisboard.lib.color.schemes.florisDefaultKeyboardLightScheme
+import org.florisboard.lib.color.schemes.florisDefaultSettingsDarkScheme
+import org.florisboard.lib.color.schemes.florisDefaultSettingsLightScheme
+import org.florisboard.lib.color.schemes.grayDarkScheme
+import org.florisboard.lib.color.schemes.grayLightScheme
+import org.florisboard.lib.color.schemes.indigoDarkScheme
+import org.florisboard.lib.color.schemes.indigoLightScheme
+import org.florisboard.lib.color.schemes.lightBlueDarkScheme
+import org.florisboard.lib.color.schemes.lightBlueLightScheme
+import org.florisboard.lib.color.schemes.lightGreenDarkScheme
+import org.florisboard.lib.color.schemes.lightGreenLightScheme
+import org.florisboard.lib.color.schemes.lightPinkDarkScheme
+import org.florisboard.lib.color.schemes.lightPinkLightScheme
+import org.florisboard.lib.color.schemes.limeDarkScheme
+import org.florisboard.lib.color.schemes.limeLightScheme
+import org.florisboard.lib.color.schemes.orangeDarkScheme
+import org.florisboard.lib.color.schemes.orangeLightScheme
+import org.florisboard.lib.color.schemes.pinkDarkScheme
+import org.florisboard.lib.color.schemes.pinkLightScheme
+import org.florisboard.lib.color.schemes.purpleDarkScheme
+import org.florisboard.lib.color.schemes.purpleLightScheme
+import org.florisboard.lib.color.schemes.redDarkScheme
+import org.florisboard.lib.color.schemes.redLightScheme
+import org.florisboard.lib.color.schemes.tealDarkScheme
+import org.florisboard.lib.color.schemes.tealLightScheme
+import org.florisboard.lib.color.schemes.yellowDarkScheme
+import org.florisboard.lib.color.schemes.yellowLightScheme
+
+val DEFAULT_GREEN = Color(0xFF4CAF50)
+
+data class ColorMappings(val light: ColorScheme, val dark: ColorScheme) {
+    companion object {
+
+        val default = ColorMappings(florisDefaultKeyboardLightScheme, florisDefaultKeyboardDarkScheme)
+        private val red = ColorMappings(redLightScheme, redDarkScheme)
+        private val pink = ColorMappings(pinkLightScheme, pinkDarkScheme)
+        private val lightPink = ColorMappings(lightPinkLightScheme, lightPinkDarkScheme)
+        private val purple = ColorMappings(purpleLightScheme, purpleDarkScheme)
+        private val deepPurple = ColorMappings(deepPurpleLightScheme, deepPurpleDarkScheme)
+        private val indigo = ColorMappings(indigoLightScheme, indigoDarkScheme)
+        private val blue = ColorMappings(blueLightScheme, blueDarkScheme)
+        private val lightBlue = ColorMappings(lightBlueLightScheme, lightBlueDarkScheme)
+        private val cyan = ColorMappings(cyanLightScheme, cyanDarkScheme)
+        private val teal = ColorMappings(tealLightScheme, tealDarkScheme)
+        private val lightGreen = ColorMappings(lightGreenLightScheme, lightGreenDarkScheme)
+        private val lime = ColorMappings(limeLightScheme, limeDarkScheme)
+        private val yellow = ColorMappings(yellowLightScheme, yellowDarkScheme)
+        private val amber = ColorMappings(amberLightScheme, amberDarkScheme)
+        private val orange = ColorMappings(orangeLightScheme, orangeDarkScheme)
+        private val brown = ColorMappings(brownLightScheme, brownDarkScheme)
+        private val blueGray = ColorMappings(blueGrayLightScheme, blueGrayDarkScheme)
+        private val gray = ColorMappings(grayLightScheme, grayDarkScheme)
+
+        val schemes = mapOf(
+            DEFAULT_GREEN to default, // GREEN 500
+            Color(0xFFF44336) to red, // RED 500
+            Color(0xFFE91E63) to pink, // PINK 500
+            Color(0xFFFF2C93) to lightPink, // LIGHT PINK 500
+            Color(0xFF9C27B0) to purple, // PURPLE 500
+            Color(0xFF673AB7) to deepPurple, // DEEP PURPLE 500
+            Color(0xFF3F51B5) to indigo, // INDIGO 500
+            Color(0xFF2196F3) to blue, // BLUE 500
+            Color(0xFF03A9F4) to lightBlue, // LIGHT BLUE 500
+            Color(0xFF00BCD4) to cyan, // CYAN 500
+            Color(0xFF009688) to teal, // TEAL 500
+            Color(0xFF8BC34A) to lightGreen, // LIGHT GREEN 500
+            Color(0xFFCDDC39) to lime, // LIME 500
+            Color(0xFFFFEB3B) to yellow, // YELLOW 500
+            Color(0xFFFFC107) to amber, // AMBER 500
+            Color(0xFFFF9800) to orange, // ORANGE 500
+            Color(0xFF795548) to brown, // BROWN 500
+            Color(0xFF607D8B) to blueGray, // BLUE GREY 500
+            Color(0xFF9E9E9E) to gray, // GRAY 500
+        )
+
+        val colors = schemes.keys.toTypedArray()
+
+        fun getColorSchemeOrDefault(
+            color: Color,
+            isDark: Boolean,
+            settings: Boolean = false,
+        ): ColorScheme {
+            if (settings && color == DEFAULT_GREEN) {
+                return if (isDark) {
+                    florisDefaultSettingsDarkScheme
+                } else {
+                    florisDefaultSettingsLightScheme
+                }
+            }
+            return schemes
+                .getOrDefault(
+                    color,
+                    default,
+                ).let {
+                    when {
+                        isDark -> it.dark
+                        else -> it.light
+                    }
+                }
+        }
+    }
+}
+

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/AmberScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/AmberScheme.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF775A0B)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFFFDF9E)
+private val onPrimaryContainerLight = Color(0xFF5B4300)
+private val secondaryLight = Color(0xFF6B5D3F)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFF5E0BB)
+private val onSecondaryContainerLight = Color(0xFF52452A)
+private val tertiaryLight = Color(0xFF4A6547)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFCCEBC4)
+private val onTertiaryContainerLight = Color(0xFF334D31)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFFF8F2)
+private val onBackgroundLight = Color(0xFF1F1B13)
+private val surfaceLight = Color(0xFFFFF8F2)
+private val onSurfaceLight = Color(0xFF1F1B13)
+private val surfaceVariantLight = Color(0xFFEDE1CF)
+private val onSurfaceVariantLight = Color(0xFF4D4639)
+private val outlineLight = Color(0xFF7F7667)
+private val outlineVariantLight = Color(0xFFD0C5B4)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF353027)
+private val inverseOnSurfaceLight = Color(0xFFF9EFE2)
+private val inversePrimaryLight = Color(0xFFE9C16C)
+private val surfaceDimLight = Color(0xFFE2D9CC)
+private val surfaceBrightLight = Color(0xFFFFF8F2)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFFCF2E5)
+private val surfaceContainerLight = Color(0xFFF6ECDF)
+private val surfaceContainerHighLight = Color(0xFFF1E7D9)
+private val surfaceContainerHighestLight = Color(0xFFEBE1D4)
+private val primaryDark = Color(0xFFE9C16C)
+private val onPrimaryDark = Color(0xFF3F2E00)
+private val primaryContainerDark = Color(0xFF5B4300)
+private val onPrimaryContainerDark = Color(0xFFFFDF9E)
+private val secondaryDark = Color(0xFFD8C4A0)
+private val onSecondaryDark = Color(0xFF3A2F15)
+private val secondaryContainerDark = Color(0xFF52452A)
+private val onSecondaryContainerDark = Color(0xFFF5E0BB)
+private val tertiaryDark = Color(0xFFB0CFAA)
+private val onTertiaryDark = Color(0xFF1D361C)
+private val tertiaryContainerDark = Color(0xFF334D31)
+private val onTertiaryContainerDark = Color(0xFFCCEBC4)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF17130B)
+private val onBackgroundDark = Color(0xFFEBE1D4)
+private val surfaceDark = Color(0xFF17130B)
+private val onSurfaceDark = Color(0xFFEBE1D4)
+private val surfaceVariantDark = Color(0xFF4D4639)
+private val onSurfaceVariantDark = Color(0xFFD0C5B4)
+private val outlineDark = Color(0xFF998F80)
+private val outlineVariantDark = Color(0xFF4D4639)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFEBE1D4)
+private val inverseOnSurfaceDark = Color(0xFF353027)
+private val inversePrimaryDark = Color(0xFF775A0B)
+private val surfaceDimDark = Color(0xFF17130B)
+private val surfaceBrightDark = Color(0xFF3E382F)
+private val surfaceContainerLowestDark = Color(0xFF110E07)
+private val surfaceContainerLowDark = Color(0xFF1F1B13)
+private val surfaceContainerDark = Color(0xFF231F17)
+private val surfaceContainerHighDark = Color(0xFF2E2921)
+private val surfaceContainerHighestDark = Color(0xFF39342B)
+
+val amberLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val amberDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/BlueGrayScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/BlueGrayScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF116682)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFBDE9FF)
+private val onPrimaryContainerLight = Color(0xFF004D64)
+private val secondaryLight = Color(0xFF4D616C)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFD0E6F2)
+private val onSecondaryContainerLight = Color(0xFF354A53)
+private val tertiaryLight = Color(0xFF5D5B7D)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFE3DFFF)
+private val onTertiaryContainerLight = Color(0xFF454364)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFF6FAFD)
+private val onBackgroundLight = Color(0xFF171C1F)
+private val surfaceLight = Color(0xFFF6FAFD)
+private val onSurfaceLight = Color(0xFF171C1F)
+private val surfaceVariantLight = Color(0xFFDCE4E9)
+private val onSurfaceVariantLight = Color(0xFF40484C)
+private val outlineLight = Color(0xFF70787D)
+private val outlineVariantLight = Color(0xFFC0C8CD)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF2C3134)
+private val inverseOnSurfaceLight = Color(0xFFEDF1F5)
+private val inversePrimaryLight = Color(0xFF8BD0EF)
+private val surfaceDimLight = Color(0xFFD6DBDE)
+private val surfaceBrightLight = Color(0xFFF6FAFD)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF0F4F8)
+private val surfaceContainerLight = Color(0xFFEAEEF2)
+private val surfaceContainerHighLight = Color(0xFFE4E9EC)
+private val surfaceContainerHighestLight = Color(0xFFDFE3E7)
+private val primaryDark = Color(0xFF8BD0EF)
+private val onPrimaryDark = Color(0xFF003546)
+private val primaryContainerDark = Color(0xFF004D64)
+private val onPrimaryContainerDark = Color(0xFFBDE9FF)
+private val secondaryDark = Color(0xFFB4CAD6)
+private val onSecondaryDark = Color(0xFF1F333C)
+private val secondaryContainerDark = Color(0xFF354A53)
+private val onSecondaryContainerDark = Color(0xFFD0E6F2)
+private val tertiaryDark = Color(0xFFC6C2EA)
+private val onTertiaryDark = Color(0xFF2E2D4D)
+private val tertiaryContainerDark = Color(0xFF454364)
+private val onTertiaryContainerDark = Color(0xFFE3DFFF)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF0F1417)
+private val onBackgroundDark = Color(0xFFDFE3E7)
+private val surfaceDark = Color(0xFF0F1417)
+private val onSurfaceDark = Color(0xFFDFE3E7)
+private val surfaceVariantDark = Color(0xFF40484C)
+private val onSurfaceVariantDark = Color(0xFFC0C8CD)
+private val outlineDark = Color(0xFF8A9297)
+private val outlineVariantDark = Color(0xFF40484C)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFDFE3E7)
+private val inverseOnSurfaceDark = Color(0xFF2C3134)
+private val inversePrimaryDark = Color(0xFF116682)
+private val surfaceDimDark = Color(0xFF0F1417)
+private val surfaceBrightDark = Color(0xFF353A3D)
+private val surfaceContainerLowestDark = Color(0xFF0A0F11)
+private val surfaceContainerLowDark = Color(0xFF171C1F)
+private val surfaceContainerDark = Color(0xFF1B2023)
+private val surfaceContainerHighDark = Color(0xFF262B2D)
+private val surfaceContainerHighestDark = Color(0xFF303538)
+
+
+val blueGrayLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val blueGrayDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/BlueScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/BlueScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF36618E)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFD1E4FF)
+private val onPrimaryContainerLight = Color(0xFF194975)
+private val secondaryLight = Color(0xFF535F70)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFD7E3F7)
+private val onSecondaryContainerLight = Color(0xFF3B4858)
+private val tertiaryLight = Color(0xFF6B5778)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFF2DAFF)
+private val onTertiaryContainerLight = Color(0xFF523F5F)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFF8F9FF)
+private val onBackgroundLight = Color(0xFF191C20)
+private val surfaceLight = Color(0xFFF8F9FF)
+private val onSurfaceLight = Color(0xFF191C20)
+private val surfaceVariantLight = Color(0xFFDFE2EB)
+private val onSurfaceVariantLight = Color(0xFF43474E)
+private val outlineLight = Color(0xFF73777F)
+private val outlineVariantLight = Color(0xFFC3C7CF)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF2E3135)
+private val inverseOnSurfaceLight = Color(0xFFEFF0F7)
+private val inversePrimaryLight = Color(0xFFA0CAFD)
+private val surfaceDimLight = Color(0xFFD8DAE0)
+private val surfaceBrightLight = Color(0xFFF8F9FF)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF2F3FA)
+private val surfaceContainerLight = Color(0xFFECEEF4)
+private val surfaceContainerHighLight = Color(0xFFE6E8EE)
+private val surfaceContainerHighestLight = Color(0xFFE1E2E8)
+
+private val primaryDark = Color(0xFFA0CAFD)
+private val onPrimaryDark = Color(0xFF003258)
+private val primaryContainerDark = Color(0xFF194975)
+private val onPrimaryContainerDark = Color(0xFFD1E4FF)
+private val secondaryDark = Color(0xFFBBC7DB)
+private val onSecondaryDark = Color(0xFF253140)
+private val secondaryContainerDark = Color(0xFF3B4858)
+private val onSecondaryContainerDark = Color(0xFFD7E3F7)
+private val tertiaryDark = Color(0xFFD6BEE4)
+private val onTertiaryDark = Color(0xFF3B2948)
+private val tertiaryContainerDark = Color(0xFF523F5F)
+private val onTertiaryContainerDark = Color(0xFFF2DAFF)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF111418)
+private val onBackgroundDark = Color(0xFFE1E2E8)
+private val surfaceDark = Color(0xFF111418)
+private val onSurfaceDark = Color(0xFFE1E2E8)
+private val surfaceVariantDark = Color(0xFF43474E)
+private val onSurfaceVariantDark = Color(0xFFC3C7CF)
+private val outlineDark = Color(0xFF8D9199)
+private val outlineVariantDark = Color(0xFF43474E)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFE1E2E8)
+private val inverseOnSurfaceDark = Color(0xFF2E3135)
+private val inversePrimaryDark = Color(0xFF36618E)
+private val surfaceDimDark = Color(0xFF111418)
+private val surfaceBrightDark = Color(0xFF36393E)
+private val surfaceContainerLowestDark = Color(0xFF0B0E13)
+private val surfaceContainerLowDark = Color(0xFF191C20)
+private val surfaceContainerDark = Color(0xFF1D2024)
+private val surfaceContainerHighDark = Color(0xFF272A2F)
+private val surfaceContainerHighestDark = Color(0xFF32353A)
+
+val blueLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val blueDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/BrownScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/BrownScheme.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF8F4C33)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFFFDBCF)
+private val onPrimaryContainerLight = Color(0xFF72361E)
+private val secondaryLight = Color(0xFF77574C)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFFFDBCF)
+private val onSecondaryContainerLight = Color(0xFF5D4035)
+private val tertiaryLight = Color(0xFF695E2F)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFF2E2A8)
+private val onTertiaryContainerLight = Color(0xFF50471A)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFFF8F6)
+private val onBackgroundLight = Color(0xFF231A16)
+private val surfaceLight = Color(0xFFFFF8F6)
+private val onSurfaceLight = Color(0xFF231A16)
+private val surfaceVariantLight = Color(0xFFF5DED6)
+private val onSurfaceVariantLight = Color(0xFF53433E)
+private val outlineLight = Color(0xFF85736D)
+private val outlineVariantLight = Color(0xFFD8C2BB)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF392E2B)
+private val inverseOnSurfaceLight = Color(0xFFFFEDE7)
+private val inversePrimaryLight = Color(0xFFFFB59A)
+private val surfaceDimLight = Color(0xFFE8D6D1)
+private val surfaceBrightLight = Color(0xFFFFF8F6)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFFFF1EC)
+private val surfaceContainerLight = Color(0xFFFCEAE4)
+private val surfaceContainerHighLight = Color(0xFFF7E4DF)
+private val surfaceContainerHighestLight = Color(0xFFF1DFD9)
+private val primaryDark = Color(0xFFFFB59A)
+private val onPrimaryDark = Color(0xFF55200A)
+private val primaryContainerDark = Color(0xFF72361E)
+private val onPrimaryContainerDark = Color(0xFFFFDBCF)
+private val secondaryDark = Color(0xFFE7BEAF)
+private val onSecondaryDark = Color(0xFF442A20)
+private val secondaryContainerDark = Color(0xFF5D4035)
+private val onSecondaryContainerDark = Color(0xFFFFDBCF)
+private val tertiaryDark = Color(0xFFD5C68E)
+private val onTertiaryDark = Color(0xFF393005)
+private val tertiaryContainerDark = Color(0xFF50471A)
+private val onTertiaryContainerDark = Color(0xFFF2E2A8)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF1A110E)
+private val onBackgroundDark = Color(0xFFF1DFD9)
+private val surfaceDark = Color(0xFF1A110E)
+private val onSurfaceDark = Color(0xFFF1DFD9)
+private val surfaceVariantDark = Color(0xFF53433E)
+private val onSurfaceVariantDark = Color(0xFFD8C2BB)
+private val outlineDark = Color(0xFFA08D86)
+private val outlineVariantDark = Color(0xFF53433E)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFF1DFD9)
+private val inverseOnSurfaceDark = Color(0xFF392E2B)
+private val inversePrimaryDark = Color(0xFF8F4C33)
+private val surfaceDimDark = Color(0xFF1A110E)
+private val surfaceBrightDark = Color(0xFF423733)
+private val surfaceContainerLowestDark = Color(0xFF140C09)
+private val surfaceContainerLowDark = Color(0xFF231A16)
+private val surfaceContainerDark = Color(0xFF271E1A)
+private val surfaceContainerHighDark = Color(0xFF322824)
+private val surfaceContainerHighestDark = Color(0xFF3D322F)
+
+val brownLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val brownDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/CyanScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/CyanScheme.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+
+private val primaryLight = Color(0xFF006876)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFA1EFFF)
+private val onPrimaryContainerLight = Color(0xFF004E59)
+private val secondaryLight = Color(0xFF4A6268)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFCDE7ED)
+private val onSecondaryContainerLight = Color(0xFF334A50)
+private val tertiaryLight = Color(0xFF545D7E)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFDBE1FF)
+private val onTertiaryContainerLight = Color(0xFF3C4665)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFF5FAFC)
+private val onBackgroundLight = Color(0xFF171D1E)
+private val surfaceLight = Color(0xFFF5FAFC)
+private val onSurfaceLight = Color(0xFF171D1E)
+private val surfaceVariantLight = Color(0xFFDBE4E6)
+private val onSurfaceVariantLight = Color(0xFF3F484A)
+private val outlineLight = Color(0xFF6F797B)
+private val outlineVariantLight = Color(0xFFBFC8CA)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF2B3133)
+private val inverseOnSurfaceLight = Color(0xFFECF2F3)
+private val inversePrimaryLight = Color(0xFF83D3E3)
+private val surfaceDimLight = Color(0xFFD5DBDC)
+private val surfaceBrightLight = Color(0xFFF5FAFC)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFEFF5F6)
+private val surfaceContainerLight = Color(0xFFE9EFF0)
+private val surfaceContainerHighLight = Color(0xFFE3E9EB)
+private val surfaceContainerHighestLight = Color(0xFFDEE3E5)
+
+private val primaryDark = Color(0xFF83D3E3)
+private val onPrimaryDark = Color(0xFF00363E)
+private val primaryContainerDark = Color(0xFF004E59)
+private val onPrimaryContainerDark = Color(0xFFA1EFFF)
+private val secondaryDark = Color(0xFFB1CBD1)
+private val onSecondaryDark = Color(0xFF1C3439)
+private val secondaryContainerDark = Color(0xFF334A50)
+private val onSecondaryContainerDark = Color(0xFFCDE7ED)
+private val tertiaryDark = Color(0xFFBCC5EB)
+private val onTertiaryDark = Color(0xFF262F4D)
+private val tertiaryContainerDark = Color(0xFF3C4665)
+private val onTertiaryContainerDark = Color(0xFFDBE1FF)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF0E1416)
+private val onBackgroundDark = Color(0xFFDEE3E5)
+private val surfaceDark = Color(0xFF0E1416)
+private val onSurfaceDark = Color(0xFFDEE3E5)
+private val surfaceVariantDark = Color(0xFF3F484A)
+private val onSurfaceVariantDark = Color(0xFFBFC8CA)
+private val outlineDark = Color(0xFF899295)
+private val outlineVariantDark = Color(0xFF3F484A)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFDEE3E5)
+private val inverseOnSurfaceDark = Color(0xFF2B3133)
+private val inversePrimaryDark = Color(0xFF006876)
+private val surfaceDimDark = Color(0xFF0E1416)
+private val surfaceBrightDark = Color(0xFF343A3C)
+private val surfaceContainerLowestDark = Color(0xFF090F10)
+private val surfaceContainerLowDark = Color(0xFF171D1E)
+private val surfaceContainerDark = Color(0xFF1B2122)
+private val surfaceContainerHighDark = Color(0xFF252B2C)
+private val surfaceContainerHighestDark = Color(0xFF303637)
+
+val cyanLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val cyanDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/DeepPurpleScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/DeepPurpleScheme.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+
+private val primaryLight = Color(0xFF68548E)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFEBDDFF)
+private val onPrimaryContainerLight = Color(0xFF4F3D74)
+private val secondaryLight = Color(0xFF635B70)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFE9DEF8)
+private val onSecondaryContainerLight = Color(0xFF4B4358)
+private val tertiaryLight = Color(0xFF7E525D)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFFFD9E1)
+private val onTertiaryContainerLight = Color(0xFF643B46)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFEF7FF)
+private val onBackgroundLight = Color(0xFF1D1B20)
+private val surfaceLight = Color(0xFFFEF7FF)
+private val onSurfaceLight = Color(0xFF1D1B20)
+private val surfaceVariantLight = Color(0xFFE7E0EB)
+private val onSurfaceVariantLight = Color(0xFF49454E)
+private val outlineLight = Color(0xFF7A757F)
+private val outlineVariantLight = Color(0xFFCBC4CF)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF322F35)
+private val inverseOnSurfaceLight = Color(0xFFF5EFF7)
+private val inversePrimaryLight = Color(0xFFD3BCFD)
+private val surfaceDimLight = Color(0xFFDED8E0)
+private val surfaceBrightLight = Color(0xFFFEF7FF)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF8F1FA)
+private val surfaceContainerLight = Color(0xFFF2ECF4)
+private val surfaceContainerHighLight = Color(0xFFEDE6EE)
+private val surfaceContainerHighestLight = Color(0xFFE7E0E8)
+
+private val primaryDark = Color(0xFFD3BCFD)
+private val onPrimaryDark = Color(0xFF38265C)
+private val primaryContainerDark = Color(0xFF4F3D74)
+private val onPrimaryContainerDark = Color(0xFFEBDDFF)
+private val secondaryDark = Color(0xFFCDC2DB)
+private val onSecondaryDark = Color(0xFF342D40)
+private val secondaryContainerDark = Color(0xFF4B4358)
+private val onSecondaryContainerDark = Color(0xFFE9DEF8)
+private val tertiaryDark = Color(0xFFF0B7C5)
+private val onTertiaryDark = Color(0xFF4A2530)
+private val tertiaryContainerDark = Color(0xFF643B46)
+private val onTertiaryContainerDark = Color(0xFFFFD9E1)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF151218)
+private val onBackgroundDark = Color(0xFFE7E0E8)
+private val surfaceDark = Color(0xFF151218)
+private val onSurfaceDark = Color(0xFFE7E0E8)
+private val surfaceVariantDark = Color(0xFF49454E)
+private val onSurfaceVariantDark = Color(0xFFCBC4CF)
+private val outlineDark = Color(0xFF948F99)
+private val outlineVariantDark = Color(0xFF49454E)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFE7E0E8)
+private val inverseOnSurfaceDark = Color(0xFF322F35)
+private val inversePrimaryDark = Color(0xFF68548E)
+private val surfaceDimDark = Color(0xFF151218)
+private val surfaceBrightDark = Color(0xFF3B383E)
+private val surfaceContainerLowestDark = Color(0xFF0F0D13)
+private val surfaceContainerLowDark = Color(0xFF1D1B20)
+private val surfaceContainerDark = Color(0xFF211F24)
+private val surfaceContainerHighDark = Color(0xFF2C292F)
+private val surfaceContainerHighestDark = Color(0xFF36343A)
+
+val deepPurpleLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val deepPurpleDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/FlorisDefaultKeyboardScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/FlorisDefaultKeyboardScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF3B6939)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFBCF0B4)
+private val onPrimaryContainerLight = Color(0xFF235024)
+private val secondaryLight = Color(0xFF52634F)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFD5E8CF)
+private val onSecondaryContainerLight = Color(0xFF3B4B38)
+private val tertiaryLight = Color(0xFF38656A)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFBCEBF0)
+private val onTertiaryContainerLight = Color(0xFF1F4D52)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFF7FBF1)
+private val onBackgroundLight = Color(0xFF191D17)
+private val surfaceLight = Color(0xFFF7FBF1)
+private val onSurfaceLight = Color(0xFF191D17)
+private val surfaceVariantLight = Color(0xFFDEE5D8)
+private val onSurfaceVariantLight = Color(0xFF424940)
+private val outlineLight = Color(0xFF72796F)
+private val outlineVariantLight = Color(0xFFC2C9BD)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF2D322C)
+private val inverseOnSurfaceLight = Color(0xFFEFF2E9)
+private val inversePrimaryLight = Color(0xFFA1D39A)
+private val surfaceDimLight = Color(0xFFD8DBD2)
+private val surfaceBrightLight = Color(0xFFF7FBF1)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF1F5EC)
+private val surfaceContainerLight = Color(0xFFECEFE6)
+private val surfaceContainerHighLight = Color(0xFFE6E9E0)
+private val surfaceContainerHighestLight = Color(0xFFE0E4DB)
+private val primaryDark = Color(0xFFA1D39A)
+private val onPrimaryDark = Color(0xFF0A390F)
+private val primaryContainerDark = Color(0xFF235024)
+private val onPrimaryContainerDark = Color(0xFFBCF0B4)
+private val secondaryDark = Color(0xFFBACCB3)
+private val onSecondaryDark = Color(0xFF253423)
+private val secondaryContainerDark = Color(0xFF3B4B38)
+private val onSecondaryContainerDark = Color(0xFFD5E8CF)
+private val tertiaryDark = Color(0xFFA0CFD4)
+private val onTertiaryDark = Color(0xFF00363B)
+private val tertiaryContainerDark = Color(0xFF1F4D52)
+private val onTertiaryContainerDark = Color(0xFFBCEBF0)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF10140F)
+private val onBackgroundDark = Color(0xFFE0E4DB)
+private val surfaceDark = Color(0xFF10140F)
+private val onSurfaceDark = Color(0xFFE0E4DB)
+private val surfaceVariantDark = Color(0xFF424940)
+private val onSurfaceVariantDark = Color(0xFFC2C9BD)
+private val outlineDark = Color(0xFF8C9388)
+private val outlineVariantDark = Color(0xFF424940)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFE0E4DB)
+private val inverseOnSurfaceDark = Color(0xFF2D322C)
+private val inversePrimaryDark = Color(0xFF3B6939)
+private val surfaceDimDark = Color(0xFF10140F)
+private val surfaceBrightDark = Color(0xFF363A34)
+private val surfaceContainerLowestDark = Color(0xFF0B0F0A)
+private val surfaceContainerLowDark = Color(0xFF191D17)
+private val surfaceContainerDark = Color(0xFF1D211B)
+private val surfaceContainerHighDark = Color(0xFF272B25)
+private val surfaceContainerHighestDark = Color(0xFF323630)
+
+
+val florisDefaultKeyboardLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val florisDefaultKeyboardDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/FlorisDefaultSettingsScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/FlorisDefaultSettingsScheme.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF006E1C)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFF58BC5B)
+private val onPrimaryContainerLight = Color(0xFF002204)
+private val secondaryLight = Color(0xFF005E16)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFF2E8534)
+private val onSecondaryContainerLight = Color(0xFFFFFFFF)
+private val tertiaryLight = Color(0xFF964900)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFFF8926)
+private val onTertiaryContainerLight = Color(0xFF341500)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF410002)
+private val backgroundLight = Color(0xFFF5FBEF)
+private val onBackgroundLight = Color(0xFF171D16)
+private val surfaceLight = Color(0xFFF5FBEF)
+private val onSurfaceLight = Color(0xFF171D16)
+private val surfaceVariantLight = Color(0xFFDAE6D4)
+private val onSurfaceVariantLight = Color(0xFF3F4A3C)
+private val outlineLight = Color(0xFF6F7A6B)
+private val outlineVariantLight = Color(0xFFBECAB9)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF2C322A)
+private val inverseOnSurfaceLight = Color(0xFFEDF3E7)
+private val inversePrimaryLight = Color(0xFF78DC77)
+private val surfaceDimLight = Color(0xFFD6DCD0)
+private val surfaceBrightLight = Color(0xFFF5FBEF)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF0F6EA)
+private val surfaceContainerLight = Color(0xFFEAF0E4)
+private val surfaceContainerHighLight = Color(0xFFE4EADE)
+private val surfaceContainerHighestLight = Color(0xFFDEE4D9)
+
+private val primaryDark = Color(0xFF78DC77)
+private val onPrimaryDark = Color(0xFF00390A)
+private val primaryContainerDark = Color(0xFF43A648)
+private val onPrimaryContainerDark = Color(0xFF000000)
+private val secondaryDark = Color(0xFF82DB7E)
+private val onSecondaryDark = Color(0xFF00390A)
+private val secondaryContainerDark = Color(0xFF2D8433)
+private val onSecondaryContainerDark = Color(0xFFFFFFFF)
+private val tertiaryDark = Color(0xFFFFB786)
+private val onTertiaryDark = Color(0xFF502400)
+private val tertiaryContainerDark = Color(0xFFEA7600)
+private val onTertiaryContainerDark = Color(0xFF030100)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF0F120E)
+private val onBackgroundDark = Color(0xFFDEE4D9)
+private val surfaceDark = Color(0xFF0F120E)
+private val onSurfaceDark = Color(0xFFDEE4D9)
+private val surfaceVariantDark = Color(0xFF3F4A3C)
+private val onSurfaceVariantDark = Color(0xFFBECAB9)
+private val outlineDark = Color(0xFF899484)
+private val outlineVariantDark = Color(0xFF3F4A3C)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFDEE4D9)
+private val inverseOnSurfaceDark = Color(0xFF2C322A)
+private val inversePrimaryDark = Color(0xFF006E1C)
+private val surfaceDimDark = Color(0xFF0F150E)
+private val surfaceBrightDark = Color(0xFF353B33)
+private val surfaceContainerLowestDark = Color(0xFF0A1009)
+private val surfaceContainerLowDark = Color(0xFF171D16)
+private val surfaceContainerDark = Color(0xFF1B211A)
+private val surfaceContainerHighDark = Color(0xFF262C24)
+private val surfaceContainerHighestDark = Color(0xFF30362E)
+
+val amoledDark = Color(0xFF000000)
+
+val florisDefaultSettingsLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val florisDefaultSettingsDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/GrayScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/GrayScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF5E5E5F)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFF9E9E9E)
+private val onPrimaryContainerLight = Color(0xFF343636)
+private val secondaryLight = Color(0xFF5F5E5E)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFE4E2E1)
+private val onSecondaryContainerLight = Color(0xFF656464)
+private val tertiaryLight = Color(0xFF615D5F)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFA29D9F)
+private val onTertiaryContainerLight = Color(0xFF383537)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFCF8F8)
+private val onBackgroundLight = Color(0xFF1C1B1B)
+private val surfaceLight = Color(0xFFFCF8F8)
+private val onSurfaceLight = Color(0xFF1C1B1B)
+private val surfaceVariantLight = Color(0xFFE0E3E3)
+private val onSurfaceVariantLight = Color(0xFF444748)
+private val outlineLight = Color(0xFF747878)
+private val outlineVariantLight = Color(0xFFC4C7C7)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF313030)
+private val inverseOnSurfaceLight = Color(0xFFF4F0EF)
+private val inversePrimaryLight = Color(0xFFC7C6C6)
+private val surfaceDimLight = Color(0xFFDDD9D9)
+private val surfaceBrightLight = Color(0xFFFCF8F8)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF7F3F2)
+private val surfaceContainerLight = Color(0xFFF1EDEC)
+private val surfaceContainerHighLight = Color(0xFFEBE7E7)
+private val surfaceContainerHighestLight = Color(0xFFE5E2E1)
+private val primaryDark = Color(0xFFC7C6C6)
+private val onPrimaryDark = Color(0xFF2F3131)
+private val primaryContainerDark = Color(0xFF9E9E9E)
+private val onPrimaryContainerDark = Color(0xFF343636)
+private val secondaryDark = Color(0xFFC8C6C6)
+private val onSecondaryDark = Color(0xFF303030)
+private val secondaryContainerDark = Color(0xFF474747)
+private val onSecondaryContainerDark = Color(0xFFB6B5B4)
+private val tertiaryDark = Color(0xFFCBC5C7)
+private val onTertiaryDark = Color(0xFF323031)
+private val tertiaryContainerDark = Color(0xFFA29D9F)
+private val onTertiaryContainerDark = Color(0xFF383537)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF141313)
+private val onBackgroundDark = Color(0xFFE5E2E1)
+private val surfaceDark = Color(0xFF141313)
+private val onSurfaceDark = Color(0xFFE5E2E1)
+private val surfaceVariantDark = Color(0xFF444748)
+private val onSurfaceVariantDark = Color(0xFFC4C7C7)
+private val outlineDark = Color(0xFF8E9192)
+private val outlineVariantDark = Color(0xFF444748)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFE5E2E1)
+private val inverseOnSurfaceDark = Color(0xFF313030)
+private val inversePrimaryDark = Color(0xFF5E5E5F)
+private val surfaceDimDark = Color(0xFF141313)
+private val surfaceBrightDark = Color(0xFF3A3939)
+private val surfaceContainerLowestDark = Color(0xFF0E0E0E)
+private val surfaceContainerLowDark = Color(0xFF1C1B1B)
+private val surfaceContainerDark = Color(0xFF201F1F)
+private val surfaceContainerHighDark = Color(0xFF2A2A2A)
+private val surfaceContainerHighestDark = Color(0xFF353434)
+
+
+val grayLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val grayDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/IndigoScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/IndigoScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF515B92)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFDEE0FF)
+private val onPrimaryContainerLight = Color(0xFF394379)
+private val secondaryLight = Color(0xFF5B5D72)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFE0E1F9)
+private val onSecondaryContainerLight = Color(0xFF434659)
+private val tertiaryLight = Color(0xFF77536D)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFFFD7F1)
+private val onTertiaryContainerLight = Color(0xFF5D3C55)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFBF8FF)
+private val onBackgroundLight = Color(0xFF1B1B21)
+private val surfaceLight = Color(0xFFFBF8FF)
+private val onSurfaceLight = Color(0xFF1B1B21)
+private val surfaceVariantLight = Color(0xFFE3E1EC)
+private val onSurfaceVariantLight = Color(0xFF46464F)
+private val outlineLight = Color(0xFF767680)
+private val outlineVariantLight = Color(0xFFC7C5D0)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF303036)
+private val inverseOnSurfaceLight = Color(0xFFF2EFF7)
+private val inversePrimaryLight = Color(0xFFBAC3FF)
+private val surfaceDimLight = Color(0xFFDBD9E0)
+private val surfaceBrightLight = Color(0xFFFBF8FF)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF5F2FA)
+private val surfaceContainerLight = Color(0xFFEFEDF4)
+private val surfaceContainerHighLight = Color(0xFFE9E7EF)
+private val surfaceContainerHighestLight = Color(0xFFE4E1E9)
+
+private val primaryDark = Color(0xFFBAC3FF)
+private val onPrimaryDark = Color(0xFF222C61)
+private val primaryContainerDark = Color(0xFF394379)
+private val onPrimaryContainerDark = Color(0xFFDEE0FF)
+private val secondaryDark = Color(0xFFC3C5DD)
+private val onSecondaryDark = Color(0xFF2D2F42)
+private val secondaryContainerDark = Color(0xFF434659)
+private val onSecondaryContainerDark = Color(0xFFE0E1F9)
+private val tertiaryDark = Color(0xFFE6BAD7)
+private val onTertiaryDark = Color(0xFF44263D)
+private val tertiaryContainerDark = Color(0xFF5D3C55)
+private val onTertiaryContainerDark = Color(0xFFFFD7F1)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF121318)
+private val onBackgroundDark = Color(0xFFE4E1E9)
+private val surfaceDark = Color(0xFF121318)
+private val onSurfaceDark = Color(0xFFE4E1E9)
+private val surfaceVariantDark = Color(0xFF46464F)
+private val onSurfaceVariantDark = Color(0xFFC7C5D0)
+private val outlineDark = Color(0xFF90909A)
+private val outlineVariantDark = Color(0xFF46464F)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFE4E1E9)
+private val inverseOnSurfaceDark = Color(0xFF303036)
+private val inversePrimaryDark = Color(0xFF515B92)
+private val surfaceDimDark = Color(0xFF121318)
+private val surfaceBrightDark = Color(0xFF39393F)
+private val surfaceContainerLowestDark = Color(0xFF0D0E13)
+private val surfaceContainerLowDark = Color(0xFF1B1B21)
+private val surfaceContainerDark = Color(0xFF1F1F25)
+private val surfaceContainerHighDark = Color(0xFF29292F)
+private val surfaceContainerHighestDark = Color(0xFF34343A)
+
+val indigoLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val indigoDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/LightBlueScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/LightBlueScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF27638A)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFCAE6FF)
+private val onPrimaryContainerLight = Color(0xFF004B70)
+private val secondaryLight = Color(0xFF50606E)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFD3E5F5)
+private val onSecondaryContainerLight = Color(0xFF384956)
+private val tertiaryLight = Color(0xFF65587B)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFEBDDFF)
+private val onTertiaryContainerLight = Color(0xFF4D4162)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFF7F9FF)
+private val onBackgroundLight = Color(0xFF181C20)
+private val surfaceLight = Color(0xFFF7F9FF)
+private val onSurfaceLight = Color(0xFF181C20)
+private val surfaceVariantLight = Color(0xFFDDE3EA)
+private val onSurfaceVariantLight = Color(0xFF41474D)
+private val outlineLight = Color(0xFF72787E)
+private val outlineVariantLight = Color(0xFFC1C7CE)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF2D3135)
+private val inverseOnSurfaceLight = Color(0xFFEEF1F6)
+private val inversePrimaryLight = Color(0xFF96CDF8)
+private val surfaceDimLight = Color(0xFFD7DADF)
+private val surfaceBrightLight = Color(0xFFF7F9FF)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF1F4F9)
+private val surfaceContainerLight = Color(0xFFEBEEF3)
+private val surfaceContainerHighLight = Color(0xFFE5E8ED)
+private val surfaceContainerHighestLight = Color(0xFFE0E3E8)
+
+private val primaryDark = Color(0xFF96CDF8)
+private val onPrimaryDark = Color(0xFF00344F)
+private val primaryContainerDark = Color(0xFF004B70)
+private val onPrimaryContainerDark = Color(0xFFCAE6FF)
+private val secondaryDark = Color(0xFFB7C9D9)
+private val onSecondaryDark = Color(0xFF22323F)
+private val secondaryContainerDark = Color(0xFF384956)
+private val onSecondaryContainerDark = Color(0xFFD3E5F5)
+private val tertiaryDark = Color(0xFFCFC0E8)
+private val onTertiaryDark = Color(0xFF362B4B)
+private val tertiaryContainerDark = Color(0xFF4D4162)
+private val onTertiaryContainerDark = Color(0xFFEBDDFF)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF101417)
+private val onBackgroundDark = Color(0xFFE0E3E8)
+private val surfaceDark = Color(0xFF101417)
+private val onSurfaceDark = Color(0xFFE0E3E8)
+private val surfaceVariantDark = Color(0xFF41474D)
+private val onSurfaceVariantDark = Color(0xFFC1C7CE)
+private val outlineDark = Color(0xFF8B9198)
+private val outlineVariantDark = Color(0xFF41474D)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFE0E3E8)
+private val inverseOnSurfaceDark = Color(0xFF2D3135)
+private val inversePrimaryDark = Color(0xFF27638A)
+private val surfaceDimDark = Color(0xFF101417)
+private val surfaceBrightDark = Color(0xFF363A3E)
+private val surfaceContainerLowestDark = Color(0xFF0B0F12)
+private val surfaceContainerLowDark = Color(0xFF181C20)
+private val surfaceContainerDark = Color(0xFF1C2024)
+private val surfaceContainerHighDark = Color(0xFF262A2E)
+private val surfaceContainerHighestDark = Color(0xFF313539)
+
+val lightBlueLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val lightBlueDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/LightGreenScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/LightGreenScheme.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+
+private val primaryLight = Color(0xFF4B662C)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFCCEDA4)
+private val onPrimaryContainerLight = Color(0xFF344E16)
+private val secondaryLight = Color(0xFF576249)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFDBE7C8)
+private val onSecondaryContainerLight = Color(0xFF404A33)
+private val tertiaryLight = Color(0xFF386663)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFBBECE8)
+private val onTertiaryContainerLight = Color(0xFF1F4E4B)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFF9FAEF)
+private val onBackgroundLight = Color(0xFF1A1C16)
+private val surfaceLight = Color(0xFFF9FAEF)
+private val onSurfaceLight = Color(0xFF1A1C16)
+private val surfaceVariantLight = Color(0xFFE1E4D5)
+private val onSurfaceVariantLight = Color(0xFF44483D)
+private val outlineLight = Color(0xFF75796C)
+private val outlineVariantLight = Color(0xFFC5C8BA)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF2F312A)
+private val inverseOnSurfaceLight = Color(0xFFF0F2E6)
+private val inversePrimaryLight = Color(0xFFB1D18A)
+private val surfaceDimLight = Color(0xFFDADBD0)
+private val surfaceBrightLight = Color(0xFFF9FAEF)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF3F4E9)
+private val surfaceContainerLight = Color(0xFFEEEFE4)
+private val surfaceContainerHighLight = Color(0xFFE8E9DE)
+private val surfaceContainerHighestLight = Color(0xFFE2E3D8)
+
+private val primaryDark = Color(0xFFB1D18A)
+private val onPrimaryDark = Color(0xFF1F3701)
+private val primaryContainerDark = Color(0xFF344E16)
+private val onPrimaryContainerDark = Color(0xFFCCEDA4)
+private val secondaryDark = Color(0xFFBFCBAD)
+private val onSecondaryDark = Color(0xFF2A331E)
+private val secondaryContainerDark = Color(0xFF404A33)
+private val onSecondaryContainerDark = Color(0xFFDBE7C8)
+private val tertiaryDark = Color(0xFFA0D0CC)
+private val onTertiaryDark = Color(0xFF003735)
+private val tertiaryContainerDark = Color(0xFF1F4E4B)
+private val onTertiaryContainerDark = Color(0xFFBBECE8)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF12140E)
+private val onBackgroundDark = Color(0xFFE2E3D8)
+private val surfaceDark = Color(0xFF12140E)
+private val onSurfaceDark = Color(0xFFE2E3D8)
+private val surfaceVariantDark = Color(0xFF44483D)
+private val onSurfaceVariantDark = Color(0xFFC5C8BA)
+private val outlineDark = Color(0xFF8E9285)
+private val outlineVariantDark = Color(0xFF44483D)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFE2E3D8)
+private val inverseOnSurfaceDark = Color(0xFF2F312A)
+private val inversePrimaryDark = Color(0xFF4B662C)
+private val surfaceDimDark = Color(0xFF12140E)
+private val surfaceBrightDark = Color(0xFF383A32)
+private val surfaceContainerLowestDark = Color(0xFF0C0F09)
+private val surfaceContainerLowDark = Color(0xFF1A1C16)
+private val surfaceContainerDark = Color(0xFF1E201A)
+private val surfaceContainerHighDark = Color(0xFF282B24)
+private val surfaceContainerHighestDark = Color(0xFF33362E)
+
+val lightGreenLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val lightGreenDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/LightPinkScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/LightPinkScheme.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF8B4A61)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFFFD9E3)
+private val onPrimaryContainerLight = Color(0xFF6F334A)
+private val secondaryLight = Color(0xFF74565F)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFFFD9E3)
+private val onSecondaryContainerLight = Color(0xFF5A3F48)
+private val tertiaryLight = Color(0xFF7D5635)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFFFDCC2)
+private val onTertiaryContainerLight = Color(0xFF623F20)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFFF8F8)
+private val onBackgroundLight = Color(0xFF22191C)
+private val surfaceLight = Color(0xFFFFF8F8)
+private val onSurfaceLight = Color(0xFF22191C)
+private val surfaceVariantLight = Color(0xFFF2DDE2)
+private val onSurfaceVariantLight = Color(0xFF514347)
+private val outlineLight = Color(0xFF837377)
+private val outlineVariantLight = Color(0xFFD5C2C6)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF372E30)
+private val inverseOnSurfaceLight = Color(0xFFFDEDF0)
+private val inversePrimaryLight = Color(0xFFFFB0C9)
+private val surfaceDimLight = Color(0xFFE6D6D9)
+private val surfaceBrightLight = Color(0xFFFFF8F8)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFFFF0F2)
+private val surfaceContainerLight = Color(0xFFFAEAED)
+private val surfaceContainerHighLight = Color(0xFFF5E4E7)
+private val surfaceContainerHighestLight = Color(0xFFEFDFE1)
+
+private val primaryDark = Color(0xFFFFB0C9)
+private val onPrimaryDark = Color(0xFF541D33)
+private val primaryContainerDark = Color(0xFF6F334A)
+private val onPrimaryContainerDark = Color(0xFFFFD9E3)
+private val secondaryDark = Color(0xFFE2BDC7)
+private val onSecondaryDark = Color(0xFF422931)
+private val secondaryContainerDark = Color(0xFF5A3F48)
+private val onSecondaryContainerDark = Color(0xFFFFD9E3)
+private val tertiaryDark = Color(0xFFEFBC94)
+private val onTertiaryDark = Color(0xFF48290C)
+private val tertiaryContainerDark = Color(0xFF623F20)
+private val onTertiaryContainerDark = Color(0xFFFFDCC2)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF191113)
+private val onBackgroundDark = Color(0xFFEFDFE1)
+private val surfaceDark = Color(0xFF191113)
+private val onSurfaceDark = Color(0xFFEFDFE1)
+private val surfaceVariantDark = Color(0xFF514347)
+private val onSurfaceVariantDark = Color(0xFFD5C2C6)
+private val outlineDark = Color(0xFF9E8C90)
+private val outlineVariantDark = Color(0xFF514347)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFEFDFE1)
+private val inverseOnSurfaceDark = Color(0xFF372E30)
+private val inversePrimaryDark = Color(0xFF8B4A61)
+private val surfaceDimDark = Color(0xFF191113)
+private val surfaceBrightDark = Color(0xFF403739)
+private val surfaceContainerLowestDark = Color(0xFF140C0E)
+private val surfaceContainerLowDark = Color(0xFF22191C)
+private val surfaceContainerDark = Color(0xFF261D20)
+private val surfaceContainerHighDark = Color(0xFF31282A)
+private val surfaceContainerHighestDark = Color(0xFF3C3235)
+
+
+val lightPinkLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val lightPinkDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/LimeScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/LimeScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF5C631D)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFE1E994)
+private val onPrimaryContainerLight = Color(0xFF444B04)
+private val secondaryLight = Color(0xFF5E6044)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFE4E5C1)
+private val onSecondaryContainerLight = Color(0xFF46492E)
+private val tertiaryLight = Color(0xFF3C665A)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFBEECDC)
+private val onTertiaryContainerLight = Color(0xFF234E43)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFCFAEC)
+private val onBackgroundLight = Color(0xFF1C1C14)
+private val surfaceLight = Color(0xFFFCFAEC)
+private val onSurfaceLight = Color(0xFF1C1C14)
+private val surfaceVariantLight = Color(0xFFE5E3D2)
+private val onSurfaceVariantLight = Color(0xFF47483B)
+private val outlineLight = Color(0xFF787869)
+private val outlineVariantLight = Color(0xFFC8C7B7)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF313128)
+private val inverseOnSurfaceLight = Color(0xFFF3F1E4)
+private val inversePrimaryLight = Color(0xFFC5CD7A)
+private val surfaceDimLight = Color(0xFFDCDACE)
+private val surfaceBrightLight = Color(0xFFFCFAEC)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF6F4E7)
+private val surfaceContainerLight = Color(0xFFF0EEE1)
+private val surfaceContainerHighLight = Color(0xFFEBE8DC)
+private val surfaceContainerHighestLight = Color(0xFFE5E3D6)
+
+private val primaryDark = Color(0xFFC5CD7A)
+private val onPrimaryDark = Color(0xFF2F3300)
+private val primaryContainerDark = Color(0xFF444B04)
+private val onPrimaryContainerDark = Color(0xFFE1E994)
+private val secondaryDark = Color(0xFFC7C9A6)
+private val onSecondaryDark = Color(0xFF30321A)
+private val secondaryContainerDark = Color(0xFF46492E)
+private val onSecondaryContainerDark = Color(0xFFE4E5C1)
+private val tertiaryDark = Color(0xFFA2D0C1)
+private val onTertiaryDark = Color(0xFF07372D)
+private val tertiaryContainerDark = Color(0xFF234E43)
+private val onTertiaryContainerDark = Color(0xFFBEECDC)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF13140C)
+private val onBackgroundDark = Color(0xFFE5E3D6)
+private val surfaceDark = Color(0xFF13140C)
+private val onSurfaceDark = Color(0xFFE5E3D6)
+private val surfaceVariantDark = Color(0xFF47483B)
+private val onSurfaceVariantDark = Color(0xFFC8C7B7)
+private val outlineDark = Color(0xFF929282)
+private val outlineVariantDark = Color(0xFF47483B)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFE5E3D6)
+private val inverseOnSurfaceDark = Color(0xFF313128)
+private val inversePrimaryDark = Color(0xFF5C631D)
+private val surfaceDimDark = Color(0xFF13140C)
+private val surfaceBrightDark = Color(0xFF3A3A31)
+private val surfaceContainerLowestDark = Color(0xFF0E0F08)
+private val surfaceContainerLowDark = Color(0xFF1C1C14)
+private val surfaceContainerDark = Color(0xFF202018)
+private val surfaceContainerHighDark = Color(0xFF2A2A22)
+private val surfaceContainerHighestDark = Color(0xFF35352D)
+
+val limeLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val limeDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/OrangeScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/OrangeScheme.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF855318)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFFFDCBE)
+private val onPrimaryContainerLight = Color(0xFF693C00)
+private val secondaryLight = Color(0xFF725A42)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFFFDCBE)
+private val onSecondaryContainerLight = Color(0xFF59422C)
+private val tertiaryLight = Color(0xFF58633A)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFDCE8B4)
+private val onTertiaryContainerLight = Color(0xFF414B24)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFFF8F5)
+private val onBackgroundLight = Color(0xFF211A14)
+private val surfaceLight = Color(0xFFFFF8F5)
+private val onSurfaceLight = Color(0xFF211A14)
+private val surfaceVariantLight = Color(0xFFF2DFD1)
+private val onSurfaceVariantLight = Color(0xFF51453A)
+private val outlineLight = Color(0xFF837468)
+private val outlineVariantLight = Color(0xFFD5C3B5)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF372F28)
+private val inverseOnSurfaceLight = Color(0xFFFDEEE3)
+private val inversePrimaryLight = Color(0xFFFDB975)
+private val surfaceDimLight = Color(0xFFE6D7CD)
+private val surfaceBrightLight = Color(0xFFFFF8F5)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFFFF1E7)
+private val surfaceContainerLight = Color(0xFFFAEBE0)
+private val surfaceContainerHighLight = Color(0xFFF4E5DB)
+private val surfaceContainerHighestLight = Color(0xFFEFE0D5)
+private val primaryDark = Color(0xFFFDB975)
+private val onPrimaryDark = Color(0xFF4A2800)
+private val primaryContainerDark = Color(0xFF693C00)
+private val onPrimaryContainerDark = Color(0xFFFFDCBE)
+private val secondaryDark = Color(0xFFE1C1A4)
+private val onSecondaryDark = Color(0xFF402C18)
+private val secondaryContainerDark = Color(0xFF59422C)
+private val onSecondaryContainerDark = Color(0xFFFFDCBE)
+private val tertiaryDark = Color(0xFFC0CC9A)
+private val onTertiaryDark = Color(0xFF2B3410)
+private val tertiaryContainerDark = Color(0xFF414B24)
+private val onTertiaryContainerDark = Color(0xFFDCE8B4)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF19120C)
+private val onBackgroundDark = Color(0xFFEFE0D5)
+private val surfaceDark = Color(0xFF19120C)
+private val onSurfaceDark = Color(0xFFEFE0D5)
+private val surfaceVariantDark = Color(0xFF51453A)
+private val onSurfaceVariantDark = Color(0xFFD5C3B5)
+private val outlineDark = Color(0xFF9D8E81)
+private val outlineVariantDark = Color(0xFF51453A)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFEFE0D5)
+private val inverseOnSurfaceDark = Color(0xFF372F28)
+private val inversePrimaryDark = Color(0xFF855318)
+private val surfaceDimDark = Color(0xFF19120C)
+private val surfaceBrightDark = Color(0xFF403830)
+private val surfaceContainerLowestDark = Color(0xFF130D07)
+private val surfaceContainerLowDark = Color(0xFF211A14)
+private val surfaceContainerDark = Color(0xFF261E18)
+private val surfaceContainerHighDark = Color(0xFF302822)
+private val surfaceContainerHighestDark = Color(0xFF3C332C)
+
+val orangeLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val orangeDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/PinkScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/PinkScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF8E4957)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFFFD9DE)
+private val onPrimaryContainerLight = Color(0xFF71333F)
+private val secondaryLight = Color(0xFF75565B)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFFFD9DE)
+private val onSecondaryContainerLight = Color(0xFF5C3F43)
+private val tertiaryLight = Color(0xFF795831)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFFFDDBA)
+private val onTertiaryContainerLight = Color(0xFF5F411C)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFFF8F7)
+private val onBackgroundLight = Color(0xFF22191A)
+private val surfaceLight = Color(0xFFFFF8F7)
+private val onSurfaceLight = Color(0xFF22191A)
+private val surfaceVariantLight = Color(0xFFF3DDDF)
+private val onSurfaceVariantLight = Color(0xFF524345)
+private val outlineLight = Color(0xFF847375)
+private val outlineVariantLight = Color(0xFFD6C2C3)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF382E2F)
+private val inverseOnSurfaceLight = Color(0xFFFEEDEE)
+private val inversePrimaryLight = Color(0xFFFFB2BE)
+private val surfaceDimLight = Color(0xFFE7D6D7)
+private val surfaceBrightLight = Color(0xFFFFF8F7)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFFFF0F1)
+private val surfaceContainerLight = Color(0xFFFBEAEB)
+private val surfaceContainerHighLight = Color(0xFFF5E4E5)
+private val surfaceContainerHighestLight = Color(0xFFF0DEE0)
+
+private val primaryDark = Color(0xFFFFB2BE)
+private val onPrimaryDark = Color(0xFF561D2A)
+private val primaryContainerDark = Color(0xFF71333F)
+private val onPrimaryContainerDark = Color(0xFFFFD9DE)
+private val secondaryDark = Color(0xFFE5BDC2)
+private val onSecondaryDark = Color(0xFF43292D)
+private val secondaryContainerDark = Color(0xFF5C3F43)
+private val onSecondaryContainerDark = Color(0xFFFFD9DE)
+private val tertiaryDark = Color(0xFFEBBF90)
+private val onTertiaryDark = Color(0xFF452B08)
+private val tertiaryContainerDark = Color(0xFF5F411C)
+private val onTertiaryContainerDark = Color(0xFFFFDDBA)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF191112)
+private val onBackgroundDark = Color(0xFFF0DEE0)
+private val surfaceDark = Color(0xFF191112)
+private val onSurfaceDark = Color(0xFFF0DEE0)
+private val surfaceVariantDark = Color(0xFF524345)
+private val onSurfaceVariantDark = Color(0xFFD6C2C3)
+private val outlineDark = Color(0xFF9F8C8E)
+private val outlineVariantDark = Color(0xFF524345)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFF0DEE0)
+private val inverseOnSurfaceDark = Color(0xFF382E2F)
+private val inversePrimaryDark = Color(0xFF8E4957)
+private val surfaceDimDark = Color(0xFF191112)
+private val surfaceBrightDark = Color(0xFF413738)
+private val surfaceContainerLowestDark = Color(0xFF140C0D)
+private val surfaceContainerLowDark = Color(0xFF22191A)
+private val surfaceContainerDark = Color(0xFF261D1E)
+private val surfaceContainerHighDark = Color(0xFF312829)
+private val surfaceContainerHighestDark = Color(0xFF3C3233)
+
+val pinkLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val pinkDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/PurpleScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/PurpleScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF7B4E7F)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFFFD6FE)
+private val onPrimaryContainerLight = Color(0xFF613766)
+private val secondaryLight = Color(0xFF6B586B)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFF4DBF1)
+private val onSecondaryContainerLight = Color(0xFF534153)
+private val tertiaryLight = Color(0xFF82524A)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFFFDAD4)
+private val onTertiaryContainerLight = Color(0xFF673B34)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFFF7FA)
+private val onBackgroundLight = Color(0xFF1F1A1F)
+private val surfaceLight = Color(0xFFFFF7FA)
+private val onSurfaceLight = Color(0xFF1F1A1F)
+private val surfaceVariantLight = Color(0xFFECDFE8)
+private val onSurfaceVariantLight = Color(0xFF4D444C)
+private val outlineLight = Color(0xFF7F747D)
+private val outlineVariantLight = Color(0xFFD0C3CC)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF352F34)
+private val inverseOnSurfaceLight = Color(0xFFF9EEF5)
+private val inversePrimaryLight = Color(0xFFEBB5ED)
+private val surfaceDimLight = Color(0xFFE2D7DE)
+private val surfaceBrightLight = Color(0xFFFFF7FA)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFFCF0F7)
+private val surfaceContainerLight = Color(0xFFF6EBF2)
+private val surfaceContainerHighLight = Color(0xFFF0E5EC)
+private val surfaceContainerHighestLight = Color(0xFFEBDFE6)
+
+private val primaryDark = Color(0xFFEBB5ED)
+private val onPrimaryDark = Color(0xFF49204E)
+private val primaryContainerDark = Color(0xFF613766)
+private val onPrimaryContainerDark = Color(0xFFFFD6FE)
+private val secondaryDark = Color(0xFFD7BFD5)
+private val onSecondaryDark = Color(0xFF3B2B3C)
+private val secondaryContainerDark = Color(0xFF534153)
+private val onSecondaryContainerDark = Color(0xFFF4DBF1)
+private val tertiaryDark = Color(0xFFF6B8AD)
+private val onTertiaryDark = Color(0xFF4C251F)
+private val tertiaryContainerDark = Color(0xFF673B34)
+private val onTertiaryContainerDark = Color(0xFFFFDAD4)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF171216)
+private val onBackgroundDark = Color(0xFFEBDFE6)
+private val surfaceDark = Color(0xFF171216)
+private val onSurfaceDark = Color(0xFFEBDFE6)
+private val surfaceVariantDark = Color(0xFF4D444C)
+private val onSurfaceVariantDark = Color(0xFFD0C3CC)
+private val outlineDark = Color(0xFF998D96)
+private val outlineVariantDark = Color(0xFF4D444C)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFEBDFE6)
+private val inverseOnSurfaceDark = Color(0xFF352F34)
+private val inversePrimaryDark = Color(0xFF7B4E7F)
+private val surfaceDimDark = Color(0xFF171216)
+private val surfaceBrightDark = Color(0xFF3E373D)
+private val surfaceContainerLowestDark = Color(0xFF110D11)
+private val surfaceContainerLowDark = Color(0xFF1F1A1F)
+private val surfaceContainerDark = Color(0xFF231E23)
+private val surfaceContainerHighDark = Color(0xFF2E282D)
+private val surfaceContainerHighestDark = Color(0xFF393338)
+
+val purpleLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val purpleDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/RedScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/RedScheme.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF904A42)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFFFDAD5)
+private val onPrimaryContainerLight = Color(0xFF73342C)
+private val secondaryLight = Color(0xFF775652)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFFFDAD5)
+private val onSecondaryContainerLight = Color(0xFF5D3F3B)
+private val tertiaryLight = Color(0xFF705C2E)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFFCDFA6)
+private val onTertiaryContainerLight = Color(0xFF574419)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFFF8F7)
+private val onBackgroundLight = Color(0xFF231918)
+private val surfaceLight = Color(0xFFFFF8F7)
+private val onSurfaceLight = Color(0xFF231918)
+private val surfaceVariantLight = Color(0xFFF5DDDA)
+private val onSurfaceVariantLight = Color(0xFF534341)
+private val outlineLight = Color(0xFF857370)
+private val outlineVariantLight = Color(0xFFD8C2BE)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF392E2C)
+private val inverseOnSurfaceLight = Color(0xFFFFEDEA)
+private val inversePrimaryLight = Color(0xFFFFB4A9)
+private val surfaceDimLight = Color(0xFFE8D6D3)
+private val surfaceBrightLight = Color(0xFFFFF8F7)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFFFF0EE)
+private val surfaceContainerLight = Color(0xFFFCEAE7)
+private val surfaceContainerHighLight = Color(0xFFF7E4E1)
+private val surfaceContainerHighestLight = Color(0xFFF1DEDC)
+
+private val primaryDark = Color(0xFFFFB4A9)
+private val onPrimaryDark = Color(0xFF561E18)
+private val primaryContainerDark = Color(0xFF73342C)
+private val onPrimaryContainerDark = Color(0xFFFFDAD5)
+private val secondaryDark = Color(0xFFE7BDB7)
+private val onSecondaryDark = Color(0xFF442926)
+private val secondaryContainerDark = Color(0xFF5D3F3B)
+private val onSecondaryContainerDark = Color(0xFFFFDAD5)
+private val tertiaryDark = Color(0xFFDFC38C)
+private val onTertiaryDark = Color(0xFF3E2E04)
+private val tertiaryContainerDark = Color(0xFF574419)
+private val onTertiaryContainerDark = Color(0xFFFCDFA6)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF1A1110)
+private val onBackgroundDark = Color(0xFFF1DEDC)
+private val surfaceDark = Color(0xFF1A1110)
+private val onSurfaceDark = Color(0xFFF1DEDC)
+private val surfaceVariantDark = Color(0xFF534341)
+private val onSurfaceVariantDark = Color(0xFFD8C2BE)
+private val outlineDark = Color(0xFFA08C89)
+private val outlineVariantDark = Color(0xFF534341)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFF1DEDC)
+private val inverseOnSurfaceDark = Color(0xFF392E2C)
+private val inversePrimaryDark = Color(0xFF904A42)
+private val surfaceDimDark = Color(0xFF1A1110)
+private val surfaceBrightDark = Color(0xFF423735)
+private val surfaceContainerLowestDark = Color(0xFF140C0B)
+private val surfaceContainerLowDark = Color(0xFF231918)
+private val surfaceContainerDark = Color(0xFF271D1C)
+private val surfaceContainerHighDark = Color(0xFF322826)
+private val surfaceContainerHighestDark = Color(0xFF3D3231)
+
+
+val redLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val redDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/TealScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/TealScheme.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF006A60)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFF9EF2E4)
+private val onPrimaryContainerLight = Color(0xFF005048)
+private val secondaryLight = Color(0xFF4A635F)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFCCE8E2)
+private val onSecondaryContainerLight = Color(0xFF334B47)
+private val tertiaryLight = Color(0xFF456179)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFCCE5FF)
+private val onTertiaryContainerLight = Color(0xFF2D4961)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFF4FBF8)
+private val onBackgroundLight = Color(0xFF161D1C)
+private val surfaceLight = Color(0xFFF4FBF8)
+private val onSurfaceLight = Color(0xFF161D1C)
+private val surfaceVariantLight = Color(0xFFDAE5E1)
+private val onSurfaceVariantLight = Color(0xFF3F4947)
+private val outlineLight = Color(0xFF6F7977)
+private val outlineVariantLight = Color(0xFFBEC9C6)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF2B3230)
+private val inverseOnSurfaceLight = Color(0xFFECF2EF)
+private val inversePrimaryLight = Color(0xFF82D5C8)
+private val surfaceDimLight = Color(0xFFD5DBD9)
+private val surfaceBrightLight = Color(0xFFF4FBF8)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFEFF5F2)
+private val surfaceContainerLight = Color(0xFFE9EFED)
+private val surfaceContainerHighLight = Color(0xFFE3EAE7)
+private val surfaceContainerHighestLight = Color(0xFFDDE4E1)
+
+private val primaryDark = Color(0xFF82D5C8)
+private val onPrimaryDark = Color(0xFF003731)
+private val primaryContainerDark = Color(0xFF005048)
+private val onPrimaryContainerDark = Color(0xFF9EF2E4)
+private val secondaryDark = Color(0xFFB1CCC6)
+private val onSecondaryDark = Color(0xFF1C3531)
+private val secondaryContainerDark = Color(0xFF334B47)
+private val onSecondaryContainerDark = Color(0xFFCCE8E2)
+private val tertiaryDark = Color(0xFFADCAE6)
+private val onTertiaryDark = Color(0xFF153349)
+private val tertiaryContainerDark = Color(0xFF2D4961)
+private val onTertiaryContainerDark = Color(0xFFCCE5FF)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF0E1513)
+private val onBackgroundDark = Color(0xFFDDE4E1)
+private val surfaceDark = Color(0xFF0E1513)
+private val onSurfaceDark = Color(0xFFDDE4E1)
+private val surfaceVariantDark = Color(0xFF3F4947)
+private val onSurfaceVariantDark = Color(0xFFBEC9C6)
+private val outlineDark = Color(0xFF899390)
+private val outlineVariantDark = Color(0xFF3F4947)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFDDE4E1)
+private val inverseOnSurfaceDark = Color(0xFF2B3230)
+private val inversePrimaryDark = Color(0xFF006A60)
+private val surfaceDimDark = Color(0xFF0E1513)
+private val surfaceBrightDark = Color(0xFF343B39)
+private val surfaceContainerLowestDark = Color(0xFF090F0E)
+private val surfaceContainerLowDark = Color(0xFF161D1C)
+private val surfaceContainerDark = Color(0xFF1A2120)
+private val surfaceContainerHighDark = Color(0xFF252B2A)
+private val surfaceContainerHighestDark = Color(0xFF303635)
+
+
+val tealLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val tealDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/YellowScheme.kt
+++ b/lib/color/src/main/kotlin/org/florisboard/lib/color/schemes/YellowScheme.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.color.schemes
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+private val primaryLight = Color(0xFF685F12)
+private val onPrimaryLight = Color(0xFFFFFFFF)
+private val primaryContainerLight = Color(0xFFF1E48A)
+private val onPrimaryContainerLight = Color(0xFF4F4800)
+private val secondaryLight = Color(0xFF645F41)
+private val onSecondaryLight = Color(0xFFFFFFFF)
+private val secondaryContainerLight = Color(0xFFEBE3BD)
+private val onSecondaryContainerLight = Color(0xFF4B472B)
+private val tertiaryLight = Color(0xFF406652)
+private val onTertiaryLight = Color(0xFFFFFFFF)
+private val tertiaryContainerLight = Color(0xFFC2ECD3)
+private val onTertiaryContainerLight = Color(0xFF294E3B)
+private val errorLight = Color(0xFFBA1A1A)
+private val onErrorLight = Color(0xFFFFFFFF)
+private val errorContainerLight = Color(0xFFFFDAD6)
+private val onErrorContainerLight = Color(0xFF93000A)
+private val backgroundLight = Color(0xFFFFF9EB)
+private val onBackgroundLight = Color(0xFF1D1C13)
+private val surfaceLight = Color(0xFFFFF9EB)
+private val onSurfaceLight = Color(0xFF1D1C13)
+private val surfaceVariantLight = Color(0xFFE8E2D0)
+private val onSurfaceVariantLight = Color(0xFF4A473A)
+private val outlineLight = Color(0xFF7B7768)
+private val outlineVariantLight = Color(0xFFCBC6B5)
+private val scrimLight = Color(0xFF000000)
+private val inverseSurfaceLight = Color(0xFF323027)
+private val inverseOnSurfaceLight = Color(0xFFF6F0E3)
+private val inversePrimaryLight = Color(0xFFD4C871)
+private val surfaceDimLight = Color(0xFFDFDACC)
+private val surfaceBrightLight = Color(0xFFFFF9EB)
+private val surfaceContainerLowestLight = Color(0xFFFFFFFF)
+private val surfaceContainerLowLight = Color(0xFFF9F3E5)
+private val surfaceContainerLight = Color(0xFFF3EEE0)
+private val surfaceContainerHighLight = Color(0xFFEDE8DA)
+private val surfaceContainerHighestLight = Color(0xFFE7E2D5)
+
+private val primaryDark = Color(0xFFD4C871)
+private val onPrimaryDark = Color(0xFF363100)
+private val primaryContainerDark = Color(0xFF4F4800)
+private val onPrimaryContainerDark = Color(0xFFF1E48A)
+private val secondaryDark = Color(0xFFCEC7A3)
+private val onSecondaryDark = Color(0xFF343117)
+private val secondaryContainerDark = Color(0xFF4B472B)
+private val onSecondaryContainerDark = Color(0xFFEBE3BD)
+private val tertiaryDark = Color(0xFFA7D0B7)
+private val onTertiaryDark = Color(0xFF103726)
+private val tertiaryContainerDark = Color(0xFF294E3B)
+private val onTertiaryContainerDark = Color(0xFFC2ECD3)
+private val errorDark = Color(0xFFFFB4AB)
+private val onErrorDark = Color(0xFF690005)
+private val errorContainerDark = Color(0xFF93000A)
+private val onErrorContainerDark = Color(0xFFFFDAD6)
+private val backgroundDark = Color(0xFF15130C)
+private val onBackgroundDark = Color(0xFFE7E2D5)
+private val surfaceDark = Color(0xFF15130C)
+private val onSurfaceDark = Color(0xFFE7E2D5)
+private val surfaceVariantDark = Color(0xFF4A473A)
+private val onSurfaceVariantDark = Color(0xFFCBC6B5)
+private val outlineDark = Color(0xFF959181)
+private val outlineVariantDark = Color(0xFF4A473A)
+private val scrimDark = Color(0xFF000000)
+private val inverseSurfaceDark = Color(0xFFE7E2D5)
+private val inverseOnSurfaceDark = Color(0xFF323027)
+private val inversePrimaryDark = Color(0xFF685F12)
+private val surfaceDimDark = Color(0xFF15130C)
+private val surfaceBrightDark = Color(0xFF3B3930)
+private val surfaceContainerLowestDark = Color(0xFF0F0E07)
+private val surfaceContainerLowDark = Color(0xFF1D1C13)
+private val surfaceContainerDark = Color(0xFF212017)
+private val surfaceContainerHighDark = Color(0xFF2C2A21)
+private val surfaceContainerHighestDark = Color(0xFF37352C)
+
+val yellowLightScheme = lightColorScheme(
+    primary = primaryLight,
+    onPrimary = onPrimaryLight,
+    primaryContainer = primaryContainerLight,
+    onPrimaryContainer = onPrimaryContainerLight,
+    secondary = secondaryLight,
+    onSecondary = onSecondaryLight,
+    secondaryContainer = secondaryContainerLight,
+    onSecondaryContainer = onSecondaryContainerLight,
+    tertiary = tertiaryLight,
+    onTertiary = onTertiaryLight,
+    tertiaryContainer = tertiaryContainerLight,
+    onTertiaryContainer = onTertiaryContainerLight,
+    error = errorLight,
+    onError = onErrorLight,
+    errorContainer = errorContainerLight,
+    onErrorContainer = onErrorContainerLight,
+    background = backgroundLight,
+    onBackground = onBackgroundLight,
+    surface = surfaceLight,
+    onSurface = onSurfaceLight,
+    surfaceVariant = surfaceVariantLight,
+    onSurfaceVariant = onSurfaceVariantLight,
+    outline = outlineLight,
+    outlineVariant = outlineVariantLight,
+    scrim = scrimLight,
+    inverseSurface = inverseSurfaceLight,
+    inverseOnSurface = inverseOnSurfaceLight,
+    inversePrimary = inversePrimaryLight,
+    surfaceDim = surfaceDimLight,
+    surfaceBright = surfaceBrightLight,
+    surfaceContainerLowest = surfaceContainerLowestLight,
+    surfaceContainerLow = surfaceContainerLowLight,
+    surfaceContainer = surfaceContainerLight,
+    surfaceContainerHigh = surfaceContainerHighLight,
+    surfaceContainerHighest = surfaceContainerHighestLight,
+)
+
+val yellowDarkScheme = darkColorScheme(
+    primary = primaryDark,
+    onPrimary = onPrimaryDark,
+    primaryContainer = primaryContainerDark,
+    onPrimaryContainer = onPrimaryContainerDark,
+    secondary = secondaryDark,
+    onSecondary = onSecondaryDark,
+    secondaryContainer = secondaryContainerDark,
+    onSecondaryContainer = onSecondaryContainerDark,
+    tertiary = tertiaryDark,
+    onTertiary = onTertiaryDark,
+    tertiaryContainer = tertiaryContainerDark,
+    onTertiaryContainer = onTertiaryContainerDark,
+    error = errorDark,
+    onError = onErrorDark,
+    errorContainer = errorContainerDark,
+    onErrorContainer = onErrorContainerDark,
+    background = backgroundDark,
+    onBackground = onBackgroundDark,
+    surface = surfaceDark,
+    onSurface = onSurfaceDark,
+    surfaceVariant = surfaceVariantDark,
+    onSurfaceVariant = onSurfaceVariantDark,
+    outline = outlineDark,
+    outlineVariant = outlineVariantDark,
+    scrim = scrimDark,
+    inverseSurface = inverseSurfaceDark,
+    inverseOnSurface = inverseOnSurfaceDark,
+    inversePrimary = inversePrimaryDark,
+    surfaceDim = surfaceDimDark,
+    surfaceBright = surfaceBrightDark,
+    surfaceContainerLowest = surfaceContainerLowestDark,
+    surfaceContainerLow = surfaceContainerLowDark,
+    surfaceContainer = surfaceContainerDark,
+    surfaceContainerHigh = surfaceContainerHighDark,
+    surfaceContainerHighest = surfaceContainerHighestDark,
+)

--- a/lib/snygg/build.gradle.kts
+++ b/lib/snygg/build.gradle.kts
@@ -65,6 +65,7 @@ android {
 
 dependencies {
     implementation(project(":lib:android"))
+    implementation(project(":lib:color"))
     implementation(project(":lib:kotlin"))
 
     implementation(libs.androidx.core.ktx)

--- a/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggModifiers.kt
+++ b/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggModifiers.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.takeOrElse
-import org.florisboard.lib.android.AndroidVersion
 import org.florisboard.lib.snygg.SnyggPropertySet
 import org.florisboard.lib.snygg.value.SnyggDpSizeValue
 import org.florisboard.lib.snygg.value.SnyggMaterialYouValue
@@ -52,11 +51,7 @@ fun Modifier.snyggBackground(
         )
 
         is SnyggMaterialYouValue -> this.background(
-            color = if (AndroidVersion.ATLEAST_API31_S) {
-                bg.loadColor(context)
-            } else {
-                fallbackColor
-            },
+            color = bg.loadColor(context),
             shape = shape,
         )
 
@@ -104,13 +99,7 @@ fun Modifier.snyggShadow(
 fun SnyggValue.solidColor(context: Context, default: Color = Color.Transparent): Color {
     return when (this) {
         is SnyggSolidColorValue -> this.color
-        is SnyggMaterialYouValue -> {
-            if (AndroidVersion.ATLEAST_API31_S) {
-                this.loadColor(context)
-            } else {
-                default
-            }
-        }
+        is SnyggMaterialYouValue -> this.loadColor(context)
         else -> default
     }
 }

--- a/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/value/SnyggValue.kt
+++ b/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/value/SnyggValue.kt
@@ -16,8 +16,6 @@
 
 package org.florisboard.lib.snygg.value
 
-import org.florisboard.lib.android.AndroidVersion
-
 /**
  * SnyggValue is the base interface for all possible property values a Snygg stylesheet can hold. In general, a Snygg
  * value can be one specific type of value (e.g. a color, a keyword describing a behavior, shape, etc.).
@@ -109,8 +107,8 @@ object SnyggImplicitInheritValue : SnyggValue, SnyggValueEncoder {
 
 val SnyggVarValueEncoders = listOfNotNull(
     SnyggSolidColorValue,
-    if (AndroidVersion.ATLEAST_API31_S) SnyggMaterialYouLightColorValue else null,
-    if (AndroidVersion.ATLEAST_API31_S) SnyggMaterialYouDarkColorValue else null,
+    SnyggMaterialYouLightColorValue,
+    SnyggMaterialYouDarkColorValue,
     //SnyggImageRefValue,
     SnyggRectangleShapeValue,
     SnyggCircleShapeValue,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ dependencyResolutionManagement {
 include(":app")
 include(":benchmark")
 include(":lib:android")
+include(":lib:color")
 include(":lib:kotlin")
 include(":lib:native")
 include(":lib:snygg")


### PR DESCRIPTION
Closes #2749 

This PR adds the possibility to select custom material you colors based on an accent color. 

- [x] Create snapshot from https://github.com/patrickgold/jetpref/pull/14
- [x] Implement new ColorPickerPreference
- [x] Modify SnyggMaterialYouValue to work with the new colorscheme
- [x] Optional: Adapt AppTheme to also use the user defined colorscheme
- [x] Improve colorpicker logic in https://github.com/patrickgold/jetpref/pull/14
- [x] Localize strings
- [x] Create new snapshot from https://github.com/patrickgold/jetpref/pull/14 and implement material you logic
- [x] Before Merge: Use release version of https://github.com/patrickgold/jetpref/pull/14

