### PR TITLE
Fix wrong pref migration for clipboard sync

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -903,9 +903,10 @@ abstract class FlorisPreferenceModel : PreferenceModel() {
                 entry.transform(
                     type = PreferenceType.string(),
                     rawValue = when (entry.rawValue) {
-                        "true" -> ClipboardSyncBehavior.ALL_EVENTS
-                        else -> ClipboardSyncBehavior.NO_EVENTS
-                    }.name,
+                        "true" -> ClipboardSyncBehavior.ALL_EVENTS.name
+                        "false" -> ClipboardSyncBehavior.NO_EVENTS.name
+                        else -> entry.rawValue
+                    },
                 )
             }
             "clipboard__num_history_grid_columns_portrait" -> {


### PR DESCRIPTION
## Description

The clipboard sync migration was wrong and reset the values every time to "No events". Thanks to @tsiflimagas for finding this bug.

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
