### PR TITLE
Add Arabic question mark to ~right popup mappings

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ar.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/ar.json
@@ -70,8 +70,9 @@
       ]
     },
     "~right": {
-      "main": { "code": 1611, "label": "ً" },
+      "main": { "code": 1567, "label": "؟" },
       "relevant": [
+        { "code": 1611, "label": "ً" },
         { "code": 1622, "label": "ٖ" },
         { "code": 1648, "label": "ٰ" },
         { "code": 1619, "label": "ٓ" },


### PR DESCRIPTION
This update adds the Arabic question mark (؟) to the ~right popup key mappings