### PR TITLE
Rework clipboard delete button to respect active filters

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardManager.kt
@@ -286,6 +286,15 @@ class ClipboardManager(
         }
     }
 
+    fun clearExactHistory(items: List<ClipboardItem>) {
+        ioScope.launch {
+            for (item in items) {
+                item.close(appContext)
+            }
+            clipHistoryDao?.delete(items)
+        }
+    }
+
     /**
      * Clears all unpinned items from the clipboard history
      */
@@ -391,7 +400,8 @@ class ClipboardManager(
         private val now = System.currentTimeMillis()
 
         val pinned = all.filter { it.isPinned }
-        val recent = all.filter { !it.isPinned && (now - it.creationTimestampMs < RECENT_TIMESPAN_MS) }
-        val other = all.filter { !it.isPinned && (now - it.creationTimestampMs >= RECENT_TIMESPAN_MS) }
+        val unpinned = all.filter { !it.isPinned }
+        val recent = unpinned.filter { (now - it.creationTimestampMs) < RECENT_TIMESPAN_MS }
+        val other = unpinned.filter { (now - it.creationTimestampMs) >= RECENT_TIMESPAN_MS }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -695,7 +695,8 @@
     <string name="clipboard__cleared_primary_clip">Cleared primary clip</string>
     <string name="clipboard__cleared_history">Cleared history</string>
     <string name="clipboard__cleared_full_history">Cleared full history</string>
-    <string name="clipboard__confirm_clear_history__message">Are you sure you want to clear your clipboard history? This will clear all items except pinned ones, regardless of active filters.</string>
+    <string name="clipboard__confirm_clear_unfiltered_history__message">Are you sure you want to clear your full clipboard history? This will affect all items, except pinned ones.</string>
+    <string name="clipboard__confirm_clear_filtered_history__message">Are you sure you want to clear your clipboard history? This will affect all currently filtered items, except pinned ones.</string>
     <string name="settings__clipboard__title">Clipboard</string>
     <string name="pref__clipboard__use_internal_clipboard__label">Use internal clipboard</string>
     <string name="pref__clipboard__use_internal_clipboard__summary">Use an internal clipboard instead of the system clipboard</string>


### PR DESCRIPTION
Closes #3074

The delete all button in the clipboard input layout now respects the currently active filters. As with the generic delete all button, pinned items will never be deleted with a bulk action and require manual deletion.