### PR TITLE
Update hu.json in popup mappings of Hungarian layout

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/hu.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/hu.json
@@ -10,9 +10,9 @@
       "main": { "$": "auto_text_key" ,"code" : 237, "label": "í" }
     },
     "o": {
-      "main": { "$": "auto_text_key", "code" : 246, "label": "ö" },
+      "main": { "$": "auto_text_key", "code" : 243, "label": "ó" },
       "relevant": [
-        { "$": "auto_text_key", "code" : 243, "label": "ó" },
+        { "$": "auto_text_key", "code" : 246, "label": "ö" },
         { "$": "auto_text_key", "code" : 337, "label": "ő" }
       ]
     },
@@ -22,9 +22,9 @@
       ]
     },
     "u": {
-      "main": { "$": "auto_text_key", "code" : 252, "label": "ü" },
+      "main": { "$": "auto_text_key", "code" : 250, "label": "ú" },
       "relevant": [
-        { "$": "auto_text_key", "code" : 250, "label": "ú" },
+        { "$": "auto_text_key", "code" : 252, "label": "ü" },
         { "$": "auto_text_key", "code" : 369, "label": "ű" }
       ]
     },


### PR DESCRIPTION
I suggest modifications for main alternatives to keys 
o -> ó instead of ö
u -> ú instead of ü
as those (ö and ü) already have their own keys on the keyboard. So ó and ú become more easily reachable.
And this way the main alternatives fit better to the similar letter pairs (e.g. a-á, e-é, i-í) and the layout becomes more conveniently usable.