### PR TITLE
Correction and update of the French popup mapping

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/fr.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/fr.json
@@ -4,76 +4,111 @@
       "main": { "$": "auto_text_key", "code":  224, "label": "à" },
       "relevant": [
         { "$": "auto_text_key", "code":  228, "label": "ä" },
-        { "$": "auto_text_key", "code":  227, "label": "ã" },
-        { "$": "auto_text_key", "code":  229, "label": "å" },
-        { "$": "auto_text_key", "code":  257, "label": "ā" },
-        { "$": "auto_text_key", "code":  170, "label": "ª" },
         { "$": "auto_text_key", "code":  226, "label": "â" },
         { "$": "auto_text_key", "code":  230, "label": "æ" },
-        { "$": "auto_text_key", "code":  225, "label": "á" }
+        { "$": "auto_text_key", "code":  227, "label": "ã" },
+        { "$": "auto_text_key", "code":  945, "label": "α" }
+      ]
+    },
+    "b": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  946, "label": "β" }
       ]
     },
     "c": {
-      "main": { "$": "auto_text_key", "code":  231, "label": "ç" },
       "relevant": [
-        { "$": "auto_text_key", "code":  269, "label": "č" },
-        { "$": "auto_text_key", "code":  263, "label": "ć" }
+        { "$": "auto_text_key", "code":  231, "label": "ç" }
       ]
     },
+    "d": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  948, "label": "δ" }
+      ]
+    },	
     "e": {
       "main": { "$": "auto_text_key", "code":  233, "label": "é" },
       "relevant": [
-        { "$": "auto_text_key", "code":  279, "label": "ė" },
-        { "$": "auto_text_key", "code":  281, "label": "ę" },
-        { "$": "auto_text_key", "code":  275, "label": "ē" },
-        { "$": "auto_text_key", "code":  234, "label": "ê" },
         { "$": "auto_text_key", "code":  232, "label": "è" },
-        { "$": "auto_text_key", "code":  235, "label": "ë" }
+        { "$": "auto_text_key", "code":  234, "label": "ê" },
+        { "$": "auto_text_key", "code":  235, "label": "ë" },
+        { "$": "auto_text_key", "code":  951, "label": "η" }
       ]
     },
+    "g": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  947, "label": "γ" }
+      ]
+    },	
     "i": {
       "main": { "$": "auto_text_key", "code":  238, "label": "î" },
       "relevant": [
-        { "$": "auto_text_key", "code":  299, "label": "ī" },
-        { "$": "auto_text_key", "code":  237, "label": "í" },
-        { "$": "auto_text_key", "code":  303, "label": "į" },
-        { "$": "auto_text_key", "code":  236, "label": "ì" },
-        { "$": "auto_text_key", "code":  239, "label": "ï" }
+        { "$": "auto_text_key", "code":  239, "label": "ï" },
+        { "$": "auto_text_key", "code":  953, "label": "ι" }
+      ]
+    },
+    "k": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  954, "label": "κ" }
+      ]
+    },
+    "l": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  955, "label": "λ" }
+      ]
+    },
+    "m": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  956, "label": "μ" }
       ]
     },
     "n": {
       "relevant": [
-        { "$": "auto_text_key", "code":  241, "label": "ñ" },
-        { "$": "auto_text_key", "code":  324, "label": "ń" }
+        { "$": "auto_text_key", "code":  241, "label": "ñ" }
       ]
     },
     "o": {
       "main": { "$": "auto_text_key", "code":  244, "label": "ô" },
       "relevant": [
-        { "$": "auto_text_key", "code":  186, "label": "º" },
-        { "$": "auto_text_key", "code":  333, "label": "ō" },
+        { "$": "auto_text_key", "code":  339, "label": "œ" },
         { "$": "auto_text_key", "code":  248, "label": "ø" },
-        { "$": "auto_text_key", "code":  245, "label": "õ" },
-        { "$": "auto_text_key", "code":  243, "label": "ó" },
-        { "$": "auto_text_key", "code":  242, "label": "ò" },
-        { "$": "auto_text_key", "code":  246, "label": "ö" },
-        { "$": "auto_text_key", "code":  339, "label": "œ" }
+        { "$": "auto_text_key", "code":  959, "label": "ο" },
+        { "$": "auto_text_key", "code":  969, "label": "ω" }
+      ]
+    },
+    "p": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  966, "label": "φ" },
+        { "$": "auto_text_key", "code":  960, "label": "π" },
+        { "$": "auto_text_key", "code":  968, "label": "ψ" }
+      ]
+    },
+    "r": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  961, "label": "ρ" }
       ]
     },
     "s": {
       "relevant": [
         { "$": "auto_text_key", "code":  223, "label": "ß" },
-        { "$": "auto_text_key", "code":  353, "label": "š" },
-        { "$": "auto_text_key", "code":  347, "label": "ś" }
+		{ "$": "auto_text_key", "code":  963, "label": "σ" }
+      ]
+    },
+    "t": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  952, "label": "θ" }
       ]
     },
     "u": {
       "main": { "$": "auto_text_key", "code":  249, "label": "ù" },
       "relevant": [
-        { "$": "auto_text_key", "code":  363, "label": "ū" },
+        { "$": "auto_text_key", "code":  251, "label": "û" },
         { "$": "auto_text_key", "code":  252, "label": "ü" },
-        { "$": "auto_text_key", "code":  250, "label": "ú" },
-        { "$": "auto_text_key", "code":  251, "label": "û" }
+        { "$": "auto_text_key", "code":  965, "label": "υ" },
+      ]
+    },
+    "x": {
+      "relevant": [
+        { "$": "auto_text_key", "code":  958, "label": "ξ" }
       ]
     },
     "y": {
@@ -112,6 +147,7 @@
     "~right": {
       "main": { "code": -255, "label": ".com" },
       "relevant": [
+        { "code": -255, "label": ".fr" },
         { "code": -255, "label": ".gov" },
         { "code": -255, "label": ".edu" },
         { "code": -255, "label": ".org" },


### PR DESCRIPTION
## Description

The popup mapping of the French keyboard displayed many characters that do not exist in French provided an order that was not intuitive in terms of character frequency of use.
This PR proposes a correction to this and a small improvement by adding Greek characters used in science:

- Removal of characters not used in French
- Addition of Greek characters used in scientific/technical annotation
- Reordering of characters according to frequency of use

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [X] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [X] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
