### PR TITLE
Fix error in "o" long press option for Czech (cs)

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cs.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/cs.json
@@ -35,8 +35,7 @@
     },
     "o": {
       "relevant": [
-        { "$": "auto_text_key", "code":  243, "label": "ó" },
-        { "$": "auto_text_key", "code":  244, "label": "ô" }
+        { "$": "auto_text_key", "code":  243, "label": "ó" }
       ]
     },
     "a": {


### PR DESCRIPTION
## Description

Fix a mistake with o long press. Fixes #2825

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
