### PR TITLE
Add `mode` attribute to select element styles

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -588,6 +588,10 @@ class FlorisImeService : LifecycleInputMethodService() {
     @Composable
     private fun ImeUi() {
         val state by keyboardManager.activeState.collectAsState()
+        val attributes = mapOf(
+            FlorisImeUi.Attr.Mode to state.keyboardMode.toString(),
+            FlorisImeUi.Attr.ShiftState to state.inputShiftState.toString(),
+        )
         val layoutDirection = LocalLayoutDirection.current
         LaunchedEffect(layoutDirection) {
             keyboardManager.activeState.layoutDirection = layoutDirection
@@ -595,7 +599,7 @@ class FlorisImeService : LifecycleInputMethodService() {
         CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
             SnyggBox(
                 elementName = FlorisImeUi.Window.elementName,
-                attributes = mapOf(FlorisImeUi.Attr.ShiftState to state.inputShiftState.attrName()),
+                attributes = attributes,
                 modifier = Modifier
                     .fillMaxWidth()
                     .wrapContentHeight()

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/EnumDisplayEntries.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/EnumDisplayEntries.kt
@@ -24,7 +24,9 @@ import dev.patrickgold.florisboard.ime.core.DisplayLanguageNamesIn
 import dev.patrickgold.florisboard.ime.input.CapitalizationBehavior
 import dev.patrickgold.florisboard.ime.input.HapticVibrationMode
 import dev.patrickgold.florisboard.ime.input.InputFeedbackActivationMode
+import dev.patrickgold.florisboard.ime.input.InputShiftState
 import dev.patrickgold.florisboard.ime.keyboard.IncognitoMode
+import dev.patrickgold.florisboard.ime.keyboard.KeyboardMode
 import dev.patrickgold.florisboard.ime.keyboard.SpaceBarMode
 import dev.patrickgold.florisboard.ime.landscapeinput.LandscapeInputUiMode
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiHistory
@@ -361,6 +363,58 @@ private val ENUM_DISPLAY_ENTRIES = mapOf<Pair<KClass<*>, String>, @Composable ()
             entry(
                 key = InputFeedbackActivationMode.IGNORE_SYSTEM_SETTINGS,
                 label = stringRes(R.string.enum__input_feedback_activation_mode__haptic_ignore_system_settings),
+            )
+        }
+    },
+    InputShiftState::class to DEFAULT to {
+        listPrefEntries {
+            entry(
+                key = InputShiftState.UNSHIFTED,
+                label = stringRes(R.string.enum__input_shift_state__unshifted),
+            )
+            entry(
+                key = InputShiftState.SHIFTED_MANUAL,
+                label = stringRes(R.string.enum__input_shift_state__shifted_manual),
+            )
+            entry(
+                key = InputShiftState.SHIFTED_AUTOMATIC,
+                label = stringRes(R.string.enum__input_shift_state__shifted_automatic),
+            )
+            entry(
+                key = InputShiftState.CAPS_LOCK,
+                label = stringRes(R.string.enum__input_shift_state__caps_lock),
+            )
+        }
+    },
+    KeyboardMode::class to DEFAULT to {
+        listPrefEntries {
+            entry(
+                key = KeyboardMode.CHARACTERS,
+                label = stringRes(R.string.enum__keyboard_mode__characters),
+            )
+            entry(
+                key = KeyboardMode.SYMBOLS,
+                label = stringRes(R.string.enum__keyboard_mode__symbols),
+            )
+            entry(
+                key = KeyboardMode.SYMBOLS2,
+                label = stringRes(R.string.enum__keyboard_mode__symbols2),
+            )
+            entry(
+                key = KeyboardMode.NUMERIC,
+                label = stringRes(R.string.enum__keyboard_mode__numeric),
+            )
+            entry(
+                key = KeyboardMode.NUMERIC_ADVANCED,
+                label = stringRes(R.string.enum__keyboard_mode__numeric_advanced),
+            )
+            entry(
+                key = KeyboardMode.PHONE,
+                label = stringRes(R.string.enum__keyboard_mode__phone),
+            )
+            entry(
+                key = KeyboardMode.PHONE2,
+                label = stringRes(R.string.enum__keyboard_mode__phone2),
             )
         }
     },

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/input/InputShiftState.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/input/InputShiftState.kt
@@ -43,7 +43,7 @@ enum class InputShiftState(val value: Int) {
         fun fromInt(int: Int) = entries.firstOrNull { it.value == int } ?: UNSHIFTED
     }
 
-    fun attrName() = name.lowercase()
+    override fun toString() = name.lowercase()
 
     fun toInt() = value
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardMode.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardMode.kt
@@ -19,6 +19,7 @@ package dev.patrickgold.florisboard.ime.keyboard
 enum class KeyboardMode(val value: Int) {
     UNSPECIFIED(-1),
     CHARACTERS(0),
+    @Deprecated(message = "TODO: remove")
     EDITING(1),
     SYMBOLS(2),
     SYMBOLS2(3),
@@ -26,7 +27,9 @@ enum class KeyboardMode(val value: Int) {
     NUMERIC_ADVANCED(5),
     PHONE(6),
     PHONE2(7),
+    @Deprecated(message = "TODO: remove")
     SMARTBAR_CLIPBOARD_CURSOR_ROW(8),
+    @Deprecated(message = "TODO: remove")
     SMARTBAR_NUMBER_ROW(9),
     SMARTBAR_QUICK_ACTIONS(10);
 
@@ -34,7 +37,7 @@ enum class KeyboardMode(val value: Int) {
         fun fromInt(int: Int) = entries.firstOrNull { it.value == int } ?: CHARACTERS
     }
 
-    fun attrName() = name.lowercase()
+    override fun toString() = name.lowercase()
 
     fun toInt() = value
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/popup/PopupUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/popup/PopupUi.kt
@@ -17,7 +17,6 @@
 package dev.patrickgold.florisboard.ime.popup
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.requiredHeight
@@ -31,6 +30,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import dev.patrickgold.florisboard.ime.keyboard.Key
 import dev.patrickgold.florisboard.ime.theme.FlorisImeUi
+import org.florisboard.lib.snygg.SnyggQueryAttributes
 import org.florisboard.lib.snygg.SnyggSelector
 import org.florisboard.lib.snygg.ui.SnyggBox
 import org.florisboard.lib.snygg.ui.SnyggColumn
@@ -41,11 +41,13 @@ import org.florisboard.lib.snygg.ui.SnyggText
 @Composable
 fun PopupBaseBox(
     modifier: Modifier = Modifier,
+    attributes: SnyggQueryAttributes,
     key: Key,
     shouldIndicateExtendedPopups: Boolean,
 ): Unit = with(LocalDensity.current) {
     SnyggBox(
         elementName = FlorisImeUi.KeyPopupBox.elementName,
+        attributes = attributes,
         modifier = modifier,
     ) {
         key.label?.let { label ->
@@ -64,6 +66,7 @@ fun PopupBaseBox(
         if (shouldIndicateExtendedPopups) {
             SnyggIcon(
                 elementName = FlorisImeUi.KeyPopupExtendedIndicator.elementName,
+                attributes = attributes,
                 modifier = Modifier.align(Alignment.CenterEnd),
                 imageVector = Icons.Default.MoreHoriz,
             )
@@ -74,13 +77,14 @@ fun PopupBaseBox(
 @Composable
 fun PopupExtBox(
     modifier: Modifier = Modifier,
+    attributes: SnyggQueryAttributes,
     elements: List<List<PopupUiController.Element>>,
     elemArrangement: Arrangement.Horizontal,
     elemWidth: Dp,
     elemHeight: Dp,
     activeElementIndex: Int,
 ): Unit = with(LocalDensity.current) {
-    SnyggColumn(FlorisImeUi.KeyPopupBox.elementName, modifier = modifier) {
+    SnyggColumn(FlorisImeUi.KeyPopupBox.elementName, attributes, modifier = modifier) {
         for (row in elements.asReversed()) {
             SnyggRow(
                 modifier = Modifier
@@ -96,6 +100,7 @@ fun PopupExtBox(
                     }
                     SnyggBox(
                         elementName = FlorisImeUi.KeyPopupElement.elementName,
+                        attributes = attributes,
                         selector = selector,
                         modifier = Modifier.size(elemWidth, elemHeight),
                     ) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/popup/PopupUiController.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/popup/PopupUiController.kt
@@ -42,6 +42,7 @@ import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyHintConfiguration
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKey
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
+import dev.patrickgold.florisboard.ime.theme.FlorisImeUi
 import dev.patrickgold.florisboard.lib.FlorisRect
 import dev.patrickgold.florisboard.lib.toIntOffset
 
@@ -447,11 +448,16 @@ class PopupUiController(
 
     @Composable
     fun RenderPopups(): Unit = with(LocalDensity.current) {
+        val attributes = mapOf(
+            FlorisImeUi.Attr.Mode to evaluator.keyboard.mode.toString(),
+            FlorisImeUi.Attr.ShiftState to evaluator.state.inputShiftState.toString(),
+        )
         baseRenderInfo?.let { renderInfo ->
             PopupBaseBox(
                 modifier = Modifier
                     .requiredSize(renderInfo.bounds.size.toDpSize())
                     .absoluteOffset { renderInfo.bounds.topLeft.toIntOffset() },
+                attributes = attributes,
                 key = renderInfo.key,
                 shouldIndicateExtendedPopups = renderInfo.shouldIndicateExtendedPopups && extRenderInfo == null,
             )
@@ -464,6 +470,7 @@ class PopupUiController(
                 modifier = Modifier
                     .requiredSize(renderInfo.bounds.size.toDpSize())
                     .absoluteOffset { renderInfo.bounds.topLeft.toIntOffset() },
+                attributes = attributes,
                 elements = renderInfo.elements,
                 elemArrangement = if (renderInfo.anchorLeft) {
                     Arrangement.Start

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
@@ -314,8 +314,8 @@ private fun TextKeyButton(
 ) = with(LocalDensity.current) {
     val attributes = mapOf(
         FlorisImeUi.Attr.Code to key.computedData.code,
-        FlorisImeUi.Attr.Mode to evaluator.keyboard.mode.attrName(),
-        FlorisImeUi.Attr.ShiftState to evaluator.state.inputShiftState.attrName(),
+        FlorisImeUi.Attr.Mode to evaluator.keyboard.mode.toString(),
+        FlorisImeUi.Attr.ShiftState to evaluator.state.inputShiftState.toString(),
     )
     val selector = when {
         !key.isEnabled -> SnyggSelector.DISABLED

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeTheme.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeTheme.kt
@@ -21,15 +21,19 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import dev.patrickgold.florisboard.app.florisPreferenceModel
+import dev.patrickgold.florisboard.keyboardManager
 import dev.patrickgold.florisboard.lib.observeAsNonNullState
 import dev.patrickgold.florisboard.themeManager
 import dev.patrickgold.jetpref.datastore.model.observeAsState
+import org.florisboard.lib.snygg.SnyggAttributes
+import org.florisboard.lib.snygg.SnyggQueryAttributes
 import org.florisboard.lib.snygg.ui.ProvideSnyggTheme
 import org.florisboard.lib.snygg.ui.rememberSnyggTheme
 
@@ -45,6 +49,7 @@ object FlorisImeTheme {
 @Composable
 fun FlorisImeTheme(content: @Composable () -> Unit) {
     val context = LocalContext.current
+    val keyboardManager by context.keyboardManager()
     val themeManager by context.themeManager()
 
     val prefs by florisPreferenceModel()
@@ -60,6 +65,12 @@ fun FlorisImeTheme(content: @Composable () -> Unit) {
     val snyggTheme = rememberSnyggTheme(activeStyle, assetResolver)
     val fontSizeMultiplier = prefs.keyboard.fontSizeMultiplier()
 
+    val state by keyboardManager.activeState.collectAsState()
+    val attributes = mapOf(
+        FlorisImeUi.Attr.Mode to state.keyboardMode.toString(),
+        FlorisImeUi.Attr.ShiftState to state.inputShiftState.toString(),
+    )
+
     MaterialTheme {
         CompositionLocalProvider(
             LocalConfig provides activeConfig,
@@ -70,6 +81,7 @@ fun FlorisImeTheme(content: @Composable () -> Unit) {
                 dynamicAccentColor = accentColor,
                 fontSizeMultiplier = fontSizeMultiplier,
                 assetResolver = assetResolver,
+                rootAttributes = attributes,
                 content = content,
             )
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeThemeBaseStyle.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeThemeBaseStyle.kt
@@ -96,7 +96,7 @@ val FlorisImeThemeBaseStyle = SnyggStylesheet.v2 {
     }
     FlorisImeUi.Key.elementName(
         FlorisImeUi.Attr.Code to listOf(KeyCode.SHIFT),
-        FlorisImeUi.Attr.ShiftState to listOf(InputShiftState.CAPS_LOCK.attrName()),
+        FlorisImeUi.Attr.ShiftState to listOf(InputShiftState.CAPS_LOCK.toString()),
     ) {
         foreground = rgbaColor(255, 152, 0)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,12 +186,13 @@
     <string name="settings__theme_editor__rule_name">Element / Annotation</string>
     <string name="settings__theme_editor__rule_codes">Target key codes</string>
     <string name="settings__theme_editor__rule_groups">Groups</string>
-    <string name="settings__theme_editor__rule_shift_states">Shift states</string>
+    <string name="settings__theme_editor__rule_modes">Target modes (layers)</string>
+    <string name="settings__theme_editor__rule_shift_states">Target shift states</string>
     <string name="settings__theme_editor__rule_selectors">Selectors</string>
     <string name="settings__theme_editor__add_code">Add key code</string>
     <string name="settings__theme_editor__edit_code">Edit key code</string>
     <string name="settings__theme_editor__no_codes_defined">Apply rule to all target elements.</string>
-    <string name="settings__theme_editor__codes_defined">Apply rule only to target elements with following key codes:</string>
+    <string name="settings__theme_editor__no_enum_value_to_add_anymore">All possible values have been added.</string>
     <string name="settings__theme_editor__code_already_exists">This key code is already defined.</string>
     <string name="settings__theme_editor__code_invalid">This key code is not valid. Ensure that the key code is within the range of {c_min} to {c_max} for characters or {i_min} to {i_max} for internal special keys.</string>
     <string name="settings__theme_editor__code_help_text">Alternatively the following links will help you to find the corresponding key code:</string>
@@ -991,6 +992,14 @@
     <string name="enum__input_shift_state__shifted_manual" comment="Enum value label">Shifted (manual)</string>
     <string name="enum__input_shift_state__shifted_automatic" comment="Enum value label">Shifted (automatic)</string>
     <string name="enum__input_shift_state__caps_lock" comment="Enum value label">Caps lock</string>
+
+    <string name="enum__keyboard_mode__characters" comment="Enum value label">Characters</string>
+    <string name="enum__keyboard_mode__symbols" comment="Enum value label">Symbols</string>
+    <string name="enum__keyboard_mode__symbols2" comment="Enum value label">Symbols 2</string>
+    <string name="enum__keyboard_mode__numeric" comment="Enum value label">Numeric</string>
+    <string name="enum__keyboard_mode__numeric_advanced" comment="Enum value label">Numeric advanced</string>
+    <string name="enum__keyboard_mode__phone" comment="Enum value label">Phone</string>
+    <string name="enum__keyboard_mode__phone2" comment="Enum value label">Phone 2</string>
 
     <string name="enum__landscape_input_ui_mode__never_show" comment="Enum value label">Never show</string>
     <string name="enum__landscape_input_ui_mode__always_show" comment="Enum value label">Always show</string>

--- a/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggUi.kt
+++ b/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggUi.kt
@@ -149,6 +149,7 @@ fun ProvideSnyggTheme(
     dynamicAccentColor: Color = Color.Unspecified,
     fontSizeMultiplier: Float = 1.0f,
     assetResolver: SnyggAssetResolver = SnyggDefaultAssetResolver,
+    rootAttributes: SnyggQueryAttributes = emptyMap(),
     content: @Composable () -> Unit,
 ) {
     val context = LocalContext.current
@@ -184,7 +185,7 @@ fun ProvideSnyggTheme(
         LocalSnyggPreloadedCustomFontFamilies provides customFontFamilies,
         LocalSnyggParentStyle provides initParentStyle,
     ) {
-        ProvideSnyggStyle("root", SnyggAttributes.of(), SnyggSelector.NONE) {
+        ProvideSnyggStyle("root", rootAttributes, SnyggSelector.NONE) {
             content()
         }
     }


### PR DESCRIPTION
This PR adds the `mode` attribute, which allows to further customize the theme based on the active mode.

The following attribute values are supported:
- `characters`
- `symbols`
- `symbols2`
- `numeric`
- `numeric_advanced`
- `phone`
- `phone2`

It can be applied to the following elements:
- `root`
- `window`
- `key`
- `key-hint`
- `key-popup-box`
- `key-popup-element`
- `key-popup-extended-indicator`