### PR TITLE
Modified FlorisSpellCheckerService.kt

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisSpellCheckerService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisSpellCheckerService.kt
@@ -31,6 +31,9 @@ import dev.patrickgold.florisboard.lib.devtools.flogInfo
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import org.florisboard.lib.kotlin.map
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class FlorisSpellCheckerService : SpellCheckerService() {
     private val prefs by FlorisPreferenceStore
@@ -42,7 +45,9 @@ class FlorisSpellCheckerService : SpellCheckerService() {
         flogInfo(LogTopic.SPELL_EVENTS)
 
         super.onCreate()
-        dictionaryManager.loadUserDictionariesIfNecessary()
+        CoroutineScope(Dispatchers.IO).launch {
+            dictionaryManager.loadUserDictionariesIfNecessary()
+        }
     }
 
     override fun createSession(): Session {


### PR DESCRIPTION
Hello,
**Issue:** Application.onCreate() currently calls **dictionaryManager.loadUserDictionariesIfNecessary()** on the main thread. This may block the UI during app startup when **initializing Room databases**.
**Change:** The call is moved to a Dispatchers.IO coroutine, ensuring the database initialization runs on a background thread.