### PR TITLE
Fix Amenian phonetic layout addition

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -22,7 +22,7 @@
         "label": "Armenian Alt Phonetic",
         "authors": [ "MikayelB" ],
         "direction": "ltr",
-        "modifier": "org.florisboard.layouts:armenian_alt_phonetic"
+        "modifier": "org.florisboard.layouts:armenian"
       },
       {
         "id": "western_armenian",

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -407,6 +407,16 @@
       "currencySet": "org.florisboard.currencysets:armenian_dram",
       "popupMapping": "org.florisboard.localization:hy",
       "preferred": {
+        "characters": "org.florisboard.layouts:armenian_alt_phonetic",
+        "symbols": "org.florisboard.layouts:armenian"
+      }
+    },
+    {
+      "languageTag": "hy",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:armenian_dram",
+      "popupMapping": "org.florisboard.localization:hy",
+      "preferred": {
         "characters": "org.florisboard.layouts:western_armenian",
         "symbols": "org.florisboard.layouts:armenian"
       }


### PR DESCRIPTION
Sorry for the second PR on the same topic, but I previously didn't add the Armenian layout properly (I thought I did)(#2871)

It is now appearing this way (no "enter"/"shift" etc)

![Screenshot From 2025-05-14 12-23-49](https://github.com/user-attachments/assets/3197dc68-66e7-4f65-be5d-aa85abdfa736)

And here is the fixed version (this PR's changes)

![Screenshot From 2025-05-14 12-23-33](https://github.com/user-attachments/assets/ed429e1b-6a3a-4787-8bdd-66a00fa0cbd5)

I properly checked, the changes are still minor but correct this time.
Sorry for the inconvenience 
