### PR TITLE
Add Armenian layout to extension.json

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -18,6 +18,13 @@
         "modifier": "org.florisboard.layouts:arabic"
       },
       {
+        "id": "armenian_alt_phonetic",
+        "label": "Armenian Alt Phonetic",
+        "authors": [ "MikayelB" ],
+        "direction": "ltr",
+        "modifier": "org.florisboard.layouts:armenian_alt_phonetic"
+      },
+      {
         "id": "western_armenian",
         "label": "Armenian (Western)",
         "authors": [ "PJTSearch" ],


### PR DESCRIPTION
The [armenian_alt_phonetic.json](https://github.com/florisboard/florisboard/commit/a7f8980d350aedaa6af26083e678fbca5b3d7833#diff-2b961f94cbb97e3bf1d5ec590214ff2fc568e200c8e701d73a4a5d075ef236c0) was configured (commit [a7f8980](https://github.com/florisboard/florisboard/commit/a7f8980d350aedaa6af26083e678fbca5b3d7833)) but wasn't properly added to extension.json, that's why it doesn't show up in the layout menu.

Thank you all for your hard work :)