### PR TITLE
Rework one-handed mode.

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -615,12 +615,13 @@ class FlorisImeService : LifecycleInputMethodService() {
                         .padding(bottom = bottomOffset),
                 ) {
                     val oneHandedMode by prefs.keyboard.oneHandedMode.observeAsState()
+                    val oneHandedModeEnabled by prefs.keyboard.oneHandedModeEnabled.observeAsState()
                     val oneHandedModeScaleFactor by prefs.keyboard.oneHandedModeScaleFactor.observeAsState()
                     val keyboardWeight = when {
-                        oneHandedMode == OneHandedMode.OFF || configuration.isOrientationLandscape() -> 1f
+                        !oneHandedModeEnabled || configuration.isOrientationLandscape() -> 1f
                         else -> oneHandedModeScaleFactor / 100f
                     }
-                    if (oneHandedMode == OneHandedMode.END && configuration.isOrientationPortrait()) {
+                    if (oneHandedModeEnabled && oneHandedMode == OneHandedMode.END && configuration.isOrientationPortrait()) {
                         OneHandedPanel(
                             panelSide = OneHandedMode.START,
                             weight = 1f - keyboardWeight,
@@ -639,7 +640,7 @@ class FlorisImeService : LifecycleInputMethodService() {
                             }
                         }
                     }
-                    if (oneHandedMode == OneHandedMode.START && configuration.isOrientationPortrait()) {
+                    if (oneHandedModeEnabled && oneHandedMode == OneHandedMode.START && configuration.isOrientationPortrait()) {
                         OneHandedPanel(
                             panelSide = OneHandedMode.END,
                             weight = 1f - keyboardWeight,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -488,7 +488,7 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
         )
         val oneHandedModeEnabled = boolean(
             key = "keyboard__one_handed_mode_enabled",
-            default = false
+            default = false,
         )
         val oneHandedModeScaleFactor = int(
             key = "keyboard__one_handed_mode_scale_factor",

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/EnumDisplayEntries.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/EnumDisplayEntries.kt
@@ -377,10 +377,6 @@ private val ENUM_DISPLAY_ENTRIES = mapOf<Pair<KClass<*>, String>, @Composable ()
     OneHandedMode::class to DEFAULT to {
         listPrefEntries {
             entry(
-                key = OneHandedMode.OFF,
-                label = stringRes(R.string.enum__one_handed_mode__off),
-            )
-            entry(
                 key = OneHandedMode.START,
                 label = stringRes(R.string.enum__one_handed_mode__start),
             )

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/keyboard/KeyboardScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/keyboard/KeyboardScreen.kt
@@ -107,8 +107,10 @@ fun KeyboardScreen() = FlorisScreen {
         PreferenceGroup(title = stringRes(R.string.pref__keyboard__group_layout__label)) {
             ListPreference(
                 prefs.keyboard.oneHandedMode,
+                prefs.keyboard.oneHandedModeEnabled,
                 title = stringRes(R.string.pref__keyboard__one_handed_mode__label),
                 entries = enumDisplayEntriesOf(OneHandedMode::class),
+                summarySwitchDisabled = stringRes(R.string.state__disabled)
             )
             DialogSliderPreference(
                 prefs.keyboard.oneHandedModeScaleFactor,
@@ -117,7 +119,7 @@ fun KeyboardScreen() = FlorisScreen {
                 min = 70,
                 max = 90,
                 stepIncrement = 1,
-                enabledIf = { prefs.keyboard.oneHandedMode isNotEqualTo OneHandedMode.OFF },
+                enabledIf = { prefs.keyboard.oneHandedModeEnabled.isTrue() },
             )
             ListPreference(
                 prefs.keyboard.landscapeInputUiMode,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/keyboard/KeyboardScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/keyboard/KeyboardScreen.kt
@@ -110,7 +110,7 @@ fun KeyboardScreen() = FlorisScreen {
                 prefs.keyboard.oneHandedModeEnabled,
                 title = stringRes(R.string.pref__keyboard__one_handed_mode__label),
                 entries = enumDisplayEntriesOf(OneHandedMode::class),
-                summarySwitchDisabled = stringRes(R.string.state__disabled)
+                summarySwitchDisabled = stringRes(R.string.state__disabled),
             )
             DialogSliderPreference(
                 prefs.keyboard.oneHandedModeScaleFactor,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
@@ -206,7 +206,7 @@ fun ComputingEvaluator.computeImageVector(data: KeyData): ImageVector? {
             Icons.Default.DeleteSweep
         }
         KeyCode.COMPACT_LAYOUT_TO_LEFT,
-        KeyCode.COMPACT_LAYOUT_TO_RIGHT -> {
+        KeyCode.TOGGLE_COMPACT_LAYOUT -> {
             context()?.vectorResource(id = R.drawable.ic_accessibility_one_handed)
         }
         KeyCode.VOICE_INPUT -> {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
@@ -206,6 +206,7 @@ fun ComputingEvaluator.computeImageVector(data: KeyData): ImageVector? {
             Icons.Default.DeleteSweep
         }
         KeyCode.COMPACT_LAYOUT_TO_LEFT,
+        KeyCode.COMPACT_LAYOUT_TO_RIGHT,
         KeyCode.TOGGLE_COMPACT_LAYOUT -> {
             context()?.vectorResource(id = R.drawable.ic_accessibility_one_handed)
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/FlorisImeSizing.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/FlorisImeSizing.kt
@@ -119,7 +119,7 @@ fun ProvideKeyboardRowBaseHeight(content: @Composable () -> Unit) {
 
     val heightFactorPortrait by prefs.keyboard.heightFactorPortrait.observeAsTransformingState { it.toFloat() / 100f }
     val heightFactorLandscape by prefs.keyboard.heightFactorLandscape.observeAsTransformingState { it.toFloat() / 100f }
-    val oneHandedMode by prefs.keyboard.oneHandedMode.observeAsState()
+    val oneHandedMode by prefs.keyboard.oneHandedModeEnabled.observeAsState()
     val oneHandedModeScaleFactor by prefs.keyboard.oneHandedModeScaleFactor.observeAsTransformingState { it.toFloat() / 100f }
 
     // Only set systemBarHeights on api 35 or later because https://developer.android.com/about/versions/15/behavior-changes-15#stable-configuration
@@ -134,7 +134,7 @@ fun ProvideKeyboardRowBaseHeight(content: @Composable () -> Unit) {
     ) {
         calcInputViewHeight(resources, systemBarHeights) * when {
             configuration.isOrientationLandscape() -> heightFactorLandscape
-            else -> heightFactorPortrait * (if (oneHandedMode != OneHandedMode.OFF) oneHandedModeScaleFactor else 1f)
+            else -> heightFactorPortrait * (if (oneHandedMode) oneHandedModeScaleFactor else 1f)
         }
     }
     val smartbarHeight = baseRowHeight * 0.753f

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -46,6 +46,7 @@ import dev.patrickgold.florisboard.ime.input.InputShiftState
 import dev.patrickgold.florisboard.ime.nlp.ClipboardSuggestionCandidate
 import dev.patrickgold.florisboard.ime.nlp.PunctuationRule
 import dev.patrickgold.florisboard.ime.nlp.SuggestionCandidate
+import dev.patrickgold.florisboard.ime.onehanded.OneHandedMode
 import dev.patrickgold.florisboard.ime.popup.PopupMappingComponent
 import dev.patrickgold.florisboard.ime.text.composing.Composer
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
@@ -716,8 +717,15 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                 clipboardManager.updatePrimaryClip(null)
                 appContext.showShortToast(R.string.clipboard__cleared_primary_clip)
             }
-            KeyCode.COMPACT_LAYOUT_TO_LEFT -> toggleOneHandedMode()
             KeyCode.TOGGLE_COMPACT_LAYOUT -> toggleOneHandedMode()
+            KeyCode.COMPACT_LAYOUT_TO_LEFT -> {
+                prefs.keyboard.oneHandedMode.set(OneHandedMode.START)
+                toggleOneHandedMode()
+            }
+            KeyCode.COMPACT_LAYOUT_TO_RIGHT -> {
+                prefs.keyboard.oneHandedMode.set(OneHandedMode.END)
+                toggleOneHandedMode()
+            }
             KeyCode.DELETE -> handleDelete()
             KeyCode.DELETE_WORD -> handleDeleteWord()
             KeyCode.ENTER -> handleEnter()

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -46,7 +46,6 @@ import dev.patrickgold.florisboard.ime.input.InputShiftState
 import dev.patrickgold.florisboard.ime.nlp.ClipboardSuggestionCandidate
 import dev.patrickgold.florisboard.ime.nlp.PunctuationRule
 import dev.patrickgold.florisboard.ime.nlp.SuggestionCandidate
-import dev.patrickgold.florisboard.ime.onehanded.OneHandedMode
 import dev.patrickgold.florisboard.ime.popup.PopupMappingComponent
 import dev.patrickgold.florisboard.ime.text.composing.Composer
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
@@ -236,11 +235,8 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
         return subtypeManager.subtypes.size > 1
     }
 
-    fun toggleOneHandedMode(isRight: Boolean) {
-        prefs.keyboard.oneHandedMode.set(when (prefs.keyboard.oneHandedMode.get()) {
-            OneHandedMode.OFF -> if (isRight) { OneHandedMode.END } else { OneHandedMode.START }
-            else -> OneHandedMode.OFF
-        })
+    fun toggleOneHandedMode() {
+        prefs.keyboard.oneHandedModeEnabled.set(!prefs.keyboard.oneHandedModeEnabled.get())
     }
 
     fun executeSwipeAction(swipeAction: SwipeAction) {
@@ -720,8 +716,8 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                 clipboardManager.updatePrimaryClip(null)
                 appContext.showShortToast(R.string.clipboard__cleared_primary_clip)
             }
-            KeyCode.COMPACT_LAYOUT_TO_LEFT -> toggleOneHandedMode(isRight = false)
-            KeyCode.COMPACT_LAYOUT_TO_RIGHT -> toggleOneHandedMode(isRight = true)
+            KeyCode.COMPACT_LAYOUT_TO_LEFT -> toggleOneHandedMode()
+            KeyCode.TOGGLE_COMPACT_LAYOUT -> toggleOneHandedMode()
             KeyCode.DELETE -> handleDelete()
             KeyCode.DELETE_WORD -> handleDeleteWord()
             KeyCode.ENTER -> handleEnter()

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/onehanded/OneHandedMode.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/onehanded/OneHandedMode.kt
@@ -20,7 +20,6 @@ package dev.patrickgold.florisboard.ime.onehanded
  * Static object which contains all possible one-handed mode strings.
  */
 enum class OneHandedMode {
-    OFF,
     START,
     END;
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/onehanded/OneHandedPanel.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/onehanded/OneHandedPanel.kt
@@ -63,7 +63,7 @@ fun RowScope.OneHandedPanel(
         IconButton(
             onClick = {
                 inputFeedbackController.keyPress()
-                prefs.keyboard.oneHandedMode.set(OneHandedMode.OFF)
+                prefs.keyboard.oneHandedModeEnabled.set(false)
             },
             modifier = Modifier.fillMaxWidth()
         ) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickAction.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickAction.kt
@@ -97,7 +97,7 @@ fun QuickAction.computeDisplayName(evaluator: ComputingEvaluator): String {
             KeyCode.TOGGLE_AUTOCORRECT -> R.string.quick_action__toggle_autocorrect
             KeyCode.VOICE_INPUT -> R.string.quick_action__voice_input
             // TODO: In the future this will be merged into the resize keyboard panel, for now it is a separate action
-            KeyCode.COMPACT_LAYOUT_TO_RIGHT -> R.string.quick_action__one_handed_mode
+            KeyCode.TOGGLE_COMPACT_LAYOUT -> R.string.quick_action__one_handed_mode
             KeyCode.DRAG_MARKER -> if (evaluator.state.debugShowDragAndDropHelpers) {
                 R.string.quick_action__drag_marker
             } else {
@@ -133,7 +133,7 @@ fun QuickAction.computeTooltip(evaluator: ComputingEvaluator): String {
             KeyCode.TOGGLE_AUTOCORRECT -> R.string.quick_action__toggle_autocorrect__tooltip
             KeyCode.VOICE_INPUT -> R.string.quick_action__voice_input__tooltip
             // TODO: In the future this will be merged into the resize keyboard panel, for now it is a separate action
-            KeyCode.COMPACT_LAYOUT_TO_RIGHT -> R.string.quick_action__one_handed_mode__tooltip
+            KeyCode.TOGGLE_COMPACT_LAYOUT -> R.string.quick_action__one_handed_mode__tooltip
             KeyCode.DRAG_MARKER -> if (evaluator.state.debugShowDragAndDropHelpers) {
                 R.string.quick_action__drag_marker__tooltip
             } else {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickActionArrangement.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickActionArrangement.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.plus
 import kotlinx.serialization.modules.polymorphic
 
-private val QuickActionJsonConfig = Json(DefaultJsonConfig) {
+val QuickActionJsonConfig = Json(DefaultJsonConfig) {
     classDiscriminator = "$"
     encodeDefaults = false
     ignoreUnknownKeys = true

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickActionArrangement.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/quickaction/QuickActionArrangement.kt
@@ -61,7 +61,7 @@ data class QuickActionArrangement(
                 QuickAction.InsertKey(TextKeyData.TOGGLE_INCOGNITO_MODE),
                 QuickAction.InsertKey(TextKeyData.IME_UI_MODE_CLIPBOARD),
                 QuickAction.InsertKey(TextKeyData.IME_UI_MODE_MEDIA),
-                QuickAction.InsertKey(TextKeyData.COMPACT_LAYOUT_TO_RIGHT),
+                QuickAction.InsertKey(TextKeyData.TOGGLE_COMPACT_LAYOUT),
                 QuickAction.InsertKey(TextKeyData.TOGGLE_AUTOCORRECT),
                 QuickAction.InsertKey(TextKeyData.ARROW_UP),
                 QuickAction.InsertKey(TextKeyData.ARROW_DOWN),

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
@@ -68,8 +68,9 @@ object KeyCode {
     const val CLIPBOARD_CLEAR_FULL_HISTORY = -37
     const val CLIPBOARD_CLEAR_PRIMARY_CLIP = -38
 
+    const val TOGGLE_COMPACT_LAYOUT =       -110
     const val COMPACT_LAYOUT_TO_LEFT =      -111
-    const val TOGGLE_COMPACT_LAYOUT =       -112
+    const val COMPACT_LAYOUT_TO_RIGHT =     -112
     const val SPLIT_LAYOUT =                -113
     const val MERGE_LAYOUT =                -114
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt
@@ -69,7 +69,7 @@ object KeyCode {
     const val CLIPBOARD_CLEAR_PRIMARY_CLIP = -38
 
     const val COMPACT_LAYOUT_TO_LEFT =      -111
-    const val COMPACT_LAYOUT_TO_RIGHT =     -112
+    const val TOGGLE_COMPACT_LAYOUT =       -112
     const val SPLIT_LAYOUT =                -113
     const val MERGE_LAYOUT =                -114
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
@@ -121,8 +121,9 @@ class TextKeyData(
                 CLIPBOARD_CLEAR_HISTORY,
                 CLIPBOARD_CLEAR_FULL_HISTORY,
                 CLIPBOARD_CLEAR_PRIMARY_CLIP,
-                COMPACT_LAYOUT_TO_LEFT,
                 TOGGLE_COMPACT_LAYOUT,
+                COMPACT_LAYOUT_TO_LEFT,
+                COMPACT_LAYOUT_TO_RIGHT,
                 UNDO,
                 REDO,
                 VIEW_CHARACTERS,
@@ -336,16 +337,22 @@ class TextKeyData(
             label = "clipboard_clear_primary_clip",
         )
 
+        /** Predefined key data for [KeyCode.TOGGLE_COMPACT_LAYOUT] */
+        val TOGGLE_COMPACT_LAYOUT = TextKeyData(
+            type = KeyType.SYSTEM_GUI,
+            code = KeyCode.TOGGLE_COMPACT_LAYOUT,
+            label = "toggle_compact_layout",
+        )
         /** Predefined key data for [KeyCode.COMPACT_LAYOUT_TO_LEFT] */
         val COMPACT_LAYOUT_TO_LEFT = TextKeyData(
             type = KeyType.SYSTEM_GUI,
             code = KeyCode.COMPACT_LAYOUT_TO_LEFT,
             label = "compact_layout_to_left",
         )
-        /** Predefined key data for [KeyCode.TOGGLE_COMPACT_LAYOUT] */
-        val TOGGLE_COMPACT_LAYOUT = TextKeyData(
+        /** Predefined key data for [KeyCode.COMPACT_LAYOUT_TO_RIGHT] */
+        val COMPACT_LAYOUT_TO_RIGHT = TextKeyData(
             type = KeyType.SYSTEM_GUI,
-            code = KeyCode.TOGGLE_COMPACT_LAYOUT,
+            code = KeyCode.COMPACT_LAYOUT_TO_RIGHT,
             label = "compact_layout_to_right",
         )
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyData.kt
@@ -122,7 +122,7 @@ class TextKeyData(
                 CLIPBOARD_CLEAR_FULL_HISTORY,
                 CLIPBOARD_CLEAR_PRIMARY_CLIP,
                 COMPACT_LAYOUT_TO_LEFT,
-                COMPACT_LAYOUT_TO_RIGHT,
+                TOGGLE_COMPACT_LAYOUT,
                 UNDO,
                 REDO,
                 VIEW_CHARACTERS,
@@ -342,10 +342,10 @@ class TextKeyData(
             code = KeyCode.COMPACT_LAYOUT_TO_LEFT,
             label = "compact_layout_to_left",
         )
-        /** Predefined key data for [KeyCode.COMPACT_LAYOUT_TO_RIGHT] */
-        val COMPACT_LAYOUT_TO_RIGHT = TextKeyData(
+        /** Predefined key data for [KeyCode.TOGGLE_COMPACT_LAYOUT] */
+        val TOGGLE_COMPACT_LAYOUT = TextKeyData(
             type = KeyType.SYSTEM_GUI,
-            code = KeyCode.COMPACT_LAYOUT_TO_RIGHT,
+            code = KeyCode.TOGGLE_COMPACT_LAYOUT,
             label = "compact_layout_to_right",
         )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -893,7 +893,6 @@
     <string name="enum__landscape_input_ui_mode__always_show" comment="Enum value label">Always show</string>
     <string name="enum__landscape_input_ui_mode__dynamically_show" comment="Enum value label">Dynamically show</string>
 
-    <string name="enum__one_handed_mode__off" comment="Enum value label">Off</string>
     <string name="enum__one_handed_mode__start" comment="Enum value label">Left-handed mode</string>
     <string name="enum__one_handed_mode__end" comment="Enum value label">Right-handed mode</string>
 


### PR DESCRIPTION
The one-handed mode now remembers the position
where it was disabled and opens to this position
the next time it is activated.

Closes #2036 