### PR TITLE
Clipboard filtering and timestamp display

### DIFF
--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
@@ -305,6 +305,10 @@
   "clipboard-item-popup[type=`text`]": {
     "padding": "12dp 8dp"
   },
+  "clipboard-item-timestamp": {
+    "font-size": "11sp",
+    "padding": "16dp 8dp"
+  },
   "clipboard-item-actions": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
@@ -282,20 +282,24 @@
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp",
     "text-max-lines": "10",
     "text-overflow": "ellipsis"
+  },
+  "clipboard-item[type=`text`]": {
+    "padding": "12dp 8dp"
   },
   "clipboard-item-popup": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp"
+  },
+  "clipboard-item-popup[type=`text`]": {
+    "padding": "12dp 8dp"
   },
   "clipboard-item-actions": {
     "background": "var(--surface)",

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
@@ -28,7 +28,8 @@
     "--on-surface-variant": "#5f5f5f",
 
     "--shape": "rounded-corner(8dp, 8dp, 8dp, 8dp)",
-    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)"
+    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)",
+    "--shape-chip": "rounded-corner(50%, 50%, 50%, 50%)"
   },
 
   "window": {
@@ -248,10 +249,33 @@
   },
   "clipboard-subheader": {
     "font-size": "14sp",
-    "margin": "6dp"
+    "margin": "6dp 10dp 6dp 6dp"
   },
   "clipboard-content": {
-    "padding": "10dp"
+    "padding": "10dp 0dp"
+  },
+  "clipboard-filter-row": {
+    "background": "var(--background-variant)",
+    "foreground": "var(--on-background)",
+    "padding": "0dp 0dp 4dp 0dp",
+    "shape": "var(--shape-variant)"
+  },
+  "clipboard-filter-chip": {
+    "background": "var(--surface)",
+    "foreground": "var(--on-surface)",
+    "margin": "4dp 4dp 0dp 4dp",
+    "padding": "8dp 4dp",
+    "shape": "var(--shape-chip)"
+  },
+  "clipboard-filter-chip[state=`active`]": {
+    "background": "var(--primary)",
+    "foreground": "var(--on-primary)"
+  },
+  "clipboard-filter-chip-text": {
+    "margin": "4dp 0dp 0dp 0dp"
+  },
+  "clipboard-grid": {
+    "shape": "var(--shape-variant)"
   },
   "clipboard-item": {
     "background": "var(--surface)",
@@ -283,6 +307,9 @@
   "clipboard-item-action": {
     "font-size": "16sp",
     "padding": "12dp"
+  },
+  "clipboard-item-action-text": {
+    "margin": "4dp 0dp 0dp 0dp"
   },
   "clipboard-clear-all-dialog": {
     "background": "var(--surface)",

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day.json
@@ -290,6 +290,10 @@
   "clipboard-item[type=`text`]": {
     "padding": "12dp 8dp"
   },
+  "clipboard-item-description": {
+    "font-size": "12sp",
+    "font-style": "italic"
+  },
   "clipboard-item-popup": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day_borderless.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_day_borderless.json
@@ -28,7 +28,8 @@
     "--on-surface-variant": "#5f5f5f",
 
     "--shape": "rounded-corner(8dp, 8dp, 8dp, 8dp)",
-    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)"
+    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)",
+    "--shape-chip": "rounded-corner(50%, 50%, 50%, 50%)"
   },
 
   "window": {
@@ -238,8 +239,7 @@
   },
 
   "clipboard-header": {
-    "background": "transparent",
-    "foreground": "var(--on-surface)",
+    "foreground": "var(--on-background)",
     "font-size": "16sp"
   },
   "clipboard-header-button": {
@@ -255,30 +255,65 @@
   },
   "clipboard-subheader": {
     "font-size": "14sp",
-    "margin": "6dp"
+    "margin": "6dp 10dp 6dp 6dp"
   },
   "clipboard-content": {
-    "padding": "10dp"
+    "padding": "10dp 0dp"
+  },
+  "clipboard-filter-row": {
+    "background": "var(--background-variant)",
+    "foreground": "var(--on-background)",
+    "padding": "0dp 0dp 4dp 0dp",
+    "shape": "var(--shape-variant)"
+  },
+  "clipboard-filter-chip": {
+    "background": "var(--surface)",
+    "foreground": "var(--on-surface)",
+    "margin": "4dp 4dp 0dp 4dp",
+    "padding": "8dp 4dp",
+    "shape": "var(--shape-chip)"
+  },
+  "clipboard-filter-chip[state=`active`]": {
+    "background": "var(--primary)",
+    "foreground": "var(--on-primary)"
+  },
+  "clipboard-filter-chip-text": {
+    "margin": "4dp 0dp 0dp 0dp"
+  },
+  "clipboard-grid": {
+    "shape": "var(--shape-variant)"
   },
   "clipboard-item": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp",
     "text-max-lines": "10",
     "text-overflow": "ellipsis"
+  },
+  "clipboard-item[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-description": {
+    "font-size": "12sp",
+    "font-style": "italic"
   },
   "clipboard-item-popup": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp"
+  },
+  "clipboard-item-popup[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-timestamp": {
+    "font-size": "11sp",
+    "padding": "16dp 8dp"
   },
   "clipboard-item-actions": {
     "background": "var(--surface)",
@@ -290,6 +325,9 @@
   "clipboard-item-action": {
     "font-size": "16sp",
     "padding": "12dp"
+  },
+  "clipboard-item-action-text": {
+    "margin": "4dp 0dp 0dp 0dp"
   },
   "clipboard-clear-all-dialog": {
     "background": "var(--surface)",

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night.json
@@ -23,7 +23,8 @@
     "--on-surface-variant": "#a0a0a0",
 
     "--shape": "rounded-corner(8dp, 8dp, 8dp, 8dp)",
-    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)"
+    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)",
+    "--shape-chip": "rounded-corner(50%, 50%, 50%, 50%)"
   },
 
   "window": {
@@ -243,30 +244,65 @@
   },
   "clipboard-subheader": {
     "font-size": "14sp",
-    "margin": "6dp"
+    "margin": "6dp 10dp 6dp 6dp"
   },
   "clipboard-content": {
-    "padding": "10dp"
+    "padding": "10dp 0dp"
+  },
+  "clipboard-filter-row": {
+    "background": "var(--background-variant)",
+    "foreground": "var(--on-background)",
+    "padding": "0dp 0dp 4dp 0dp",
+    "shape": "var(--shape-variant)"
+  },
+  "clipboard-filter-chip": {
+    "background": "var(--surface)",
+    "foreground": "var(--on-surface)",
+    "margin": "4dp 4dp 0dp 4dp",
+    "padding": "8dp 4dp",
+    "shape": "var(--shape-chip)"
+  },
+  "clipboard-filter-chip[state=`active`]": {
+    "background": "var(--primary)",
+    "foreground": "var(--on-primary)"
+  },
+  "clipboard-filter-chip-text": {
+    "margin": "4dp 0dp 0dp 0dp"
+  },
+  "clipboard-grid": {
+    "shape": "var(--shape-variant)"
   },
   "clipboard-item": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp",
     "text-max-lines": "10",
     "text-overflow": "ellipsis"
+  },
+  "clipboard-item[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-description": {
+    "font-size": "12sp",
+    "font-style": "italic"
   },
   "clipboard-item-popup": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp"
+  },
+  "clipboard-item-popup[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-timestamp": {
+    "font-size": "11sp",
+    "padding": "16dp 8dp"
   },
   "clipboard-item-actions": {
     "background": "var(--surface)",
@@ -278,6 +314,9 @@
   "clipboard-item-action": {
     "font-size": "16sp",
     "padding": "12dp"
+  },
+  "clipboard-item-action-text": {
+    "margin": "4dp 0dp 0dp 0dp"
   },
   "clipboard-clear-all-dialog": {
     "background": "var(--surface)",

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night_borderless.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_night_borderless.json
@@ -23,7 +23,8 @@
     "--on-surface-variant": "#a0a0a0",
 
     "--shape": "rounded-corner(8dp, 8dp, 8dp, 8dp)",
-    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)"
+    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)",
+    "--shape-chip": "rounded-corner(50%, 50%, 50%, 50%)"
   },
 
   "window": {
@@ -233,8 +234,7 @@
   },
 
   "clipboard-header": {
-    "background": "transparent",
-    "foreground": "var(--on-surface)",
+    "foreground": "var(--on-background)",
     "font-size": "16sp"
   },
   "clipboard-header-button": {
@@ -250,30 +250,65 @@
   },
   "clipboard-subheader": {
     "font-size": "14sp",
-    "margin": "6dp"
+    "margin": "6dp 10dp 6dp 6dp"
   },
   "clipboard-content": {
-    "padding": "10dp"
+    "padding": "10dp 0dp"
+  },
+  "clipboard-filter-row": {
+    "background": "var(--background-variant)",
+    "foreground": "var(--on-background)",
+    "padding": "0dp 0dp 4dp 0dp",
+    "shape": "var(--shape-variant)"
+  },
+  "clipboard-filter-chip": {
+    "background": "var(--surface)",
+    "foreground": "var(--on-surface)",
+    "margin": "4dp 4dp 0dp 4dp",
+    "padding": "8dp 4dp",
+    "shape": "var(--shape-chip)"
+  },
+  "clipboard-filter-chip[state=`active`]": {
+    "background": "var(--primary)",
+    "foreground": "var(--on-primary)"
+  },
+  "clipboard-filter-chip-text": {
+    "margin": "4dp 0dp 0dp 0dp"
+  },
+  "clipboard-grid": {
+    "shape": "var(--shape-variant)"
   },
   "clipboard-item": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp",
     "text-max-lines": "10",
     "text-overflow": "ellipsis"
+  },
+  "clipboard-item[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-description": {
+    "font-size": "12sp",
+    "font-style": "italic"
   },
   "clipboard-item-popup": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp"
+  },
+  "clipboard-item-popup[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-timestamp": {
+    "font-size": "11sp",
+    "padding": "16dp 8dp"
   },
   "clipboard-item-actions": {
     "background": "var(--surface)",
@@ -285,6 +320,9 @@
   "clipboard-item-action": {
     "font-size": "16sp",
     "padding": "12dp"
+  },
+  "clipboard-item-action-text": {
+    "margin": "4dp 0dp 0dp 0dp"
   },
   "clipboard-clear-all-dialog": {
     "background": "var(--surface)",

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night.json
@@ -23,7 +23,8 @@
     "--on-surface-variant": "#ffffff73",
 
     "--shape": "rounded-corner(8dp, 8dp, 8dp, 8dp)",
-    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)"
+    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)",
+    "--shape-chip": "rounded-corner(50%, 50%, 50%, 50%)"
   },
 
   "window": {
@@ -247,30 +248,65 @@
   },
   "clipboard-subheader": {
     "font-size": "14sp",
-    "margin": "6dp"
+    "margin": "6dp 10dp 6dp 6dp"
   },
   "clipboard-content": {
-    "padding": "10dp"
+    "padding": "10dp 0dp"
+  },
+  "clipboard-filter-row": {
+    "background": "var(--background-variant)",
+    "foreground": "var(--on-background)",
+    "padding": "0dp 0dp 4dp 0dp",
+    "shape": "var(--shape-variant)"
+  },
+  "clipboard-filter-chip": {
+    "background": "var(--surface)",
+    "foreground": "var(--on-surface)",
+    "margin": "4dp 4dp 0dp 4dp",
+    "padding": "8dp 4dp",
+    "shape": "var(--shape-chip)"
+  },
+  "clipboard-filter-chip[state=`active`]": {
+    "background": "var(--primary)",
+    "foreground": "var(--on-primary)"
+  },
+  "clipboard-filter-chip-text": {
+    "margin": "4dp 0dp 0dp 0dp"
+  },
+  "clipboard-grid": {
+    "shape": "var(--shape-variant)"
   },
   "clipboard-item": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp",
     "text-max-lines": "10",
     "text-overflow": "ellipsis"
+  },
+  "clipboard-item[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-description": {
+    "font-size": "12sp",
+    "font-style": "italic"
   },
   "clipboard-item-popup": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp"
+  },
+  "clipboard-item-popup[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-timestamp": {
+    "font-size": "11sp",
+    "padding": "16dp 8dp"
   },
   "clipboard-item-actions": {
     "background": "var(--surface)",
@@ -282,6 +318,9 @@
   "clipboard-item-action": {
     "font-size": "16sp",
     "padding": "12dp"
+  },
+  "clipboard-item-action-text": {
+    "margin": "4dp 0dp 0dp 0dp"
   },
   "clipboard-clear-all-dialog": {
     "background": "var(--surface)",

--- a/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night_borderless.json
+++ b/app/src/main/assets/ime/theme/org.florisboard.themes/stylesheets/floris_pure_night_borderless.json
@@ -23,7 +23,8 @@
     "--on-surface-variant": "#ffffff73",
 
     "--shape": "rounded-corner(8dp, 8dp, 8dp, 8dp)",
-    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)"
+    "--shape-variant": "rounded-corner(12dp, 12dp, 12dp, 12dp)",
+    "--shape-chip": "rounded-corner(50%, 50%, 50%, 50%)"
   },
 
   "window": {
@@ -233,8 +234,7 @@
   },
 
   "clipboard-header": {
-    "background": "transparent",
-    "foreground": "var(--on-surface)",
+    "foreground": "var(--on-background)",
     "font-size": "16sp"
   },
   "clipboard-header-button": {
@@ -250,30 +250,65 @@
   },
   "clipboard-subheader": {
     "font-size": "14sp",
-    "margin": "6dp"
+    "margin": "6dp 10dp 6dp 6dp"
   },
   "clipboard-content": {
-    "padding": "10dp"
+    "padding": "10dp 0dp"
+  },
+  "clipboard-filter-row": {
+    "background": "var(--background-variant)",
+    "foreground": "var(--on-background)",
+    "padding": "0dp 0dp 4dp 0dp",
+    "shape": "var(--shape-variant)"
+  },
+  "clipboard-filter-chip": {
+    "background": "var(--surface)",
+    "foreground": "var(--on-surface)",
+    "margin": "4dp 4dp 0dp 4dp",
+    "padding": "8dp 4dp",
+    "shape": "var(--shape-chip)"
+  },
+  "clipboard-filter-chip[state=`active`]": {
+    "background": "var(--primary)",
+    "foreground": "var(--on-primary)"
+  },
+  "clipboard-filter-chip-text": {
+    "margin": "4dp 0dp 0dp 0dp"
+  },
+  "clipboard-grid": {
+    "shape": "var(--shape-variant)"
   },
   "clipboard-item": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp",
     "text-max-lines": "10",
     "text-overflow": "ellipsis"
+  },
+  "clipboard-item[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-description": {
+    "font-size": "12sp",
+    "font-style": "italic"
   },
   "clipboard-item-popup": {
     "background": "var(--surface)",
     "foreground": "var(--on-surface)",
     "font-size": "14sp",
     "margin": "4dp",
-    "padding": "12dp 8dp",
     "shape": "var(--shape-variant)",
     "shadow-elevation": "2dp"
+  },
+  "clipboard-item-popup[type=`text`]": {
+    "padding": "12dp 8dp"
+  },
+  "clipboard-item-timestamp": {
+    "font-size": "11sp",
+    "padding": "16dp 8dp"
   },
   "clipboard-item-actions": {
     "background": "var(--surface)",
@@ -285,6 +320,9 @@
   "clipboard-item-action": {
     "font-size": "16sp",
     "padding": "12dp"
+  },
+  "clipboard-item-action-text": {
+    "margin": "4dp 0dp 0dp 0dp"
   },
   "clipboard-clear-all-dialog": {
     "background": "var(--surface)",

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardInputLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardInputLayout.kt
@@ -25,7 +25,6 @@ import android.util.Size
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -102,6 +101,7 @@ import dev.patrickgold.florisboard.ime.smartbar.VerticalExitTransition
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import dev.patrickgold.florisboard.ime.theme.FlorisImeUi
 import dev.patrickgold.florisboard.keyboardManager
+import dev.patrickgold.florisboard.lib.compose.LocalLocalizedDateTimeFormatter
 import dev.patrickgold.florisboard.lib.compose.autoMirrorForRtl
 import dev.patrickgold.florisboard.lib.compose.florisHorizontalScroll
 import dev.patrickgold.florisboard.lib.compose.florisVerticalScroll
@@ -125,6 +125,7 @@ import org.florisboard.lib.snygg.ui.SnyggIcon
 import org.florisboard.lib.snygg.ui.SnyggIconButton
 import org.florisboard.lib.snygg.ui.SnyggRow
 import org.florisboard.lib.snygg.ui.SnyggText
+import java.time.Instant
 
 private val ItemWidth = 200.dp
 private val DialogWidth = 240.dp
@@ -249,7 +250,6 @@ fun ClipboardInputLayout(
         }
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
     @Composable
     fun ClipItemView(
         elementName: String,
@@ -492,41 +492,52 @@ fun ClipboardInputLayout(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceAround,
                 ) {
-                    ClipItemView(
-                        elementName = FlorisImeUi.ClipboardItemPopup.elementName,
-                        modifier = Modifier.widthIn(max = ItemWidth),
-                        item = popupItem!!,
-                        contentScrollInsteadOfClip = true,
-                    )
-                    SnyggColumn(FlorisImeUi.ClipboardItemActions.elementName) {
-                        PopupAction(
-                            icon = Icons.Outlined.PushPin,
-                            text = stringRes(if (popupItem!!.isPinned) {
-                                R.string.clip__unpin_item
-                            } else {
-                                R.string.clip__pin_item
-                            }),
-                        ) {
-                            if (popupItem!!.isPinned) {
-                                clipboardManager.unpinClip(popupItem!!)
-                            } else {
-                                clipboardManager.pinClip(popupItem!!)
+                    SnyggColumn(modifier = Modifier.weight(0.5f)) {
+                        ClipItemView(
+                            elementName = FlorisImeUi.ClipboardItemPopup.elementName,
+                            modifier = Modifier.widthIn(max = ItemWidth),
+                            item = popupItem!!,
+                            contentScrollInsteadOfClip = true,
+                        )
+                        SnyggBox(FlorisImeUi.ClipboardItemTimestamp.elementName) {
+                            val formatter = LocalLocalizedDateTimeFormatter.current
+                            SnyggText(
+                                modifier = Modifier.fillMaxWidth(),
+                                text = formatter.format(Instant.ofEpochMilli(popupItem!!.creationTimestampMs)),
+                            )
+                        }
+                    }
+                    SnyggColumn(modifier = Modifier.weight(0.5f)) {
+                        SnyggColumn(FlorisImeUi.ClipboardItemActions.elementName) {
+                            PopupAction(
+                                icon = Icons.Outlined.PushPin,
+                                text = stringRes(if (popupItem!!.isPinned) {
+                                    R.string.clip__unpin_item
+                                } else {
+                                    R.string.clip__pin_item
+                                }),
+                            ) {
+                                if (popupItem!!.isPinned) {
+                                    clipboardManager.unpinClip(popupItem!!)
+                                } else {
+                                    clipboardManager.pinClip(popupItem!!)
+                                }
+                                popupItem = null
                             }
-                            popupItem = null
-                        }
-                        PopupAction(
-                            icon = Icons.Default.Delete,
-                            text = stringRes(R.string.clip__delete_item),
-                        ) {
-                            clipboardManager.deleteClip(popupItem!!)
-                            popupItem = null
-                        }
-                        PopupAction(
-                            icon = Icons.Outlined.ContentPaste,
-                            text = stringRes(R.string.clip__paste_item),
-                        ) {
-                            clipboardManager.pasteItem(popupItem!!)
-                            popupItem = null
+                            PopupAction(
+                                icon = Icons.Default.Delete,
+                                text = stringRes(R.string.clip__delete_item),
+                            ) {
+                                clipboardManager.deleteClip(popupItem!!)
+                                popupItem = null
+                            }
+                            PopupAction(
+                                icon = Icons.Outlined.ContentPaste,
+                                text = stringRes(R.string.clip__paste_item),
+                            ) {
+                                clipboardManager.pasteItem(popupItem!!)
+                                popupItem = null
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardInputLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardInputLayout.kt
@@ -49,6 +49,8 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.items
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -108,6 +110,7 @@ import dev.patrickgold.florisboard.lib.observeAsTransformingState
 import dev.patrickgold.florisboard.lib.util.NetworkUtils
 import dev.patrickgold.jetpref.datastore.model.observeAsState
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import org.florisboard.lib.android.AndroidKeyguardManager
 import org.florisboard.lib.android.AndroidVersion
 import org.florisboard.lib.android.showShortToast
@@ -119,6 +122,7 @@ import org.florisboard.lib.snygg.ui.SnyggIcon
 import org.florisboard.lib.snygg.ui.SnyggIconButton
 import org.florisboard.lib.snygg.ui.SnyggRow
 import org.florisboard.lib.snygg.ui.SnyggText
+import java.util.Objects
 
 private val ItemWidth = 200.dp
 private val DialogWidth = 240.dp
@@ -152,6 +156,7 @@ fun ClipboardInputLayout(
         }
     }
 
+    val gridState = rememberLazyStaggeredGridState()
     var popupItem by remember(history) { mutableStateOf<ClipboardItem?>(null) }
     var showClearAllHistory by remember { mutableStateOf(false) }
 
@@ -162,6 +167,10 @@ fun ClipboardInputLayout(
         if (!isFilterRowShown) {
             activeFilterTypes.clear()
         }
+    }
+
+    LaunchedEffect(activeFilterTypes.toSet()) {
+        gridState.scrollToItem(0)
     }
 
     @Composable
@@ -246,7 +255,11 @@ fun ClipboardInputLayout(
         contentScrollInsteadOfClip: Boolean,
         modifier: Modifier = Modifier,
     ) {
-        SnyggBox(elementName,
+        SnyggBox(
+            elementName = elementName,
+            attributes = remember(item) {
+                mapOf("type" to item.type.toString().lowercase())
+            },
             modifier = modifier.fillMaxWidth(),
             clickAndSemanticsModifier = Modifier.combinedClickable(
                 interactionSource = remember { MutableInteractionSource() },
@@ -455,6 +468,7 @@ fun ClipboardInputLayout(
                 ) {
                     LazyVerticalStaggeredGrid(
                         modifier = Modifier.fillMaxSize(),
+                        state = gridState,
                         columns = staggeredGridCells,
                     ) {
                         clipboardItems(

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardInputLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardInputLayout.kt
@@ -29,7 +29,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -50,7 +49,6 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -110,19 +108,18 @@ import dev.patrickgold.florisboard.lib.observeAsTransformingState
 import dev.patrickgold.florisboard.lib.util.NetworkUtils
 import dev.patrickgold.jetpref.datastore.model.observeAsState
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import org.florisboard.lib.android.AndroidKeyguardManager
 import org.florisboard.lib.android.AndroidVersion
 import org.florisboard.lib.android.showShortToast
 import org.florisboard.lib.android.systemService
 import org.florisboard.lib.snygg.ui.SnyggBox
 import org.florisboard.lib.snygg.ui.SnyggButton
+import org.florisboard.lib.snygg.ui.SnyggChip
 import org.florisboard.lib.snygg.ui.SnyggColumn
 import org.florisboard.lib.snygg.ui.SnyggIcon
 import org.florisboard.lib.snygg.ui.SnyggIconButton
 import org.florisboard.lib.snygg.ui.SnyggRow
 import org.florisboard.lib.snygg.ui.SnyggText
-import java.util.Objects
 
 private val ItemWidth = 200.dp
 private val DialogWidth = 240.dp
@@ -404,7 +401,7 @@ fun ClipboardInputLayout(
                         clickAndSemanticsModifier = Modifier.florisHorizontalScroll(),
                     ) {
                         @Composable
-                        fun Chip(
+                        fun FilterChip(
                             imageVector: ImageVector,
                             text: String,
                             itemType: ItemType,
@@ -416,45 +413,30 @@ fun ClipboardInputLayout(
                                     "type" to itemType.toString().lowercase(),
                                 )
                             }
-                            SnyggRow(
+                            SnyggChip(
                                 elementName = FlorisImeUi.ClipboardFilterChip.elementName,
                                 attributes = attributes,
-                                clickAndSemanticsModifier = Modifier
-                                    .clickable(
-                                        interactionSource = null,
-                                        indication = ripple(),
-                                        onClick = {
-                                            if (!activeFilterTypes.add(itemType)) {
-                                                activeFilterTypes.remove(itemType)
-                                            }
-                                        },
-                                    ),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                SnyggIcon(
-                                    elementName = FlorisImeUi.ClipboardFilterChipIcon.elementName,
-                                    attributes = attributes,
-                                    imageVector = imageVector,
-                                )
-                                SnyggText(
-                                    elementName = FlorisImeUi.ClipboardFilterChipText.elementName,
-                                    attributes = attributes,
-                                    text = text,
-                                )
-                            }
+                                onClick = {
+                                    if (!activeFilterTypes.add(itemType)) {
+                                        activeFilterTypes.remove(itemType)
+                                    }
+                                },
+                                imageVector = imageVector,
+                                text = text,
+                            )
                         }
 
-                        Chip(
+                        FilterChip(
                             imageVector = Icons.Default.TextFields,
                             text = "Text",
                             itemType = ItemType.TEXT,
                         )
-                        Chip(
+                        FilterChip(
                             imageVector = Icons.Default.Image,
                             text = "Images",
                             itemType = ItemType.IMAGE,
                         )
-                        Chip(
+                        FilterChip(
                             imageVector = Icons.Default.Movie,
                             text = "Videos",
                             itemType = ItemType.VIDEO,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/Smartbar.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/Smartbar.kt
@@ -73,10 +73,10 @@ import org.florisboard.lib.snygg.ui.SnyggIconButton
 import org.florisboard.lib.snygg.ui.SnyggRow
 import org.florisboard.lib.snygg.ui.rememberSnyggThemeQuery
 
-private const val AnimationDuration = 200
+const val AnimationDuration = 200
 
-private val VerticalEnterTransition = EnterTransition.verticalTween(AnimationDuration)
-private val VerticalExitTransition = ExitTransition.verticalTween(AnimationDuration)
+val VerticalEnterTransition = EnterTransition.verticalTween(AnimationDuration)
+val VerticalExitTransition = ExitTransition.verticalTween(AnimationDuration)
 
 private val HorizontalEnterTransition = EnterTransition.horizontalTween(AnimationDuration)
 private val HorizontalExitTransition = ExitTransition.horizontalTween(AnimationDuration)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeUi.kt
@@ -93,6 +93,10 @@ enum class FlorisImeUi(val elementName: String, val resId: Int?) {
         elementName = "clipboard-item",
         resId = R.string.snygg__rule_element__clipboard_item,
     ),
+    ClipboardItemDescription(
+        elementName = "clipboard-item-description",
+        resId = R.string.snygg__rule_element__clipboard_item_description,
+    ),
     ClipboardItemPopup(
         elementName = "clipboard-item-popup",
         resId = R.string.snygg__rule_element__clipboard_item_popup,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeUi.kt
@@ -69,6 +69,26 @@ enum class FlorisImeUi(val elementName: String, val resId: Int?) {
         elementName = "clipboard-content",
         resId = R.string.snygg__rule_element__clipboard_content,
     ),
+    ClipboardFilterRow(
+        elementName = "clipboard-filter-row",
+        resId = R.string.snygg__rule_element__clipboard_filter_row,
+    ),
+    ClipboardFilterChip(
+        elementName = "clipboard-filter-chip",
+        resId = R.string.snygg__rule_element__clipboard_filter_chip,
+    ),
+    ClipboardFilterChipIcon(
+        elementName = "clipboard-filter-chip-icon",
+        resId = R.string.snygg__rule_element__clipboard_filter_chip_icon,
+    ),
+    ClipboardFilterChipText(
+        elementName = "clipboard-filter-chip-text",
+        resId = R.string.snygg__rule_element__clipboard_filter_chip_text,
+    ),
+    ClipboardGrid(
+        elementName = "clipboard-grid",
+        resId = R.string.snygg__rule_element__clipboard_grid,
+    ),
     ClipboardItem(
         elementName = "clipboard-item",
         resId = R.string.snygg__rule_element__clipboard_item,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/FlorisImeUi.kt
@@ -101,6 +101,10 @@ enum class FlorisImeUi(val elementName: String, val resId: Int?) {
         elementName = "clipboard-item-popup",
         resId = R.string.snygg__rule_element__clipboard_item_popup,
     ),
+    ClipboardItemTimestamp(
+        elementName = "clipboard-item-timestamp",
+        resId = R.string.snygg__rule_element__clipboard_item_timestamp,
+    ),
     ClipboardItemActions(
         elementName = "clipboard-item-actions",
         resId = R.string.snygg__rule_element__clipboard_item_actions,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/Resources.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/Resources.kt
@@ -22,6 +22,7 @@ import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
@@ -29,6 +30,10 @@ import androidx.compose.ui.unit.LayoutDirection
 import dev.patrickgold.florisboard.R
 import org.florisboard.lib.kotlin.CurlyArg
 import org.florisboard.lib.kotlin.curlyFormat
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.*
 
 private val LocalResourcesContext = staticCompositionLocalOf<Context> {
     error("resources context not initialized!!")
@@ -36,6 +41,13 @@ private val LocalResourcesContext = staticCompositionLocalOf<Context> {
 
 private val LocalAppNameString = staticCompositionLocalOf {
     "FlorisBoard"
+}
+
+internal val LocalLocalizedDateTimeFormatter = staticCompositionLocalOf {
+    DateTimeFormatter
+        .ofLocalizedDateTime(FormatStyle.MEDIUM)
+        .withLocale(Locale.ROOT)
+        .withZone(ZoneId.systemDefault())
 }
 
 @Composable
@@ -49,8 +61,16 @@ fun ProvideLocalizedResources(
         View.LAYOUT_DIRECTION_RTL -> LayoutDirection.Rtl
         else -> error("Given configuration specifies invalid layout direction!")
     }
+    val localeList = resourcesContext.resources.configuration.locales
+    val dateTimeFormatter = remember(resourcesContext) {
+        DateTimeFormatter
+            .ofLocalizedDateTime(FormatStyle.MEDIUM)
+            .withLocale(if (localeList.isEmpty) Locale.getDefault() else localeList.get(0))
+            .withZone(ZoneId.systemDefault())
+    }
     CompositionLocalProvider(
         LocalResourcesContext provides resourcesContext,
+        LocalLocalizedDateTimeFormatter provides dateTimeFormatter,
         LocalLayoutDirection provides layoutDirection,
         LocalAppNameString provides stringResource(R.string.floris_app_name),
     ) {

--- a/app/src/main/res/drawable/ic_content_paste.xml
+++ b/app/src/main/res/drawable/ic_content_paste.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#000000" android:pathData="M19,2h-4.18C14.4,0.84 13.3,0 12,0c-1.3,0 -2.4,0.84 -2.82,2L5,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,4c0,-1.1 -0.9,-2 -2,-2zM12,2c0.55,0 1,0.45 1,1s-0.45,1 -1,1 -1,-0.45 -1,-1 0.45,-1 1,-1zM19,20L5,20L5,4h2v3h10L17,4h2v16z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#000000" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_email.xml
+++ b/app/src/main/res/drawable/ic_email.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#000000" android:pathData="M22,6c0,-1.1 -0.9,-2 -2,-2L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6zM20,6l-8,5 -8,-5h16zM20,18L4,18L4,8l8,5 8,-5v10z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_link.xml
+++ b/app/src/main/res/drawable/ic_link.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#000000" android:pathData="M3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4L11,7L7,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9L7,15.1c-1.71,0 -3.1,-1.39 -3.1,-3.1zM8,13h8v-2L8,11v2zM17,7h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1s-1.39,3.1 -3.1,3.1h-4L13,17h4c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_phone.xml
+++ b/app/src/main/res/drawable/ic_phone.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#000000" android:pathData="M6.62,10.79c1.44,2.83 3.76,5.14 6.59,6.59l2.2,-2.2c0.27,-0.27 0.67,-0.36 1.02,-0.24 1.12,0.37 2.33,0.57 3.57,0.57 0.55,0 1,0.45 1,1V20c0,0.55 -0.45,1 -1,1 -9.39,0 -17,-7.61 -17,-17 0,-0.55 0.45,-1 1,-1h3.5c0.55,0 1,0.45 1,1 0,1.25 0.2,2.45 0.57,3.57 0.11,0.35 0.03,0.74 -0.25,1.02l-2.2,2.2z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_pin.xml
+++ b/app/src/main/res/drawable/ic_pin.xml
@@ -1,6 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp" android:height="24dp"
-    android:viewportWidth="24" android:viewportHeight="24"
-    android:autoMirrored="true">
-    <path android:fillColor="#000000" android:pathData="M14,4v5c0,1.12,0.37,2.16,1,3H9c0.65-0.86,1-1.9,1-3V4H14 M17,2H7C6.45,2,6,2.45,6,3c0,0.55,0.45,1,1,1c0,0,0,0,0,0l1,0v5 c0,1.66-1.34,3-3,3v2h5.97v7l1,1l1-1v-7H19v-2c0,0,0,0,0,0c-1.66,0-3-1.34-3-3V4l1,0c0,0,0,0,0,0c0.55,0,1-0.45,1-1 C18,2.45,17.55,2,17,2L17,2z"/>
-</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,6 +236,11 @@
     <string name="snygg__rule_element__clipboard_header_text">Clipboard header text</string>
     <string name="snygg__rule_element__clipboard_subheader">Clipboard subheader</string>
     <string name="snygg__rule_element__clipboard_content">Clipboard content</string>
+    <string name="snygg__rule_element__clipboard_filter_row">Clipboard filter row</string>
+    <string name="snygg__rule_element__clipboard_filter_chip">Clipboard filter chip</string>
+    <string name="snygg__rule_element__clipboard_filter_chip_icon">Clipboard filter chip icon</string>
+    <string name="snygg__rule_element__clipboard_filter_chip_text">Clipboard filter chip text</string>
+    <string name="snygg__rule_element__clipboard_grid">Clipboard grid</string>
     <string name="snygg__rule_element__clipboard_item">Clipboard item</string>
     <string name="snygg__rule_element__clipboard_item_popup">Clipboard item popup</string>
     <string name="snygg__rule_element__clipboard_item_actions">Clipboard item actions</string>
@@ -680,7 +685,7 @@
     <string name="clipboard__cleared_primary_clip">Cleared primary clip</string>
     <string name="clipboard__cleared_history">Cleared history</string>
     <string name="clipboard__cleared_full_history">Cleared full history</string>
-    <string name="clipboard__confirm_clear_history__message">Are you sure you want to clear your clipboard history?</string>
+    <string name="clipboard__confirm_clear_history__message">Are you sure you want to clear your clipboard history? This will clear all items except pinned ones, regardless of active filters.</string>
     <string name="settings__clipboard__title">Clipboard</string>
     <string name="pref__clipboard__use_internal_clipboard__label">Use internal clipboard</string>
     <string name="pref__clipboard__use_internal_clipboard__summary">Use an internal clipboard instead of the system clipboard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,6 +244,7 @@
     <string name="snygg__rule_element__clipboard_item">Clipboard item</string>
     <string name="snygg__rule_element__clipboard_item_description">Clipboard item description</string>
     <string name="snygg__rule_element__clipboard_item_popup">Clipboard item popup</string>
+    <string name="snygg__rule_element__clipboard_item_timestamp">Clipboard item timestamp</string>
     <string name="snygg__rule_element__clipboard_item_actions">Clipboard item actions</string>
     <string name="snygg__rule_element__clipboard_item_action">Clipboard item action</string>
     <string name="snygg__rule_element__clipboard_item_action_icon">Clipboard item action icon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,7 @@
     <string name="snygg__rule_element__clipboard_filter_chip_text">Clipboard filter chip text</string>
     <string name="snygg__rule_element__clipboard_grid">Clipboard grid</string>
     <string name="snygg__rule_element__clipboard_item">Clipboard item</string>
+    <string name="snygg__rule_element__clipboard_item_description">Clipboard item description</string>
     <string name="snygg__rule_element__clipboard_item_popup">Clipboard item popup</string>
     <string name="snygg__rule_element__clipboard_item_actions">Clipboard item actions</string>
     <string name="snygg__rule_element__clipboard_item_action">Clipboard item action</string>

--- a/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggChip.kt
+++ b/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggChip.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.snygg.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.florisboard.lib.snygg.SnyggQueryAttributes
+import org.florisboard.lib.snygg.SnyggSelector
+import org.florisboard.lib.snygg.SnyggStylesheet
+
+/**
+ * Simple layout composable that places its children in a horizontal sequence.
+ *
+ * This composable infers its style from the current [SnyggTheme][org.florisboard.lib.snygg.SnyggTheme], which is
+ * required to be provided by [ProvideSnyggTheme].
+ *
+ * @param elementName The name of this element. If `null` the style will be inherited from the parent element.
+ * @param attributes The attributes of the element used to refine the query.
+ * @param selector A specific SnyggSelector to query the style for.
+ * @param modifier The modifier to be applied to the Row.
+ * @param onClick The action that is executed on click
+ * @param enabled Weather the chip is enabled
+ * @param imageVector Icon
+ * @param text Text
+ *
+ * @since 0.5.0-alpha01
+ *
+ * @see [SnyggRow]
+ * @see [SnyggText]
+ * @see [SnyggIcon]
+ */
+@Composable
+fun SnyggChip(
+    elementName: String? = null,
+    attributes: SnyggQueryAttributes = emptyMap(),
+    selector: SnyggSelector? = null,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    imageVector: ImageVector? = null,
+    text: String,
+) {
+    SnyggChip(
+        elementName,
+        attributes,
+        selector,
+        modifier,
+        onClick,
+        enabled,
+        icon = if (imageVector == null) null else ({
+            SnyggIcon(
+                elementName = "$elementName-icon",
+                attributes = attributes,
+                selector = selector,
+                imageVector = imageVector,
+            )
+        }),
+        text = {
+            SnyggText(
+                elementName = "$elementName-text",
+                attributes = attributes,
+                selector = selector,
+                text = text,
+            )
+        },
+    )
+}
+
+@Composable
+internal fun SnyggChip(
+    elementName: String? = null,
+    attributes: SnyggQueryAttributes = emptyMap(),
+    selector: SnyggSelector? = null,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    icon: (@Composable () -> Unit)? = null,
+    text: (@Composable () -> Unit)? = null,
+) {
+    SnyggRow(
+        elementName = elementName,
+        attributes = attributes,
+        selector = selector,
+        modifier = modifier,
+        clickAndSemanticsModifier = Modifier
+            .clickable(
+                interactionSource = null,
+                indication = ripple(),
+                enabled = enabled,
+                onClick = onClick,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        icon?.invoke()
+        text?.invoke()
+    }
+}
+
+@Preview
+@Composable
+private fun SimpleSnyggChip() {
+    val stylesheet = SnyggStylesheet.v2 {
+        "preview-row" {
+            background = rgbaColor(255, 255, 255)
+            foreground = rgbaColor(255, 0, 0)
+            padding = padding(10.dp)
+        }
+        "chip" {
+            background = rgbaColor(255, 0, 0)
+            foreground = rgbaColor(255, 255, 255)
+            shape = roundedCornerShape(20, 20, 20, 20)
+        }
+    }
+    val theme = rememberSnyggTheme(stylesheet)
+
+    ProvideSnyggTheme(theme) {
+        SnyggRow("preview-row") {
+            SnyggChip(
+                elementName = "chip",
+                onClick = {},
+                text = "Hello",
+            )
+        }
+    }
+}

--- a/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggRow.kt
+++ b/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggRow.kt
@@ -39,6 +39,7 @@ import org.florisboard.lib.snygg.SnyggStylesheet
  * @param attributes The attributes of the element used to refine the query.
  * @param selector A specific SnyggSelector to query the style for.
  * @param modifier The modifier to be applied to the Row.
+ * @param clickAndSemanticsModifier The modifier to be applied to the layout after drawing the background.
  * @param horizontalArrangement The horizontal arrangement of the layout's children.
  * @param verticalAlignment The vertical alignment of the layout's children.
  * @param content The content of the Row
@@ -53,6 +54,7 @@ fun SnyggRow(
     attributes: SnyggQueryAttributes = emptyMap(),
     selector: SnyggSelector? = null,
     modifier: Modifier = Modifier,
+    clickAndSemanticsModifier: Modifier = Modifier,
     horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
     verticalAlignment: Alignment.Vertical = Alignment.Top,
     content: @Composable RowScope.() -> Unit,
@@ -64,6 +66,7 @@ fun SnyggRow(
                 .snyggShadow(style)
                 .snyggBorder(style)
                 .snyggBackground(style)
+                .then(clickAndSemanticsModifier)
                 .snyggPadding(style),
             horizontalArrangement = horizontalArrangement,
             verticalAlignment = verticalAlignment,


### PR DESCRIPTION
### Changes

- Add ability to filter the clipboard by media types (Closes: #2925)
- Add timestamp display to each clip item within focused popup (Closes: #2926)

### Changed elements

- Add `clipboard-filter-row`
- Add `clipboard-filter-chip`
- Add `clipboard-filter-chip-icon`
- Add `clipboard-filter-chip-text`
- Add `clipboard-grid`
- Add `clipboard-item-description`
- Add `clipboard-item-timestamp`

### Changed/Added attributes

- Add `type` with possible values `text`, `image`, `video`
  - Applicable to elements:
    - `clipboard-item`
    - `clipboard-item-popup`
    - `clipboard-item-description`
    - `clipboard-filter-chip`
    - `clipboard-filter-chip-icon`
    - `clipboard-filter-chip-text`
- Add `state` with possible values `active`, `inactive`
    - Applicable to elements:
      - `clipboard-filter-chip`
      - `clipboard-filter-chip-icon`
      - `clipboard-filter-chip-text`
- For now these specialized attributes are only controllable via directly editing the json stylesheets!