### PR TITLE
Feat/add missing commonly used accented letters (umlaut variants) to czech popups

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cs.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cs.json
@@ -25,7 +25,8 @@
     "u": {
       "relevant": [
         { "$": "auto_text_key", "code":  367, "label": "ů" },
-        { "$": "auto_text_key", "code":  250, "label": "ú" }
+        { "$": "auto_text_key", "code":  250, "label": "ú" },
+        { "$": "auto_text_key", "code":  252, "label": "ü" }
       ]
     },
     "i": {
@@ -41,7 +42,8 @@
     },
     "a": {
       "relevant": [
-        { "$": "auto_text_key", "code":  225, "label": "á" }
+        { "$": "auto_text_key", "code":  225, "label": "á" },
+        { "$": "auto_text_key", "code":  228, "label": "ä" }
       ]
     },
     "s": {

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cs.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cs.json
@@ -37,7 +37,8 @@
     "o": {
       "relevant": [
         { "$": "auto_text_key", "code":  243, "label": "ó" },
-        { "$": "auto_text_key", "code":  244, "label": "ô" }
+        { "$": "auto_text_key", "code":  244, "label": "ô" },
+        { "$": "auto_text_key", "code":  246, "label": "ö" }
       ]
     },
     "a": {


### PR DESCRIPTION
**Why:** Czech language vocabulary does not utilize umlaut variants of a, u, o (ä, ü, ö), but our proximity to Germany means that we nevertheless utilize these letters on a daily basis in e.g. surnames (Böhm, Schützová, Häuser).

**Solution:** This PR to add these missing accent-variants (ä, ü, ö) to the Czech layout pop-ups for letters a, u, o.

**Note:** I read the contributing guidelines as well as code of conduct and am to my best understanding not breaking any rules by opening the PR directly without first creating an accompanying issue. If that is a misunderstanding, let me know and I will fix it.