### PR TITLE
Add SnyggListItem / Allow styling of subtype pnale list items

### DIFF
--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
@@ -386,5 +386,9 @@
   "subtype-panel-list-item-icon-leading": {
     "font-size": "24sp",
     "padding": "0dp 0dp 16dp 0dp"
+  },
+  "subtype-panel-list-item-text": {
+    "text-max-lines": "1",
+    "text-overflow": "ellipsis"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
@@ -378,5 +378,13 @@
     "text-align": "center",
     "text-max-lines": "1",
     "text-overflow": "ellipsis"
+  },
+  "subtype-panel-list-item": {
+    "font-size": "16sp",
+    "padding": "16dp"
+  },
+  "subtype-panel-list-item-icon-leading": {
+    "font-size": "24sp",
+    "padding": "0dp 0dp 16dp 0dp"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day_borderless.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day_borderless.json
@@ -397,5 +397,9 @@
   "subtype-panel-list-item-icon-leading": {
     "font-size": "24sp",
     "padding": "0dp 0dp 16dp 0dp"
+  },
+  "subtype-panel-list-item-text": {
+    "text-max-lines": "1",
+    "text-overflow": "ellipsis"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day_borderless.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day_borderless.json
@@ -389,6 +389,13 @@
     "text-align": "center",
     "text-max-lines": "1",
     "text-overflow": "ellipsis"
+  },
+  "subtype-panel-list-item": {
+    "font-size": "16sp",
+    "padding": "16dp"
+  },
+  "subtype-panel-list-item-icon-leading": {
+    "font-size": "24sp",
+    "padding": "0dp 0dp 16dp 0dp"
   }
-
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night.json
@@ -379,5 +379,9 @@
   "subtype-panel-list-item-icon-leading": {
     "font-size": "24sp",
     "padding": "0dp 0dp 16dp 0dp"
+  },
+  "subtype-panel-list-item-text": {
+    "text-max-lines": "1",
+    "text-overflow": "ellipsis"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night.json
@@ -371,5 +371,13 @@
     "text-align": "center",
     "text-max-lines": "1",
     "text-overflow": "ellipsis"
+  },
+  "subtype-panel-list-item": {
+    "font-size": "16sp",
+    "padding": "16dp"
+  },
+  "subtype-panel-list-item-icon-leading": {
+    "font-size": "24sp",
+    "padding": "0dp 0dp 16dp 0dp"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night_borderless.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night_borderless.json
@@ -390,5 +390,9 @@
   "subtype-panel-list-item-icon-leading": {
     "font-size": "24sp",
     "padding": "0dp 0dp 16dp 0dp"
+  },
+  "subtype-panel-list-item-text": {
+    "text-max-lines": "1",
+    "text-overflow": "ellipsis"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night_borderless.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night_borderless.json
@@ -382,5 +382,13 @@
     "text-align": "center",
     "text-max-lines": "1",
     "text-overflow": "ellipsis"
+  },
+  "subtype-panel-list-item": {
+    "font-size": "16sp",
+    "padding": "16dp"
+  },
+  "subtype-panel-list-item-icon-leading": {
+    "font-size": "24sp",
+    "padding": "0dp 0dp 16dp 0dp"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night.json
@@ -383,5 +383,9 @@
   "subtype-panel-list-item-icon-leading": {
     "font-size": "24sp",
     "padding": "0dp 0dp 16dp 0dp"
+  },
+  "subtype-panel-list-item-text": {
+    "text-max-lines": "1",
+    "text-overflow": "ellipsis"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night.json
@@ -375,5 +375,13 @@
     "text-align": "center",
     "text-max-lines": "1",
     "text-overflow": "ellipsis"
+  },
+  "subtype-panel-list-item": {
+    "font-size": "16sp",
+    "padding": "16dp"
+  },
+  "subtype-panel-list-item-icon-leading": {
+    "font-size": "24sp",
+    "padding": "0dp 0dp 16dp 0dp"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night_borderless.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night_borderless.json
@@ -390,5 +390,9 @@
   "subtype-panel-list-item-icon-leading": {
     "font-size": "24sp",
     "padding": "0dp 0dp 16dp 0dp"
+  },
+  "subtype-panel-list-item-text": {
+    "text-max-lines": "1",
+    "text-overflow": "ellipsis"
   }
 }

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night_borderless.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night_borderless.json
@@ -382,5 +382,13 @@
     "text-align": "center",
     "text-max-lines": "1",
     "text-overflow": "ellipsis"
+  },
+  "subtype-panel-list-item": {
+    "font-size": "16sp",
+    "padding": "16dp"
+  },
+  "subtype-panel-list-item-icon-leading": {
+    "font-size": "24sp",
+    "padding": "0dp 0dp 16dp 0dp"
   }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/core/SelectSubtypePanel.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/core/SelectSubtypePanel.kt
@@ -17,7 +17,6 @@
 package dev.patrickgold.florisboard.ime.core
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -26,8 +25,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.RadioButtonChecked
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
-import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -38,11 +35,11 @@ import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.ime.keyboard.KeyboardState
 import dev.patrickgold.florisboard.ime.theme.FlorisImeUi
 import dev.patrickgold.florisboard.keyboardManager
-import dev.patrickgold.florisboard.lib.compose.rippleClickable
 import dev.patrickgold.florisboard.lib.compose.stringRes
 import dev.patrickgold.florisboard.subtypeManager
-import dev.patrickgold.jetpref.material.ui.JetPrefListItem
+import org.florisboard.lib.snygg.ui.SnyggBox
 import org.florisboard.lib.snygg.ui.SnyggColumn
+import org.florisboard.lib.snygg.ui.SnyggListItem
 import org.florisboard.lib.snygg.ui.SnyggRow
 import org.florisboard.lib.snygg.ui.SnyggText
 
@@ -71,7 +68,7 @@ fun SelectSubtypePanel(modifier: Modifier = Modifier) {
             )
         }
 
-        Box {
+        SnyggBox(FlorisImeUi.SubtypePanelList.elementName) {
             LazyColumn(
                 state = listState,
             ) {
@@ -81,22 +78,18 @@ fun SelectSubtypePanel(modifier: Modifier = Modifier) {
                         it.id
                     }
                 ) {
-                    JetPrefListItem(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .rippleClickable {
-                                subtypeManager.switchToSubtypeById(it.id)
-                                keyboardManager.activeState.isSubtypeSelectionVisible = false
-                            },
-                        icon = {
-                            if (currentlySelected == it.id) {
-                                Icon(Icons.Default.RadioButtonChecked, null)
-                            } else {
-                                Icon(Icons.Default.RadioButtonUnchecked, null)
-                            }
+                    SnyggListItem(
+                        elementName = FlorisImeUi.SubtypePanelListItem.elementName,
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = {
+                            subtypeManager.switchToSubtypeById(it.id)
+                            keyboardManager.activeState.isSubtypeSelectionVisible = false
+                        },
+                        leadingImageVector = when {
+                            currentlySelected == it.id -> Icons.Default.RadioButtonChecked
+                            else -> Icons.Default.RadioButtonUnchecked
                         },
                         text = it.primaryLocale.displayName(),
-                        colors = ListItemDefaults.colors(),
                     )
                 }
             }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/core/SelectSubtypePanel.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/core/SelectSubtypePanel.kt
@@ -80,7 +80,6 @@ fun SelectSubtypePanel(modifier: Modifier = Modifier) {
                 ) {
                     SnyggListItem(
                         elementName = FlorisImeUi.SubtypePanelListItem.elementName,
-                        modifier = Modifier.fillMaxWidth(),
                         onClick = {
                             subtypeManager.switchToSubtypeById(it.id)
                             keyboardManager.activeState.isSubtypeSelectionVisible = false

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeThemeBaseStyle.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeThemeBaseStyle.kt
@@ -308,4 +308,27 @@ val FlorisImeThemeBaseStyle = SnyggStylesheet.v2 {
         background = rgbaColor(27, 94, 32)
         foreground = rgbaColor(238, 238, 238)
     }
+
+    FlorisImeUi.SubtypePanel.elementName {
+        background = `var`("--background")
+        foreground = `var`("--on-background")
+        shape = roundedCornerShape(24.dp, 24.dp, 0.dp, 0.dp)
+    }
+    FlorisImeUi.SubtypePanelHeader.elementName {
+        background = `var`("--surface")
+        foreground = `var`("--on-surface")
+        fontSize = fontSize(18.sp)
+        padding = padding(12.dp)
+        textAlign = textAlign(TextAlign.Center)
+        textMaxLines = textMaxLines(1)
+        textOverflow = textOverflow(TextOverflow.Ellipsis)
+    }
+    FlorisImeUi.SubtypePanelListItem.elementName {
+        fontSize = fontSize(16.sp)
+        padding = padding(16.dp)
+    }
+    FlorisImeUi.SubtypePanelListItemIconLeading.elementName {
+        fontSize = fontSize(24.sp)
+        padding = padding(0.dp, 0.dp, 16.dp, 0.dp)
+    }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeThemeBaseStyle.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeThemeBaseStyle.kt
@@ -331,4 +331,8 @@ val FlorisImeThemeBaseStyle = SnyggStylesheet.v2 {
         fontSize = fontSize(24.sp)
         padding = padding(0.dp, 0.dp, 16.dp, 0.dp)
     }
+    FlorisImeUi.SubtypePanelListItemText.elementName {
+        textMaxLines = textMaxLines(1)
+        textOverflow = textOverflow(TextOverflow.Ellipsis)
+    }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeUi.kt
@@ -288,6 +288,22 @@ enum class FlorisImeUi(val elementName: String, val resId: Int?) {
     SubtypePanelHeader(
         elementName = "subtype-panel-header",
         resId = R.string.snygg__rule_element__subtype_panel_header,
+    ),
+    SubtypePanelList(
+        elementName = "subtype-panel-list",
+        resId = R.string.snygg__rule_element__subtype_panel_list,
+    ),
+    SubtypePanelListItem(
+        elementName = "subtype-panel-list-item",
+        resId = R.string.snygg__rule_element__subtype_panel_list_item,
+    ),
+    SubtypePanelListItemIconLeading(
+        elementName = "subtype-panel-list-item-icon-leading",
+        resId = R.string.snygg__rule_element__subtype_panel_list_item_icon_leading,
+    ),
+    SubtypePanelListItemText(
+        elementName = "subtype-panel-list-item-text",
+        resId = R.string.snygg__rule_element__subtype_panel_list_item_text,
     );
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,6 +299,10 @@
 
     <string name="snygg__rule_element__subtype_panel">Subtype panel</string>
     <string name="snygg__rule_element__subtype_panel_header">Subtype panel header</string>
+    <string name="snygg__rule_element__subtype_panel_list">Subtype panel list</string>
+    <string name="snygg__rule_element__subtype_panel_list_item">Subtype panel list item</string>
+    <string name="snygg__rule_element__subtype_panel_list_item_icon_leading">Subtype panel list item icon (leading)</string>
+    <string name="snygg__rule_element__subtype_panel_list_item_text">Subtype panel list item text</string>
 
     <string name="snygg__rule_selector__pressed">Pressed</string>
     <string name="snygg__rule_selector__focus">Focused</string>

--- a/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggListItem.kt
+++ b/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggListItem.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.snygg.ui
+
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.florisboard.lib.snygg.SnyggQueryAttributes
+import org.florisboard.lib.snygg.SnyggSelector
+import org.florisboard.lib.snygg.SnyggStylesheet
+
+/**
+ * Simple list item composable.
+ *
+ * This composable infers its style from the current [SnyggTheme][org.florisboard.lib.snygg.SnyggTheme], which is
+ * required to be provided by [ProvideSnyggTheme].
+ *
+ * @param elementName The name of this element. If `null` the style will be inherited from the parent element.
+ * @param attributes The attributes of the element used to refine the query.
+ * @param modifier The modifier to be applied to the [ListItem].
+ * @param onClick The clickable action for this item.
+ * @param text The text of the list item.
+ * @param leadingImageVector The leading icon of the list item.
+ * @param trailingImageVector The trailing icon of the list item.
+ * @param interactionSource The interaction source for the onClick action.
+ * @param indication The indication of the list item during interaction. Defaults to a ripple effect.
+ * @param enabled If the clickable action is enabled or not. False will set the DISABLED selector for style querying.
+ *
+ * @since 0.5.0-alpha03
+ *
+ * @see androidx.compose.material3.ListItem
+ */
+@Composable
+fun SnyggListItem(
+    elementName: String? = null,
+    attributes: SnyggQueryAttributes = emptyMap(),
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    text: String,
+    leadingImageVector: ImageVector? = null,
+    trailingImageVector: ImageVector? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    indication: Indication = ripple(),
+    enabled: Boolean = true,
+) {
+    val selector = if (enabled) SnyggSelector.NONE else SnyggSelector.DISABLED
+    val decoratedModifier = modifier.clickable(
+        interactionSource = interactionSource,
+        indication = indication,
+        enabled = enabled,
+        onClickLabel = null,
+        role = null,
+        onClick = onClick,
+    )
+    SnyggRow(elementName, attributes, selector,
+        modifier = decoratedModifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (leadingImageVector != null) {
+            SnyggBox(
+                elementName = "$elementName-icon-leading",
+                attributes = attributes,
+                selector = selector,
+            ) {
+                SnyggIcon(imageVector = leadingImageVector)
+            }
+        }
+        SnyggText(
+            elementName = "$elementName-text",
+            attributes = attributes,
+            selector = selector,
+            text = text,
+        )
+        if (trailingImageVector != null) {
+            SnyggBox(
+                elementName = "$elementName-icon-trailing",
+                attributes = attributes,
+                selector = selector,
+            ) {
+                SnyggIcon(imageVector = trailingImageVector)
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SimpleSnyggListItem() {
+    val stylesheet = SnyggStylesheet.v2 {
+        "preview" {
+            background = rgbaColor(255, 255, 255)
+            fontSize = fontSize(16.sp)
+            foreground = rgbaColor(0, 0, 0)
+        }
+        "preview-list-item" {
+            background = rgbaColor(240, 220, 220)
+            foreground = rgbaColor(0, 0, 0)
+            padding = padding(all = 16.dp)
+        }
+        "preview-list-item-icon-leading" {
+            fontSize = fontSize(24.sp)
+            padding = padding(0.dp, 0.dp, 16.dp, 0.dp)
+        }
+    }
+    val theme = rememberSnyggTheme(stylesheet)
+
+    ProvideSnyggTheme(theme) {
+        SnyggColumn("preview") {
+            Text("Snygg list item:")
+            SnyggListItem("preview-list-item",
+                modifier = Modifier.fillMaxWidth(),
+                leadingImageVector = Icons.Default.Search,
+                onClick = {},
+                text = "hello",
+            )
+            Text("vs Material3 list item:")
+            ListItem(
+                leadingContent = {
+                    Icon(Icons.Default.Search, null)
+                },
+                headlineContent = {
+                    Text("hello")
+                },
+            )
+        }
+    }
+}

--- a/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggListItem.kt
+++ b/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggListItem.kt
@@ -22,15 +22,15 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -56,8 +56,6 @@ import org.florisboard.lib.snygg.SnyggStylesheet
  * @param enabled If the clickable action is enabled or not. False will set the DISABLED selector for style querying.
  *
  * @since 0.5.0-alpha03
- *
- * @see androidx.compose.material3.ListItem
  */
 @Composable
 fun SnyggListItem(
@@ -98,6 +96,7 @@ fun SnyggListItem(
             elementName = "$elementName-text",
             attributes = attributes,
             selector = selector,
+            modifier = Modifier.fillMaxWidth(),
             text = text,
         )
         if (trailingImageVector != null) {
@@ -130,26 +129,34 @@ private fun SimpleSnyggListItem() {
             fontSize = fontSize(24.sp)
             padding = padding(0.dp, 0.dp, 16.dp, 0.dp)
         }
+        "preview-list-item"("layout" to listOf("center")) {
+            textAlign = textAlign(TextAlign.Center)
+        }
+        "preview-list-item"("layout" to listOf("long")) {
+            textMaxLines = textMaxLines(1)
+            textOverflow = textOverflow(TextOverflow.Ellipsis)
+        }
     }
     val theme = rememberSnyggTheme(stylesheet)
 
     ProvideSnyggTheme(theme) {
         SnyggColumn("preview") {
-            Text("Snygg list item:")
             SnyggListItem("preview-list-item",
-                modifier = Modifier.fillMaxWidth(),
                 leadingImageVector = Icons.Default.Search,
                 onClick = {},
                 text = "hello",
             )
-            Text("vs Material3 list item:")
-            ListItem(
-                leadingContent = {
-                    Icon(Icons.Default.Search, null)
-                },
-                headlineContent = {
-                    Text("hello")
-                },
+            SnyggListItem("preview-list-item",
+                mapOf("layout" to "center"),
+                leadingImageVector = Icons.Default.Search,
+                onClick = {},
+                text = "hello",
+            )
+            SnyggListItem("preview-list-item",
+                mapOf("layout" to "long"),
+                leadingImageVector = Icons.Default.Search,
+                onClick = {},
+                text = "hello world this is a very long list item text label",
             )
         }
     }


### PR DESCRIPTION
Fixes #2885 

The following changes are being made:
- Add element `subtype-panel-list`
- Add element `subtype-panel-list-item`
- Add element `subtype-panel-list-item-icon-leading`
- Add element `subtype-panel-list-item-text`
- Update default themes and base style regarding good default sizes/paddings

The list item style accepts most Snygg properties, `margin` may cause some layout issues if applied to the icon or text inner styles.

Screenshots:

| Floris Day       | Floris Night     |
|------------------|------------------|
| ![image](https://github.com/user-attachments/assets/672259ea-1bbe-442d-b823-1b500a136172) | ![image](https://github.com/user-attachments/assets/b6d7c139-3951-4b80-b590-c43b646145c8) |
