### PR TITLE
Inline autofill correct draw behavior

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -117,15 +117,14 @@ import org.florisboard.lib.android.AndroidInternalR
 import org.florisboard.lib.android.AndroidVersion
 import org.florisboard.lib.android.isOrientationLandscape
 import org.florisboard.lib.android.isOrientationPortrait
-import org.florisboard.lib.android.showShortToast
 import org.florisboard.lib.android.showShortToastSync
 import org.florisboard.lib.android.systemServiceOrNull
 import org.florisboard.lib.compose.ProvideLocalizedResources
-import org.florisboard.lib.kotlin.collectLatestIn
 import org.florisboard.lib.kotlin.collectIn
 import org.florisboard.lib.snygg.ui.SnyggBox
 import org.florisboard.lib.snygg.ui.SnyggButton
 import org.florisboard.lib.snygg.ui.SnyggRow
+import org.florisboard.lib.snygg.ui.SnyggSurfaceView
 import org.florisboard.lib.snygg.ui.SnyggText
 import org.florisboard.lib.snygg.ui.rememberSnyggThemeQuery
 
@@ -621,9 +620,14 @@ class FlorisImeService : LifecycleInputMethodService() {
                 clickAndSemanticsModifier = Modifier
                     // Do not remove below line or touch input may get stuck
                     .pointerInteropFilter { false },
-                supportsBackgroundImage = true,
+                supportsBackgroundImage = false,
                 allowClip = false,
             ) {
+                SnyggSurfaceView(
+                    elementName = FlorisImeUi.Window.elementName,
+                    attributes = attributes,
+                    modifier = Modifier.matchParentSize(),
+                )
                 val configuration = LocalConfiguration.current
                 val bottomOffset by if (configuration.isOrientationPortrait()) {
                     prefs.keyboard.bottomOffsetPortrait

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/popup/PopupUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/popup/PopupUi.kt
@@ -24,12 +24,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import dev.patrickgold.florisboard.ime.keyboard.Key
 import dev.patrickgold.florisboard.ime.theme.FlorisImeUi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import org.florisboard.lib.snygg.SnyggQueryAttributes
 import org.florisboard.lib.snygg.SnyggSelector
 import org.florisboard.lib.snygg.ui.SnyggBox
@@ -38,6 +41,8 @@ import org.florisboard.lib.snygg.ui.SnyggIcon
 import org.florisboard.lib.snygg.ui.SnyggRow
 import org.florisboard.lib.snygg.ui.SnyggText
 
+val GlobalStateNumPopupsShowing = MutableStateFlow(0)
+
 @Composable
 fun PopupBaseBox(
     modifier: Modifier = Modifier,
@@ -45,6 +50,13 @@ fun PopupBaseBox(
     key: Key,
     shouldIndicateExtendedPopups: Boolean,
 ): Unit = with(LocalDensity.current) {
+    DisposableEffect(key) {
+        GlobalStateNumPopupsShowing.update { it + 1 }
+        onDispose {
+            GlobalStateNumPopupsShowing.update { it - 1 }
+        }
+    }
+
     SnyggBox(
         elementName = FlorisImeUi.KeyPopupBox.elementName,
         attributes = attributes,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/InlineSuggestionsUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/InlineSuggestionsUi.kt
@@ -17,12 +17,14 @@
 package dev.patrickgold.florisboard.ime.smartbar
 
 import android.os.Build
+import android.view.View
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,6 +35,7 @@ import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.viewinterop.AndroidView
 import dev.patrickgold.florisboard.ime.nlp.NlpInlineAutofillSuggestion
+import dev.patrickgold.florisboard.ime.popup.GlobalStateNumPopupsShowing
 import dev.patrickgold.florisboard.ime.theme.FlorisImeUi
 import dev.patrickgold.florisboard.lib.toIntOffset
 import org.florisboard.lib.compose.florisHorizontalScroll
@@ -56,7 +59,8 @@ fun InlineSuggestionsUi(
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
-    val almostEmptyRect = remember { android.graphics.Rect(0, 0, 1, 1) }
+    val numPopupsShowing by GlobalStateNumPopupsShowing.collectAsState()
+    val isZOrderedOnTop = numPopupsShowing == 0
 
     Row(
         modifier
@@ -77,19 +81,14 @@ fun InlineSuggestionsUi(
                 modifier = Modifier.onGloballyPositioned { chipPos = it.positionInParent().toIntOffset() },
                 factory = { inlineSuggestion.view },
                 update = { view ->
+                    view.isZOrderedOnTop = isZOrderedOnTop
                     view.clipBounds = android.graphics.Rect(
                         (xMin - chipPos.x).coerceAtLeast(0),
                         0,
                         (xMax - chipPos.x).coerceAtMost(view.width),
                         view.height,
                     )
-                    // The empty rect is a workaround for a bug (I suppose) where an empty rect causes
-                    // no clipping, but we actually want to completely hide the view.
-                    // Thus we just show the topmost pixel of the view, which due to the round shape
-                    // of the theme should be transparent anyways.
-                    if (view.clipBounds.isEmpty) {
-                        view.clipBounds = almostEmptyRect
-                    }
+                    view.visibility = if (view.clipBounds.isEmpty) View.INVISIBLE else View.VISIBLE
                 }
             )
         }

--- a/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggSurfaceView.kt
+++ b/lib/snygg/src/main/kotlin/org/florisboard/lib/snygg/ui/SnyggSurfaceView.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2025 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.florisboard.lib.snygg.ui
+
+import android.graphics.PixelFormat
+import android.util.Log
+import android.view.SurfaceView
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import coil3.Image
+import coil3.SingletonImageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.allowHardware
+import org.florisboard.lib.snygg.SnyggQueryAttributes
+import org.florisboard.lib.snygg.SnyggSelector
+
+/**
+ * Specialized layout composable rendering a background color/image to a [SurfaceView].
+ *
+ * This composable infers its style from the current [SnyggTheme][org.florisboard.lib.snygg.SnyggTheme], which is
+ * required to be provided by [ProvideSnyggTheme].
+ *
+ * @param elementName The name of this element. If `null` the style will be inherited from the parent element.
+ * @param attributes The attributes of the element used to refine the query.
+ * @param selector A specific SnyggSelector to query the style for.
+ * @param modifier The modifier to be applied to the layout.
+ * @param backgroundImageDescription The content description of the background image.
+ *
+ * @since 0.5.0-beta04
+ *
+ * @see [Box]
+ * @see [SurfaceView]
+ */
+@Composable
+fun SnyggSurfaceView(
+    elementName: String? = null,
+    attributes: SnyggQueryAttributes = emptyMap(),
+    selector: SnyggSelector? = null,
+    modifier: Modifier = Modifier,
+    backgroundImageDescription: String? = null,
+) {
+    ProvideSnyggStyle(elementName, attributes, selector) { style ->
+        val assetResolver = LocalSnyggAssetResolver.current
+        val context = LocalContext.current
+        val imageLoader = SingletonImageLoader.get(context)
+
+        val backgroundColor = style.background(Color.Black)
+        val imagePath = remember(style, assetResolver) {
+            style.backgroundImage.uriOrNull()?.let { imageUri ->
+                assetResolver.resolveAbsolutePath(imageUri).getOrNull()
+            }
+        }
+        var image by remember { mutableStateOf<Image?>(null) }
+
+        LaunchedEffect(imagePath) {
+            if (imagePath == null) {
+                image = null
+                return@LaunchedEffect
+            }
+            val request = ImageRequest.Builder(context)
+                .data(imagePath)
+                .allowHardware(false)
+                .build()
+            val imageResult = imageLoader.execute(request)
+            image = if (imageResult is SuccessResult) {
+                imageResult.image
+            } else {
+                null
+            }
+        }
+
+        var showSurfaceView by remember { mutableStateOf(false) }
+        LifecycleResumeEffect(Unit) {
+            showSurfaceView = true
+            onPauseOrDispose {
+                showSurfaceView = false
+            }
+        }
+
+        if (showSurfaceView) {
+            var surfaceView by remember { mutableStateOf<SurfaceView?>(null) }
+            AndroidView(
+                modifier = modifier,
+                factory = { context ->
+                    Log.d("SnyggSurfaceView", "creating new instance")
+                    SurfaceView(context).apply {
+                        setZOrderOnTop(false)
+                        holder.setFormat(PixelFormat.TRANSPARENT)
+                    }
+                },
+                update = { surfaceView = it },
+            )
+            surfaceView?.let { surfaceView ->
+                LaunchedEffect(surfaceView, backgroundColor, image) {
+                    Log.d("SnyggSurfaceView", "drawToSurface(backgroundColor=$backgroundColor, image=$image)")
+                    val surface = surfaceView.holder.surface
+                    Log.d("SnyggSurfaceView", "drawToSurface: surface.isValid=${surface.isValid}")
+                    if (surface.isValid) {
+                        val canvas = surface.lockCanvas(null)
+                        try {
+                            canvas.drawColor(backgroundColor.toArgb())
+                            image?.draw(canvas)
+                        } finally {
+                            surface.unlockCanvasAndPost(canvas)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the inline autofill behavior, popups are now correctly drawing over inline autofill chips:

![inline_autofill_demo](https://github.com/user-attachments/assets/bea7fb9f-13a3-4466-b461-78f257d83035)

Pros:
- Works with all window background colors
- Works with all **static** window background images
- Works with all **dynamic** window background images (GIFs)

Cons:
- Potentially more error-prone state logic for background

TODO:
- [x] Re-add content scale support
- [x] Re-add GIF support
- [x] Evaluate GIF frame rate, may need to be adaptive

Closes #1228