### PR TITLE
Add Korean Phonetic layout 

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -260,6 +260,12 @@
         "authors": [ "patrickgold", "Hayleia" ],
         "direction": "ltr"
       },
+     {
+        "id": "korean_phonetic",
+        "label": "Korean Phonetic",
+        "authors": [ "patrickgold", "Hayleia" ],
+        "direction": "ltr"
+      },	  
       {
         "id": "kurdish",
         "label": "کوردی (قوەرتی نوێ)",

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/korean_phonetic.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/korean_phonetic.json
@@ -1,0 +1,55 @@
+[
+  [
+    { "$": "auto_text_key", "code": 12615, "label": "ㅇ"},
+    { "$": "auto_text_key", "code": 12641, "label": "ㅡ"},  
+    { "$": "case_selector",
+      "lower": { "code": 12628, "label": "ㅔ" },
+      "upper": { "code": 12630, "label": "ㅖ" }
+    },	
+    { "$": "auto_text_key", "code": 12601, "label": "ㄹ"},
+    { "$": "auto_text_key", "code": 12620, "label": "ㅌ"},
+    { "$": "case_selector",
+      "lower": { "code": 12624, "label": "ㅐ" },
+      "upper": { "code": 12626, "label": "ㅒ" }
+    },	
+    { "$": "auto_text_key", "code": 12636, "label": "ㅜ"},	
+    { "$": "auto_text_key", "code": 12643, "label": "ㅣ"},	
+    { "$": "auto_text_key", "code": 12631, "label": "ㅗ"},
+    { "$": "auto_text_key", "code": 12621, "label": "ㅍ"}	
+  ],
+  [	 
+    { "$": "auto_text_key", "code": 12623, "label": "ㅏ"},
+    { "$": "case_selector",
+      "lower": { "code": 12613, "label": "ㅅ" },
+      "upper": { "code": 12614, "label": "ㅆ" }
+    },	
+    { "$": "case_selector",
+      "lower": { "code": 12599, "label": "ㄷ" },
+      "upper": { "code": 12600, "label": "ㄸ" }
+    },	
+    { "$": "auto_text_key", "code": 12625, "label": "ㅑ"},
+    { "$": "case_selector",
+      "lower": { "code": 12593, "label": "ㄱ" },
+      "upper": { "code": 12594, "label": "ㄲ" }
+    },
+    { "$": "auto_text_key", "code": 12622, "label": "ㅎ"},
+    { "$": "case_selector",
+      "lower": { "code": 12616, "label": "ㅈ" },
+      "upper": { "code": 12617, "label": "ㅉ" }
+    },
+    { "$": "auto_text_key", "code": 12619, "label": "ㅋ"},
+    { "$": "auto_text_key", "code": 12635, "label": "ㅛ"}
+  ],
+  [
+    { "$": "auto_text_key", "code": 12629, "label": "ㅕ"},
+    { "$": "auto_text_key", "code": 12640, "label": "ㅠ"},
+    { "$": "auto_text_key", "code": 12618, "label": "ㅊ"},
+    { "$": "auto_text_key", "code": 12627, "label": "ㅓ"},
+    { "$": "case_selector",
+      "lower": { "code": 12610, "label": "ㅂ" },
+      "upper": { "code": 12611, "label": "ㅃ" }
+    },
+    { "$": "auto_text_key", "code": 12596, "label": "ㄴ"},
+    { "$": "auto_text_key", "code": 12609, "label": "ㅁ"}
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -59,6 +59,7 @@
     { "id": "ja-JP-jis", "authors": [ "waelwindows" ] },
     { "id": "kab", "authors": [ "yanis867" ] },
     { "id": "ko", "authors": [ "patrickgold", "Hayleia" ] },
+    { "id": "ko-PK", "authors": [ "patrickgold", "Hayleia" ] },	
     { "id": "ku", "authors": [ "GoRaN" ] },
     { "id": "lt", "authors": [ "patrickgold" ] },
     { "id": "lv", "authors": [ "patrickgold", "eandersons" ] },
@@ -596,6 +597,15 @@
         "characters": "org.florisboard.layouts:korean"
       }
     },
+    {
+      "languageTag": "ko-PK",
+      "composer": "org.florisboard.composers:hangul-unicode",
+      "currencySet": "org.florisboard.currencysets:south_korean_won",
+      "popupMapping": "org.florisboard.localization:ko-PK",
+      "preferred": {
+        "characters": "org.florisboard.layouts:korean_phonetic"
+      }
+    },	
     {
       "languageTag": "lt-LT",
       "composer": "org.florisboard.composers:appender",

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ko-PK.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ko-PK.json
@@ -1,0 +1,76 @@
+{
+  "all": {
+    "ㅂ": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 12611, "label": "ㅃ" }
+      ]
+    },
+    "ㅈ": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 12617, "label": "ㅉ" }
+      ]
+    },
+    "ㄷ": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 12600, "label": "ㄸ" }
+      ]
+    },
+    "ㄱ": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 12594, "label": "ㄲ" }
+      ]
+    },
+    "ㅅ": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 12614, "label": "ㅆ" }
+      ]
+    },
+    "ㅐ": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 12626, "label": "ㅒ" }
+      ]
+    },
+    "ㅔ": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 12630, "label": "ㅖ" }
+      ]
+    },
+    "~right": {
+      "main": { "code":   44, "label": "," },
+      "relevant": [
+        { "code":   38, "label": "&" },
+        { "code":   37, "label": "%" },
+        { "code":   43, "label": "+" },
+        { "code":   34, "label": "\"" },
+        { "code":   45, "label": "-" },
+        { "code":   58, "label": ":" },
+        { "code":   39, "label": "'" },
+        { "code":   64, "label": "@" },
+        { "code":   59, "label": ";" },
+        { "code":   47, "label": "/" },
+        { "$": "layout_direction_selector",
+          "ltr": { "code":   40, "label": "(" },
+          "rtl": { "code":   41, "label": "(" }
+        },
+        { "$": "layout_direction_selector",
+          "ltr": { "code":   41, "label": ")" },
+          "rtl": { "code":   40, "label": ")" }
+        },
+        { "code":   35, "label": "#" },
+        { "code":   33, "label": "!" },
+        { "code":   63, "label": "?" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".com" },
+      "relevant": [
+        { "code": -255, "label": ".gov" },
+        { "code": -255, "label": ".edu" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".net" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/23e59709-438c-478b-bc1e-9536013c85ce)

Hello,
I found out that FlorisBoard has a great korean keyboard (https://github.com/florisboard/florisboard/issues/305)
I opened this pull request to add a Korean Phonetic layout. 
This layout makes typing in Korean easier for users.

Layout: https://krbord.github.io/romaja/
https://help.keyman.com/keyboard/korean_phonetic
https://en.wikipedia.org/wiki/Keyboard_layout#Korean
https://namu.wiki/w/두벌식/자판%20종류#s-2.6



