### PR TITLE
Fix text being rendered behind the top app bar

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/crashutility/CrashDialogActivity.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/crashutility/CrashDialogActivity.kt
@@ -26,6 +26,7 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
+import android.widget.Toolbar
 import androidx.activity.ComponentActivity
 import dev.patrickgold.florisboard.BuildConfig
 import dev.patrickgold.florisboard.R
@@ -66,6 +67,9 @@ class CrashDialogActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val layout = layoutInflater.inflate(R.layout.crash_dialog, null)
         setContentView(layout)
+
+        val toolbar = layout.findViewById<Toolbar>(R.id.crash_dialog_toolbar)
+        setActionBar(toolbar)
 
         stacktraces = CrashUtility.getUnhandledStacktraces(this)
         val versionName = buildString {

--- a/app/src/main/res/layout/crash_dialog.xml
+++ b/app/src/main/res/layout/crash_dialog.xml
@@ -5,6 +5,8 @@
     android:padding="8dp"
     android:theme="@style/CrashDialogTheme">
 
+    <Toolbar android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+
     <TextView
         android:id="@+id/description"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/crash_dialog.xml
+++ b/app/src/main/res/layout/crash_dialog.xml
@@ -2,10 +2,15 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="8dp"
+    android:fitsSystemWindows="true"
     android:theme="@style/CrashDialogTheme">
 
-    <Toolbar android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+    <Toolbar
+        android:id="@+id/crash_dialog_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/colorPrimaryDark"
+        android:elevation="4dp"/>
 
     <TextView
         android:id="@+id/description"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -24,7 +24,7 @@
         <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
     </style>
 
-    <style name="CrashDialogTheme" parent="android:Theme.Material"/>
+    <style name="CrashDialogTheme" parent="android:style/Theme.Material.NoActionBar"/>
 
     <style name="FlorisImeTheme" parent="android:Theme.Material.InputMethod">
         <!-- Need this to prevent Xiaomi devices from messing with our beautiful UI -->


### PR DESCRIPTION
This commit fixes an issue where the text was rendered behind the top app bar in the crash dialog activity by removing the top app bar in the style and adding a top app bar in the layout XML.