### PR TITLE
Update snygg dynamic color scheme on wallpaper change

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisApplication.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisApplication.kt
@@ -35,7 +35,6 @@ import dev.patrickgold.florisboard.ime.nlp.NlpManager
 import dev.patrickgold.florisboard.ime.text.gestures.GlideTypingManager
 import dev.patrickgold.florisboard.ime.theme.FlorisImeTheme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
-import dev.patrickgold.florisboard.ime.theme.WallpaperChangeReceiver
 import dev.patrickgold.florisboard.lib.cache.CacheManager
 import dev.patrickgold.florisboard.lib.crashutility.CrashUtility
 import dev.patrickgold.florisboard.lib.devtools.Flog
@@ -107,7 +106,6 @@ class FlorisApplication : Application() {
             CrashUtility.stageException(e)
             return
         }
-        registerReceiver(WallpaperChangeReceiver(), IntentFilter(Intent.ACTION_WALLPAPER_CHANGED))
     }
 
     fun init() {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisApplication.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisApplication.kt
@@ -35,6 +35,7 @@ import dev.patrickgold.florisboard.ime.nlp.NlpManager
 import dev.patrickgold.florisboard.ime.text.gestures.GlideTypingManager
 import dev.patrickgold.florisboard.ime.theme.FlorisImeTheme
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
+import dev.patrickgold.florisboard.ime.theme.WallpaperChangeReceiver
 import dev.patrickgold.florisboard.lib.cache.CacheManager
 import dev.patrickgold.florisboard.lib.crashutility.CrashUtility
 import dev.patrickgold.florisboard.lib.devtools.Flog
@@ -106,6 +107,7 @@ class FlorisApplication : Application() {
             CrashUtility.stageException(e)
             return
         }
+        registerReceiver(WallpaperChangeReceiver(), IntentFilter(Intent.ACTION_WALLPAPER_CHANGED))
     }
 
     fun init() {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -18,6 +18,7 @@ package dev.patrickgold.florisboard
 
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.res.Configuration
 import android.inputmethodservice.ExtractEditText
 import android.os.Build
@@ -99,6 +100,7 @@ import dev.patrickgold.florisboard.ime.smartbar.quickaction.QuickActionsEditorPa
 import dev.patrickgold.florisboard.ime.text.TextInputLayout
 import dev.patrickgold.florisboard.ime.theme.FlorisImeTheme
 import dev.patrickgold.florisboard.ime.theme.FlorisImeUi
+import dev.patrickgold.florisboard.ime.theme.WallpaperChangeReceiver
 import dev.patrickgold.florisboard.lib.compose.FlorisButton
 import dev.patrickgold.florisboard.lib.compose.ProvideLocalizedResources
 import dev.patrickgold.florisboard.lib.compose.SystemUiIme
@@ -267,6 +269,8 @@ class FlorisImeService : LifecycleInputMethodService() {
     private var isExtractUiShown by mutableStateOf(false)
     private var resourcesContext by mutableStateOf(this as Context)
 
+    private val wallpaperChangeReceiver = WallpaperChangeReceiver()
+
     init {
         setTheme(R.style.FlorisImeTheme)
     }
@@ -280,6 +284,8 @@ class FlorisImeService : LifecycleInputMethodService() {
             config.setLocale(subtype.primaryLocale.base)
             resourcesContext = createConfigurationContext(config)
         }
+        @Suppress("DEPRECATION") // We do not retrieve the wallpaper but only listen to changes
+        registerReceiver(wallpaperChangeReceiver, IntentFilter(Intent.ACTION_WALLPAPER_CHANGED))
     }
 
     override fun onCreateInputView(): View {
@@ -318,6 +324,7 @@ class FlorisImeService : LifecycleInputMethodService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        unregisterReceiver(wallpaperChangeReceiver)
         FlorisImeServiceReference = WeakReference(null)
         inputWindowView = null
     }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/WallpaperChangeReceiver.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/WallpaperChangeReceiver.kt
@@ -26,6 +26,7 @@ class WallpaperChangeReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if (intent == null) return
         if (context == null) return
+        @Suppress("DEPRECATION") // We do not retrieve the wallpaper but only listen to changes
         if (intent.action == Intent.ACTION_WALLPAPER_CHANGED) {
             flogDebug { "Wallpaper changed" }
             context.themeManager().value.updateActiveTheme()

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/WallpaperChangeReceiver.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/WallpaperChangeReceiver.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.theme
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dev.patrickgold.florisboard.lib.devtools.flogDebug
+import dev.patrickgold.florisboard.themeManager
+
+class WallpaperChangeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent == null) return
+        if (context == null) return
+        if (intent.action == Intent.ACTION_WALLPAPER_CHANGED) {
+            flogDebug { "Wallpaper changed" }
+            context.themeManager().value.updateActiveTheme()
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/SystemUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/SystemUi.kt
@@ -22,7 +22,7 @@ import android.content.ContextWrapper
 import android.inputmethodservice.InputMethodService
 import android.view.Window
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -42,7 +42,7 @@ fun SystemUiIme() {
     val window = view.context.findWindow()!!
     val windowInsetsController = WindowInsetsControllerCompat(window, view)
 
-    SideEffect {
+    LaunchedEffect(backgroundColor) {
         if (AndroidVersion.ATLEAST_API26_O) {
             window.navigationBarColor = backgroundColor.toArgb()
             windowInsetsController.isAppearanceLightNavigationBars = useDarkIcons


### PR DESCRIPTION
Closes: #2746 
This PR updates the snygg material you color scheme cache on wallpaper change. As discussed in https://github.com/florisboard/florisboard/issues/2746#issuecomment-2680565699 this seems to fix the navigation bar color issue that occurred on updates to the wallpaper.