### PR TITLE
Add forward delete behavior

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -675,10 +675,13 @@ class FlorisImeService : LifecycleInputMethodService() {
         }
     }
 
-    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean =
-        if (keyboardManager.onHardwareKeyDown(keyCode, event)) true
-        else super.onKeyDown(keyCode, event)
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        return keyboardManager.onHardwareKeyDown(keyCode, event) || super.onKeyDown(keyCode, event)
+    }
 
+    override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        return keyboardManager.onHardwareKeyUp(keyCode, event) || super.onKeyUp(keyCode, event)
+    }
 
     private inner class ComposeInputView : AbstractComposeView(this) {
         init {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -866,6 +866,20 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                 handleEnter()
                 return true
             }
+            KeyEvent.KEYCODE_SHIFT_LEFT, KeyEvent.KEYCODE_SHIFT_RIGHT -> {
+                inputEventDispatcher.sendDown(TextKeyData.SHIFT)
+                return true
+            }
+            else -> return false
+        }
+    }
+
+    fun onHardwareKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        when (keyCode) {
+            KeyEvent.KEYCODE_SHIFT_LEFT, KeyEvent.KEYCODE_SHIFT_RIGHT -> {
+                inputEventDispatcher.sendUp(TextKeyData.SHIFT)
+                return true
+            }
             else -> return false
         }
     }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
@@ -59,6 +59,7 @@ import dev.patrickgold.florisboard.FlorisImeService
 import dev.patrickgold.florisboard.app.FlorisPreferenceStore
 import dev.patrickgold.florisboard.editorInstance
 import dev.patrickgold.florisboard.glideTypingManager
+import dev.patrickgold.florisboard.ime.editor.OperationUnit
 import dev.patrickgold.florisboard.ime.input.InputEventDispatcher
 import dev.patrickgold.florisboard.ime.keyboard.ComputingEvaluator
 import dev.patrickgold.florisboard.ime.keyboard.FlorisImeSizing
@@ -498,7 +499,7 @@ private class TextKeyboardLayoutController(
                         if (pointer.hasTriggeredGestureMove && pointer.initialKey?.computedData?.code == KeyCode.DELETE) {
                             val selection = editorInstance.activeContent.selection
                             if (selection.isSelectionMode) {
-                                editorInstance.deleteBackwards()
+                                editorInstance.deleteBackwards(OperationUnit.CHARACTERS)
                             }
                         }
                         onTouchCancelInternal(event, pointer)
@@ -521,7 +522,7 @@ private class TextKeyboardLayoutController(
                                 prefs.gestures.deleteKeySwipeLeft.get() != SwipeAction.SELECT_WORDS_PRECISELY) {
                                 val selection = editorInstance.activeContent.selection
                                 if (selection.isSelectionMode) {
-                                    editorInstance.deleteBackwards()
+                                    editorInstance.deleteBackwards(OperationUnit.CHARACTERS)
                                 }
                             }
                             onTouchCancelInternal(event, pointer)
@@ -765,10 +766,19 @@ private class TextKeyboardLayoutController(
                     }
                     val activeSelection = editorInstance.activeContent.selection
                     if (activeSelection.isValid) {
-                        editorInstance.setSelection(
-                            (activeSelection.end + event.absUnitCountX + 1).coerceIn(0, activeSelection.end),
-                            activeSelection.end,
-                        )
+                        if (inputEventDispatcher.isPressed(KeyCode.SHIFT)) {
+                            // Forward select
+                            editorInstance.setSelection(
+                                activeSelection.start,
+                                (activeSelection.start - event.absUnitCountX + 1).coerceAtLeast(activeSelection.start),
+                            )
+                        } else {
+                            // Backward select
+                            editorInstance.setSelection(
+                                (activeSelection.end + event.absUnitCountX + 1).coerceIn(0, activeSelection.end),
+                                activeSelection.end,
+                            )
+                        }
                     }
                     true
                 }


### PR DESCRIPTION
Add forward delete behavior to the existing delete key setup. Implementation details:

delete key | shift? | behavior
---|---|---
tap | no | deletes 1 char/word before cursor
tap | yes | deletes 1 char/word after cursor
tap&hold | no | deletes N chars/words fast before cursor
tap&hold | yes | deletes N chars/words fast after cursor
swipe | no | selects N chars/words and deletes on release before cursor
swipe | yes | selects N chars/words and deletes on release after cursor

Closes #450

TODO:
- [ ] Add explicit forward delete key