### PR TITLE
Add subscripts and missing fractions in number row popups

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/bengali.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/bengali.json
@@ -3,46 +3,52 @@
     { "code": 2535, "label": "১", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 2536, "label": "২", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 2537, "label": "৩", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 2538, "label": "৪", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 2539, "label": "৫", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 2540, "label": "৬", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 2542, "label": "৮", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 2543, "label": "৯", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 2534, "label": "০", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/devanagari.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/devanagari.json
@@ -3,46 +3,52 @@
     { "code": 2407, "label": "१", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 2408, "label": "२", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 2409, "label": "३", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 2410, "label": "४", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 2411, "label": "५", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 2412, "label": "६", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 2414, "label": "८", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 2415, "label": "९", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 2406, "label": "०", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/eastern_arabic.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/eastern_arabic.json
@@ -3,46 +3,52 @@
     { "code": 1633, "label": "١", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 1634, "label": "٢", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 1635, "label": "٣", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 1636, "label": "٤", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 1637, "label": "٥", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 1638, "label": "٦", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 1640, "label": "٨", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 1641, "label": "٩", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 1632, "label": "٠", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/gujarati.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/gujarati.json
@@ -3,46 +3,52 @@
     { "code": 2791, "label": "૧", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 2792, "label": "૨", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 2793, "label": "૩", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 2794, "label": "૪", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 2795, "label": "૫", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 2796, "label": "૬", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 2798, "label": "૮", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 2799, "label": "૯", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 2790, "label": "૦", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/gurmukhi.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/gurmukhi.json
@@ -3,46 +3,52 @@
     { "code": 2663, "label": "੧", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 2664, "label": "੨", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 2665, "label": "੩", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 2666, "label": "੪", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 2667, "label": "੫", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 2668, "label": "੬", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 2670, "label": "੮", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 2671, "label": "੯", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 2662, "label": "੦", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/kannada.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/kannada.json
@@ -3,46 +3,52 @@
     { "code": 3303, "label": "೧", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 3304, "label": "೨", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 3305, "label": "೩", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 3306, "label": "೪", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 3307, "label": "೫", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 3308, "label": "೬", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 3310, "label": "೮", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 3311, "label": "೯", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 3302, "label": "೦", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/malayalam.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/malayalam.json
@@ -3,46 +3,52 @@
     { "code": 3431, "label": "൧", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 3432, "label": "൨", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 3433, "label": "൩", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 3434, "label": "൪", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 3435, "label": "൫", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 3436, "label": "൬", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 3438, "label": "൮", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 3439, "label": "൯", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 3430, "label": "൦", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/oriya.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/oriya.json
@@ -3,46 +3,52 @@
     { "code": 2919, "label": "୧", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 2920, "label": "୨", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 2921, "label": "୩", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 2922, "label": "୪", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 2923, "label": "୫", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 2924, "label": "୬", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 2926, "label": "୮", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 2927, "label": "୯", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 2918, "label": "୦", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/persian.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/persian.json
@@ -3,46 +3,52 @@
     { "code": 1777, "label": "۱", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 1778, "label": "۲", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 1779, "label": "۳", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 1780, "label": "۴", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 1781, "label": "۵", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 1782, "label": "۶", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 1784, "label": "۸", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 1785, "label": "۹", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 1776, "label": "۰", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/tamil.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/tamil.json
@@ -3,46 +3,52 @@
     { "code": 3047, "label": "௧", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 3048, "label": "௨", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 3049, "label": "௩", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 3050, "label": "௪", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 3051, "label": "௫", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 3052, "label": "௬", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 3054, "label": "௮", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 3055, "label": "௯", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 3046, "label": "௦", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/telugu.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/telugu.json
@@ -3,46 +3,52 @@
     { "code": 3175, "label": "౧", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 3176, "label": "౨", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 3177, "label": "౩", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 3178, "label": "౪", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 3179, "label": "౫", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 3180, "label": "౬", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 3182, "label": "౮", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 3183, "label": "౯", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 3174, "label": "౦", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/thai.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/thai.json
@@ -27,10 +27,10 @@
     { "code":  3667, "label": "๓", "type": "numeric", "popup": {
       "main": { "code":  179, "label": "³" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
         { "code": 8323, "label": "₃"},
         { "code":  190, "label": "¾" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" }
       ]
     } },
     { "code":  3668, "label": "๔", "type": "numeric", "popup": {

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/thai.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/thai.json
@@ -3,20 +3,23 @@
     { "code":  3665, "label": "๑", "type": "numeric", "popup": {
       "main": { "code":  185, "label": "¹" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code":  3666, "label": "๒", "type": "numeric", "popup": {
       "main": { "code":  178, "label": "²" },
       "relevant": [
+        { "code": 8322, "label": "₂"},
         { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
@@ -25,6 +28,7 @@
       "main": { "code":  179, "label": "³" },
       "relevant": [
         { "code": 8535, "label": "⅗" },
+        { "code": 8323, "label": "₃"},
         { "code":  190, "label": "¾" },
         { "code": 8540, "label": "⅜" }
       ]
@@ -32,36 +36,50 @@
     { "code":  3668, "label": "๔", "type": "numeric", "popup": {
       "main": { "code": 8308, "label": "⁴" },
       "relevant": [
+        { "code": 8324, "label": "₄" },
         { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code":  3669, "label": "๕", "type": "numeric", "popup": {
       "main": { "code": 8309, "label": "⁵" },
       "relevant": [
+        { "code": 8325, "label": "₅" },
         { "code": 8538, "label": "⅚" },
         { "code": 8541, "label": "⅝" }
       ]
     } },
     { "code":  3670, "label": "๖", "type": "numeric", "popup": {
-      "main": { "code": 8310, "label": "⁶" }
+      "main": { "code": 8310, "label": "⁶" },
+      "relevant": [
+        { "code": 8326, "label": "₆" }
+      ]
     } },
     { "code":  3671, "label": "๗", "type": "numeric", "popup": {
       "main": { "code": 8311, "label": "⁷" },
       "relevant": [
+        { "code": 8327, "label": "₇" },
         { "code": 8542, "label": "⅞" }
       ]
     } },
     { "code":  3672, "label": "๘", "type": "numeric", "popup": {
-      "main": { "code": 8312, "label": "⁸" }
+      "main": { "code": 8312, "label": "⁸" },
+      "relevant": [
+        { "code": 8328, "label": "₈" }
+      ]
     } },
     { "code":  3673, "label": "๙", "type": "numeric", "popup": {
-      "main": { "code": 8313, "label": "⁹" }
+      "main": { "code": 8313, "label": "⁹" },
+      "relevant": [
+        { "code": 8329, "label": "₉" }
+      ]
     } },
     { "code":  3664, "label": "๐", "type": "numeric", "popup": {
       "main": { "code": 8304, "label": "⁰" },
       "relevant": [
         { "code": 8709, "label": "∅" },
-        { "code": 8319, "label": "ⁿ" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/warang_citi.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/warang_citi.json
@@ -3,46 +3,52 @@
     { "code": 71905, "label": "𑣡", "type": "numeric", "popup": {
       "main": { "code":   49, "label": "1" },
       "relevant": [
-        { "code": 8537, "label": "⅙" },
+        { "code": 8321, "label": "₁" },
         { "code": 8528, "label": "⅐" },
         { "code": 8539, "label": "⅛" },
         { "code": 8529, "label": "⅑" },
         { "code": 8530, "label": "⅒" },
+        { "code": 8543, "label": "⅟" },
         { "code":  185, "label": "¹" },
         { "code":  189, "label": "½" },
         { "code": 8531, "label": "⅓" },
         { "code":  188, "label": "¼" },
-        { "code": 8533, "label": "⅕" }
+        { "code": 8533, "label": "⅕" },
+        { "code": 8537, "label": "⅙" }
       ]
     } },
     { "code": 71906, "label": "𑣢", "type": "numeric", "popup": {
       "main": { "code":   50, "label": "2" },
       "relevant": [
-        { "code": 8532, "label": "⅔" },
+        { "code": 8322, "label": "₂"},
         { "code":  178, "label": "²" },
+        { "code": 8532, "label": "⅔" },
         { "code": 8534, "label": "⅖" }
       ]
     } },
     { "code": 71907, "label": "𑣣", "type": "numeric", "popup": {
       "main": { "code":   51, "label": "3" },
       "relevant": [
-        { "code": 8535, "label": "⅗" },
         { "code":  190, "label": "¾" },
-        { "code":  179, "label": "³" },
-        { "code": 8540, "label": "⅜" }
+        { "code": 8535, "label": "⅗" },
+        { "code": 8540, "label": "⅜" },
+        { "code": 8323, "label": "₃"},
+        { "code":  179, "label": "³" }
       ]
     } },
     { "code": 71908, "label": "𑣤", "type": "numeric", "popup": {
       "main": { "code":   52, "label": "4" },
       "relevant": [
-        { "code": 8536, "label": "⅘" },
-        { "code": 8308, "label": "⁴" }
+        { "code": 8324, "label": "₄" },
+        { "code": 8308, "label": "⁴" },
+        { "code": 8536, "label": "⅘" }
       ]
     } },
     { "code": 71909, "label": "𑣥", "type": "numeric", "popup": {
       "main": { "code":   53, "label": "5" },
       "relevant": [
         { "code": 8538, "label": "⅚" },
+        { "code": 8325, "label": "₅" },
         { "code": 8309, "label": "⁵" },
         { "code": 8541, "label": "⅝" }
       ]
@@ -50,6 +56,7 @@
     { "code": 71910, "label": "𑣦", "type": "numeric", "popup": {
       "main": { "code":   54, "label": "6" },
       "relevant": [
+        { "code": 8326, "label": "₆" },
         { "code": 8310, "label": "⁶" }
       ]
     } },
@@ -57,27 +64,32 @@
       "main": { "code":   55, "label": "7" },
       "relevant": [
         { "code": 8542, "label": "⅞" },
+        { "code": 8327, "label": "₇" },
         { "code": 8311, "label": "⁷" }
       ]
     } },
     { "code": 71912, "label": "𑣨", "type": "numeric", "popup": {
       "main": { "code":   56, "label": "8" },
       "relevant": [
+        { "code": 8328, "label": "₈" },
         { "code": 8312, "label": "⁸" }
       ]
     } },
     { "code": 71913, "label": "𑣩", "type": "numeric", "popup": {
       "main": { "code":   57, "label": "9" },
       "relevant": [
+        { "code": 8329, "label": "₉" },
         { "code": 8313, "label": "⁹" }
       ]
     } },
     { "code": 71904, "label": "𑣠", "type": "numeric", "popup": {
       "main": { "code":   48, "label": "0" },
       "relevant": [
-        { "code": 8319, "label": "ⁿ" },
         { "code": 8709, "label": "∅" },
-        { "code": 8304, "label": "⁰" }
+        { "code": 8319, "label": "ⁿ" },
+        { "code": 8304, "label": "⁰" },
+        { "code": 8585, "label": "↉" },
+        { "code": 8320, "label": "₀" }
       ]
     } }
   ]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/western_arabic.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/western_arabic.json
@@ -10,11 +10,13 @@
         "code": 49, "label": "1", "type": "numeric", "popup": {
           "main": { "code": 185, "label": "¹" },
           "relevant": [
+            { "code": 8321, "label": "₁" },
             { "code": 8537, "label": "⅙" },
             { "code": 8528, "label": "⅐" },
             { "code": 8539, "label": "⅛" },
             { "code": 8529, "label": "⅑" },
             { "code": 8530, "label": "⅒" },
+            { "code": 8543, "label": "⅟" },
             { "code":  189, "label": "½" },
             { "code": 8531, "label": "⅓" },
             { "code":  188, "label": "¼" },
@@ -29,6 +31,7 @@
         "code": 50, "label": "2", "type": "numeric", "popup": {
           "main": { "code": 178, "label": "²" },
           "relevant": [
+            { "code": 8322, "label": "₂"},
             { "code": 8532, "label": "⅔" },
             { "code": 8534, "label": "⅖" }
           ]
@@ -46,6 +49,7 @@
           "main": { "code": 179, "label": "³" },
           "relevant": [
             { "code": 8535, "label": "⅗" },
+            { "code": 8323, "label": "₃"},
             { "code":  190, "label": "¾" },
             { "code": 8540, "label": "⅜" }
           ]
@@ -68,6 +72,7 @@
         "code": 52, "label": "4", "type": "numeric", "popup": {
           "main": { "code": 8308, "label": "⁴" },
           "relevant": [
+            { "code": 8324, "label": "₄" },
             { "code": 8536, "label": "⅘" }
           ]
         }
@@ -86,6 +91,7 @@
         "code": 53, "label": "5", "type": "numeric", "popup": {
           "main": { "code": 8309, "label": "⁵" },
           "relevant": [
+            { "code": 8325, "label": "₅" },
             { "code": 8538, "label": "⅚" },
             { "code": 8541, "label": "⅝" }
           ]
@@ -105,7 +111,10 @@
       },
       "default": {
         "code": 54, "label": "6", "type": "numeric", "popup": {
-          "main": { "code": 8310, "label": "⁶" }
+          "main": { "code": 8310, "label": "⁶" },
+          "relevant": [
+            { "code": 8326, "label": "₆" }
+          ]
         }
       }
     },
@@ -115,6 +124,7 @@
         "code": 55, "label": "7", "type": "numeric", "popup": {
           "main": { "code": 8311, "label": "⁷" },
           "relevant": [
+            { "code": 8327, "label": "₇" },
             { "code": 8542, "label": "⅞" }
           ]
         }
@@ -132,7 +142,10 @@
       },
       "default": {
         "code": 56, "label": "8", "type": "numeric", "popup": {
-          "main": { "code": 8312, "label": "⁸" }
+          "main": { "code": 8312, "label": "⁸" },
+          "relevant": [
+            { "code": 8328, "label": "₈" }
+          ]
         }
       }
     },
@@ -160,7 +173,10 @@
       },
       "default": {
         "code":   57, "label": "9", "type": "numeric", "popup": {
-          "main": { "code": 8313, "label": "⁹" }
+          "main": { "code": 8313, "label": "⁹" },
+          "relevant": [
+            { "code": 8329, "label": "₉" }
+          ]
         }
       }
     },
@@ -191,7 +207,9 @@
           "main": { "code": 8304, "label": "⁰" },
           "relevant": [
             { "code": 8709, "label": "∅" },
-            { "code": 8319, "label": "ⁿ" }
+            { "code": 8319, "label": "ⁿ" },
+            { "code": 8585, "label": "↉" },
+            { "code": 8320, "label": "₀" }
           ]
         }
       }

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/western_arabic.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/western_arabic.json
@@ -11,7 +11,6 @@
           "main": { "code": 185, "label": "¹" },
           "relevant": [
             { "code": 8321, "label": "₁" },
-            { "code": 8537, "label": "⅙" },
             { "code": 8528, "label": "⅐" },
             { "code": 8539, "label": "⅛" },
             { "code": 8529, "label": "⅑" },
@@ -20,7 +19,8 @@
             { "code":  189, "label": "½" },
             { "code": 8531, "label": "⅓" },
             { "code":  188, "label": "¼" },
-            { "code": 8533, "label": "⅕" }
+            { "code": 8533, "label": "⅕" },
+            { "code": 8537, "label": "⅙" }
           ]
         }
       }

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/western_arabic.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/numericRow/western_arabic.json
@@ -48,10 +48,10 @@
         "code": 51, "label": "3", "type": "numeric", "popup": {
           "main": { "code": 179, "label": "³" },
           "relevant": [
-            { "code": 8535, "label": "⅗" },
+            { "code": 8540, "label": "⅜" },
             { "code": 8323, "label": "₃"},
             { "code":  190, "label": "¾" },
-            { "code": 8540, "label": "⅜" }
+            { "code": 8535, "label": "⅗" }
           ]
         }
       }


### PR DESCRIPTION
Added subscripts to the popups in the number row. Closes #2805.
Also added the two missing fractions `⅟` and `↉`.

In the Western Arabic and Thai layouts, the subscript is always directly to the left of the main popup, except for the key `1` since there is no space to the left: in this case the subscript is directly up. (Also, is it intended behaviour that Thai does not have the Western Arabic symbols `1`, `2`, ... in the popup? All other layouts have them as main popup symbol.)
The layouts CJK and neo2 are unchanged, since they did not have superscripts nor fractions (except superscript `1`,`2`, `3` in neo2). Let me know if you want me to change this.
In all other layouts, which have the Western Arabic digit as main popup, the subscript is always to the left and the superscript always to the right of the main popup, except `1`, which has the subscript directly up, and `0`, which has the superscript directly up.

Also let me know if the ordering of the various symbols in the popups is good.