### PR TITLE
Fix error in "u" long press option for Slovak (sk)

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/sk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/sk.json
@@ -24,8 +24,7 @@
     },
     "u": {
       "relevant": [
-        { "$": "auto_text_key", "code":  250, "label": "ú" },
-        { "$": "auto_text_key", "code":  367, "label": "ů" }
+        { "$": "auto_text_key", "code":  250, "label": "ú" }
       ]
     },
     "i": {


### PR DESCRIPTION
## Description

Similar to #2825. Slovak language doesn't use "ů", and it's not present in the Slovak alphabet. The letter is only present in Czech.

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
