### PR TITLE
Re-add time based theme switching

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -58,6 +58,7 @@ import dev.patrickgold.florisboard.lib.ext.ExtensionComponentName
 import dev.patrickgold.florisboard.lib.observeAsTransformingState
 import dev.patrickgold.florisboard.lib.util.VersionName
 import dev.patrickgold.jetpref.datastore.JetPref
+import dev.patrickgold.jetpref.datastore.model.LocalTime
 import dev.patrickgold.jetpref.datastore.model.PreferenceData
 import dev.patrickgold.jetpref.datastore.model.PreferenceMigrationEntry
 import dev.patrickgold.jetpref.datastore.model.PreferenceModel
@@ -749,14 +750,14 @@ class AppPrefs : PreferenceModel("florisboard-app-prefs") {
             },
             serializer = ColorPreferenceSerializer,
         )
-        //val sunriseTime = localTime(
-        //    key = "theme__sunrise_time",
-        //    default = LocalTime.of(6, 0),
-        //)
-        //val sunsetTime = localTime(
-        //    key = "theme__sunset_time",
-        //    default = LocalTime.of(18, 0),
-        //)
+        val sunriseTime = time(
+            key = "theme__sunrise_time",
+            default = LocalTime(6, 0),
+        )
+        val sunsetTime = time(
+            key = "theme__sunset_time",
+            default = LocalTime(18, 0),
+        )
         val editorColorRepresentation = enum(
             key = "theme__editor_color_representation",
             default = ColorRepresentation.HEX,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/theme/ThemeScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/theme/ThemeScreen.kt
@@ -94,13 +94,13 @@ fun ThemeScreen() = FlorisScreen {
         )
         LocalTimePickerPreference(
             pref = prefs.theme.sunriseTime,
-            title = "Sunrise Time",
+            title = stringRes(R.string.pref__theme__sunrise_time__label),
             icon = Icons.Default.WbTwilight,
             enabledIf = { prefs.theme.mode isEqualTo ThemeMode.FOLLOW_TIME },
         )
         LocalTimePickerPreference(
             pref = prefs.theme.sunsetTime,
-            title = "Sunset Time",
+            title = stringRes(R.string.pref__theme__sunset_time__label),
             icon = Icons.Default.Brightness2,
             enabledIf = { prefs.theme.mode isEqualTo ThemeMode.FOLLOW_TIME },
         )

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/theme/ThemeScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/theme/ThemeScreen.kt
@@ -16,19 +16,18 @@
 
 package dev.patrickgold.florisboard.app.settings.theme
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Brightness2
 import androidx.compose.material.icons.filled.BrightnessAuto
 import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.WbTwilight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.LocalNavController
 import dev.patrickgold.florisboard.app.Routes
@@ -37,7 +36,6 @@ import dev.patrickgold.florisboard.app.ext.AddonManagementReferenceBox
 import dev.patrickgold.florisboard.app.ext.ExtensionListScreenType
 import dev.patrickgold.florisboard.ime.theme.ThemeManager
 import dev.patrickgold.florisboard.ime.theme.ThemeMode
-import dev.patrickgold.florisboard.lib.compose.FlorisInfoCard
 import dev.patrickgold.florisboard.lib.compose.FlorisScreen
 import dev.patrickgold.florisboard.lib.compose.stringRes
 import dev.patrickgold.florisboard.lib.ext.ExtensionComponentName
@@ -45,6 +43,7 @@ import dev.patrickgold.florisboard.themeManager
 import dev.patrickgold.jetpref.datastore.model.observeAsState
 import dev.patrickgold.jetpref.datastore.ui.ColorPickerPreference
 import dev.patrickgold.jetpref.datastore.ui.ListPreference
+import dev.patrickgold.jetpref.datastore.ui.LocalTimePickerPreference
 import dev.patrickgold.jetpref.datastore.ui.Preference
 import dev.patrickgold.jetpref.datastore.ui.isMaterialYou
 import org.florisboard.lib.color.ColorMappings
@@ -66,20 +65,8 @@ fun ThemeScreen() = FlorisScreen {
     }
 
     content {
-        val themeMode by prefs.theme.mode.observeAsState()
         val dayThemeId by prefs.theme.dayThemeId.observeAsState()
         val nightThemeId by prefs.theme.nightThemeId.observeAsState()
-
-        /*Card(modifier = Modifier.padding(8.dp)) {
-            Column(modifier = Modifier.padding(8.dp)) {
-                Text("If you want to give feedback on the new stylesheet editor and theme engine, please do so in below linked feedback thread:\n")
-                Button(onClick = {
-                    context.launchUrl("https://github.com/florisboard/florisboard/discussions/1531")
-                }) {
-                    Text("Open Feedback Thread")
-                }
-            }
-        }*/
 
         ListPreference(
             prefs.theme.mode,
@@ -87,14 +74,6 @@ fun ThemeScreen() = FlorisScreen {
             title = stringRes(R.string.pref__theme__mode__label),
             entries = enumDisplayEntriesOf(ThemeMode::class),
         )
-        if (themeMode == ThemeMode.FOLLOW_TIME) {
-            FlorisInfoCard(
-                modifier = Modifier.padding(8.dp),
-                text = """
-                The theme mode "Follow time" is not available in this beta release.
-            """.trimIndent()
-            )
-        }
         Preference(
             icon = Icons.Default.LightMode,
             title = stringRes(R.string.pref__theme__day),
@@ -112,6 +91,18 @@ fun ThemeScreen() = FlorisScreen {
             onClick = {
                 navController.navigate(Routes.Settings.ThemeManager(ThemeManagerScreenAction.SELECT_NIGHT))
             },
+        )
+        LocalTimePickerPreference(
+            pref = prefs.theme.sunriseTime,
+            title = "Sunrise Time",
+            icon = Icons.Default.WbTwilight,
+            enabledIf = { prefs.theme.mode isEqualTo ThemeMode.FOLLOW_TIME },
+        )
+        LocalTimePickerPreference(
+            pref = prefs.theme.sunsetTime,
+            title = "Sunset Time",
+            icon = Icons.Default.Brightness2,
+            enabledIf = { prefs.theme.mode isEqualTo ThemeMode.FOLLOW_TIME },
         )
         ColorPickerPreference(
             pref = prefs.theme.accentColor,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/theme/ThemeManager.kt
@@ -50,7 +50,10 @@ import dev.patrickgold.florisboard.lib.devtools.flogInfo
 import dev.patrickgold.florisboard.lib.ext.ExtensionComponentName
 import dev.patrickgold.florisboard.lib.ext.ExtensionMeta
 import dev.patrickgold.florisboard.lib.io.ZipUtils
+import dev.patrickgold.florisboard.lib.util.TimeUtils.javaLocalTime
 import dev.patrickgold.florisboard.lib.util.ViewUtils
+import java.time.LocalTime
+import java.util.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -63,7 +66,6 @@ import org.florisboard.lib.kotlin.io.subDir
 import org.florisboard.lib.kotlin.io.subFile
 import org.florisboard.lib.snygg.SnyggStylesheet
 import org.florisboard.lib.snygg.value.SnyggStaticColorValue
-import java.util.UUID
 import kotlin.properties.Delegates
 
 /**
@@ -187,18 +189,14 @@ class ThemeManager(context: Context) {
                 prefs.theme.dayThemeId.get()
             }
             ThemeMode.FOLLOW_TIME -> {
-                //if (AndroidVersion.ATLEAST_API26_O) {
-                //    val current = LocalTime.now()
-                //    val sunrise = prefs.theme.sunriseTime.get()
-                //    val sunset = prefs.theme.sunsetTime.get()
-                //    if (current in sunrise..sunset) {
-                //        prefs.theme.dayThemeId.get()
-                //    } else {
-                //        prefs.theme.nightThemeId.get()
-                //    }
-                //} else {
+                val current = LocalTime.now()
+                val sunrise = prefs.theme.sunriseTime.get().javaLocalTime
+                val sunset = prefs.theme.sunsetTime.get().javaLocalTime
+                if (current in sunrise..sunset) {
+                    prefs.theme.dayThemeId.get()
+                } else {
                     prefs.theme.nightThemeId.get()
-                //}
+                }
             }
         }
     }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/util/TimeUtils.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/util/TimeUtils.kt
@@ -18,6 +18,7 @@ package dev.patrickgold.florisboard.lib.util
 
 import android.icu.text.SimpleDateFormat
 import dev.patrickgold.florisboard.lib.FlorisLocale
+import dev.patrickgold.jetpref.datastore.model.LocalTime
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 
@@ -27,4 +28,7 @@ object TimeUtils {
     fun currentUtcTimestamp(): CharSequence {
         return DateTimeFormatter.ISO_INSTANT.format(Instant.now())
     }
+
+    val LocalTime.javaLocalTime: java.time.LocalTime
+        get() = java.time.LocalTime.of(hour, minute)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ kotlinx-serialization-json = "1.8.1"
 ksp = "2.1.20-1.0.32"
 mikepenz-aboutlibraries = "12.1.2"
 patrickgold-compose-tooltip = "0.2.0-rc02"
-patrickgold-jetpref = "0.2.0-rc03"
+patrickgold-jetpref = "20250714T114059-SNAPSHOT"
 
 # Testing
 androidx-benchmark = "1.3.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ kotlinx-serialization-json = "1.8.1"
 ksp = "2.1.20-1.0.32"
 mikepenz-aboutlibraries = "12.1.2"
 patrickgold-compose-tooltip = "0.2.0-rc02"
-patrickgold-jetpref = "20250714T114059-SNAPSHOT"
+patrickgold-jetpref = "0.2.0-rc04"
 
 # Testing
 androidx-benchmark = "1.3.4"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         // Uncomment the following if testing snapshots from Maven Central
-        maven("https://central.sonatype.com/repository/maven-snapshots/")
+        // maven("https://central.sonatype.com/repository/maven-snapshots/")
         // Uncomment the following if testing snapshots from Maven Local
         // mavenLocal()
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,8 @@ dependencyResolutionManagement {
         mavenCentral()
         // Uncomment the following if testing snapshots from Maven Central
         maven("https://central.sonatype.com/repository/maven-snapshots/")
+        // Uncomment the following if testing snapshots from Maven Local
+        // mavenLocal()
     }
 }
 


### PR DESCRIPTION
This PR re-adds time based theme switching which was removed in https://github.com/florisboard/florisboard/commit/96e7f2eeacfd48c6f70901156df127f6e49ec8e5. 