### PR TITLE
Fix switching back from voice ime (#2684)

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -235,7 +235,7 @@ class FlorisImeService : LifecycleInputMethodService() {
                 for (i in 0 until el.subtypeCount){
                     if (el.getSubtypeAt(i).mode != "voice") continue
                     if (AndroidVersion.ATLEAST_API28_P) {
-                        ims.switchInputMethod(el.id)
+                        ims.switchInputMethod(el.id, el.getSubtypeAt(i))
                         return true
                     } else {
                         ims.window.window?.let { window ->


### PR DESCRIPTION
This commit fixes an issue where the voice ime was not possible to switch back to FlorisBoard, because the keyboard subtype was not specified.

Many thanks to @ElishaAz for pointing out the issue and providing a fix.
Closes: #2684 