### PR TITLE
Allow emoji suggestion on emoji name and keyword

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
@@ -71,7 +71,7 @@ class EmojiSuggestionProvider(private val context: Context) : SuggestionProvider
         val candidates = withContext(Dispatchers.Default) {
             emojis.parallelStream()
                 .filter { emoji ->
-                    emoji.name.contains(query, ignoreCase = true) &&
+                    emoji.name.contains(query, ignoreCase = true) ||
                         emoji.keywords.any { it.contains(query, ignoreCase = true) }
                 }
                 .limit(maxCandidateCount.toLong())


### PR DESCRIPTION
## problem: some emojis like 'bubbles' aren't generated with their original name as a keyword. 
## solution: filtering "name OR keyword", instead of "name AND keyword" for emoji suggestions


> I would probably look at emojicon.py but i couldn't find where that is. Also this solves it without having to double up the original name as a keyword -- it feels safe to say since i can't imagine you wouldn't want the emoji name itself as a keyword always.