### PR TITLE
Fix BottomSheetContent drawing behind system nav bar

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/sheet/BottomSheetHostUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/sheet/BottomSheetHostUi.kt
@@ -17,7 +17,6 @@
 package dev.patrickgold.florisboard.ime.sheet
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
@@ -25,8 +24,8 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
@@ -45,11 +44,7 @@ fun BottomSheetHostUi(
     onHide: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    val bgColorOutOfBounds by animateColorAsState(
-        if (isShowing) SheetOutOfBoundsBgColorActive else SheetOutOfBoundsBgColorInactive
-    )
-
-    Column(Modifier.background(bgColorOutOfBounds)) {
+    Column(Modifier.background(SheetOutOfBoundsBgColorInactive)) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -63,6 +58,7 @@ fun BottomSheetHostUi(
                 },
         )
         AnimatedVisibility(
+            modifier = Modifier.safeDrawingPadding(),
             visible = isShowing,
             enter = DialogContentEnterTransition,
             exit = DialogContentExitTransition,


### PR DESCRIPTION
This commit fixes an issue where the BottomSheetContent was drawn behind the system navigation bar. To fix this issue, I applied the saveDrawingPadding Modifier to the AnimatedVisibility. There was a color problem on the system navigation bar, so I set the background color to SheetOutOfBoundsBgColorInactive. Now the system nav bar is colored the right way.