### PR TITLE
Replace the usage of jetpref helper with official helper

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/ext/ExtensionEditScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/ext/ExtensionEditScreen.kt
@@ -42,7 +42,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.LocalNavController
@@ -85,7 +87,6 @@ import dev.patrickgold.florisboard.lib.io.ZipUtils
 import dev.patrickgold.florisboard.lib.rememberValidationResult
 import dev.patrickgold.florisboard.themeManager
 import dev.patrickgold.jetpref.datastore.ui.Preference
-import dev.patrickgold.jetpref.datastore.ui.vectorResource
 import dev.patrickgold.jetpref.material.ui.JetPrefAlertDialog
 import dev.patrickgold.jetpref.material.ui.JetPrefTextField
 import java.util.*
@@ -353,7 +354,7 @@ private fun EditScreen(
             )
             Preference(
                 onClick = { workspace.currentAction = EditorAction.ManageFiles },
-                icon = vectorResource(R.drawable.ic_file_blank),
+                icon = ImageVector.vectorResource(R.drawable.ic_file_blank),
                 title = stringRes(R.string.ext__editor__files__title),
             )
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/OtherScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/advanced/OtherScreen.kt
@@ -27,7 +27,9 @@ import androidx.compose.material.icons.filled.SettingsBackupRestore
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.vectorResource
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.AppTheme
 import dev.patrickgold.florisboard.app.LocalNavController
@@ -45,7 +47,6 @@ import dev.patrickgold.jetpref.datastore.ui.PreferenceGroup
 import dev.patrickgold.jetpref.datastore.ui.SwitchPreference
 import dev.patrickgold.jetpref.datastore.ui.isMaterialYou
 import dev.patrickgold.jetpref.datastore.ui.listPrefEntries
-import dev.patrickgold.jetpref.datastore.ui.vectorResource
 import org.florisboard.lib.android.AndroidVersion
 import org.florisboard.lib.color.ColorMappings
 
@@ -156,7 +157,7 @@ fun OtherScreen() = FlorisScreen {
             enabledIf = { AndroidVersion.ATMOST_API28_P },
         )
         Preference(
-            icon = vectorResource(R.drawable.ic_keyboard_keys),
+            icon = ImageVector.vectorResource(R.drawable.ic_keyboard_keys),
             title = stringRes(R.string.physical_keyboard__title),
             onClick = { navController.navigate(Routes.Settings.PhysicalKeyboard) },
         )

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/typing/TypingScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/typing/TypingScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.LocalNavController
@@ -42,13 +44,11 @@ import dev.patrickgold.florisboard.lib.compose.FlorisHyperlinkText
 import dev.patrickgold.florisboard.lib.compose.FlorisScreen
 import dev.patrickgold.florisboard.lib.compose.stringRes
 import dev.patrickgold.jetpref.datastore.model.observeAsState
-import dev.patrickgold.jetpref.datastore.ui.DialogSliderPreference
 import dev.patrickgold.jetpref.datastore.ui.ExperimentalJetPrefDatastoreUi
 import dev.patrickgold.jetpref.datastore.ui.ListPreference
 import dev.patrickgold.jetpref.datastore.ui.Preference
 import dev.patrickgold.jetpref.datastore.ui.PreferenceGroup
 import dev.patrickgold.jetpref.datastore.ui.SwitchPreference
-import dev.patrickgold.jetpref.datastore.ui.vectorResource
 import org.florisboard.lib.android.AndroidVersion
 
 @OptIn(ExperimentalJetPrefDatastoreUi::class)
@@ -89,7 +89,7 @@ fun TypingScreen() = FlorisScreen {
             )
             ListPreference(
                 prefs.suggestion.incognitoMode,
-                icon = vectorResource(id = R.drawable.ic_incognito),
+                icon = ImageVector.vectorResource(id = R.drawable.ic_incognito),
                 title = stringRes(R.string.pref__suggestion__incognito_mode__label),
                 entries = enumDisplayEntriesOf(IncognitoMode::class),
             )

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/ComputingEvaluator.kt
@@ -55,7 +55,7 @@ import dev.patrickgold.florisboard.ime.input.InputShiftState
 import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyType
 import dev.patrickgold.florisboard.lib.FlorisLocale
-import dev.patrickgold.jetpref.datastore.ui.vectorResource
+import dev.patrickgold.florisboard.lib.compose.vectorResource
 
 interface ComputingEvaluator {
     val version: Int

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/Smartbar.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/Smartbar.kt
@@ -49,7 +49,9 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.isUnspecified
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import dev.patrickgold.florisboard.R
 import dev.patrickgold.florisboard.app.FlorisPreferenceStore
@@ -64,7 +66,6 @@ import dev.patrickgold.florisboard.lib.compose.horizontalTween
 import dev.patrickgold.florisboard.lib.compose.verticalTween
 import dev.patrickgold.florisboard.nlpManager
 import dev.patrickgold.jetpref.datastore.model.observeAsState
-import dev.patrickgold.jetpref.datastore.ui.vectorResource
 import kotlinx.coroutines.launch
 import org.florisboard.lib.android.AndroidVersion
 import org.florisboard.lib.snygg.ui.SnyggBox
@@ -186,7 +187,7 @@ private fun SmartbarMainRow(modifier: Modifier = Modifier) {
             } else {
                 Icons.AutoMirrored.Default.KeyboardArrowRight
             }
-            val incognitoIcon = vectorResource(id = R.drawable.ic_incognito)
+            val incognitoIcon = ImageVector.vectorResource(id = R.drawable.ic_incognito)
             val incognitoDisplayMode = prefs.keyboard.incognitoDisplayMode.observeAsState()
             val isIncognitoMode = keyboardManager.activeState.isIncognitoMode
             val icon = if (isIncognitoMode) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/ImageVector.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/compose/ImageVector.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.lib.compose
+
+import android.content.Context
+import androidx.annotation.DrawableRes
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+
+fun Context.vectorResource(@DrawableRes id: Int): ImageVector? {
+    val theme = this.theme
+    return try {
+        ImageVector.vectorResource(theme = theme, resId = id, res = this.resources)
+    } catch (_: Exception) {
+        null
+    }
+}


### PR DESCRIPTION
Replace the jetpref image vector helper with the official one.
#### TODO: 
- [x] Remove the image vector helper from jetpref https://github.com/patrickgold/jetpref/pull/23