### PR TITLE
Add Kabyle AZERTY layout

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -729,6 +729,15 @@
       "currencySet": "org.florisboard.currencysets:euro",
       "popupMapping": "org.florisboard.localization:kab",
       "preferred": {
+        "characters": "org.florisboard.layouts:azerty"
+  }
+},
+    {
+      "languageTag": "kab",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:euro",
+      "popupMapping": "org.florisboard.localization:kab",
+      "preferred": {
         "characters": "org.florisboard.layouts:qwerty"
       }
     }

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -58,6 +58,7 @@
     { "id": "iw", "authors": [ "Antony" ] },
     { "id": "ja-JP-jis", "authors": [ "waelwindows" ] },
     { "id": "kab", "authors": [ "yanis867" ] },
+    { "id": "kab2", "authors": [ "BoFFire" ] },
     { "id": "ko", "authors": [ "patrickgold", "Hayleia" ] },
     { "id": "ku", "authors": [ "GoRaN" ] },
     { "id": "lt", "authors": [ "patrickgold" ] },
@@ -727,7 +728,7 @@
       "languageTag": "kab",
       "composer": "org.florisboard.composers:appender",
       "currencySet": "org.florisboard.currencysets:euro",
-      "popupMapping": "org.florisboard.localization:kab",
+      "popupMapping": "org.florisboard.localization:kab2",
       "preferred": {
         "characters": "org.florisboard.layouts:azerty"
   }

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/kab2.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/kab2.json
@@ -1,0 +1,101 @@
+{
+    "all": {
+        "a": {
+            "label": "a",
+            "relevant": [
+                { "$": "auto_text_key", "code": 603, "label": "ɛ" }
+            ]
+        },
+        "z": {
+            "label": "z",
+            "relevant": [
+                { "$": "auto_text_key", "code": 7827, "label": "ẓ" }
+            ]
+        },
+        "e": { "label": "e" },
+        "r": {
+            "label": "r",
+            "relevant": [
+                { "$": "auto_text_key", "code": 7771, "label": "ṛ" }
+            ]
+        },
+        "t": {
+            "label": "t",
+            "relevant": [
+                { "$": "auto_text_key", "code": 7789, "label": "ṭ" }
+            ]
+        },
+        "y": { "label": "y" },
+        "u": {
+            "label": "u",
+            "relevant": [
+                { "$": "auto_text_key", "code": 111, "label": "o" }
+            ]
+        },
+        "i": { "label": "i" },
+        "ɛ": { "label": "ɛ" },
+        "ɣ": { "label": "ɣ" },
+
+        "q": { "label": "q" },
+        "s": {
+            "label": "s",
+            "relevant": [
+                { "$": "auto_text_key", "code": 7779, "label": "ṣ" }
+            ]
+        },
+        "d": {
+            "label": "d",
+            "relevant": [
+                { "$": "auto_text_key", "code": 7693, "label": "ḍ" }
+            ]
+        },
+        "f": { "label": "f" },
+        "g": {
+            "label": "g",
+            "relevant": [
+                { "$": "auto_text_key", "code": 487, "label": "ǧ" },
+                { "$": "auto_text_key", "code": 611, "label": "ɣ" }
+            ]
+        },
+        "h": {
+            "label": "h",
+            "relevant": [
+                { "$": "auto_text_key", "code": 7717, "label": "ḥ" }
+            ]
+        },
+        "j": { "label": "j" },
+        "k": { "label": "k" },
+        "l": { "label": "l" },
+        "m": { "label": "m" },
+
+        "w": { "label": "w" },
+        "x": { "label": "x" },
+        "c": {
+            "label": "c",
+            "relevant": [
+                { "$": "auto_text_key", "code": 269, "label": "č" }
+            ]
+        },
+        "v": { "label": "v" },
+        "b": {
+            "label": "b",
+            "relevant": [
+                { "$": "auto_text_key", "code": 112, "label": "p" },
+                { "$": "auto_text_key", "code": 118, "label": "v" }
+            ]
+        },
+        "n": { "label": "n" }
+    },
+    "uri": {
+        "~right": {
+            "main": { "code": -255, "label": ".dz" },
+            "relevant": [
+                { "code": -255, "label": ".com" },
+                { "code": -255, "label": ".gov.dz" },
+                { "code": -255, "label": ".fr" },
+                { "code": -255, "label": ".org" },
+                { "code": -255, "label": ".net" }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I'm introducing an AZERTY layout for kabyle as it is the most used layout compared to QWERTY. This layout is based on the layout I've introduced on Heliboard and slightly improved some keys.

Next, I'll introduced a fix (new PR) for the kabyle qwerty layout introduced by @yanis867 as a lot of chars do not actually the standards we use for Kabyle as stated on the Unicode CLDR.

Regards,