### PR TITLE
Fix banking app crashes for numeric inputs

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
@@ -107,7 +107,11 @@ abstract class AbstractEditorInstance(context: Context) {
         activeInfo = editorInfo
         activeCursorCapsMode = editorInfo.initialCapsMode
         activeContent = EditorContent.Unspecified
-        currentInputConnection()?.requestCursorUpdates(CursorUpdateAll)
+        // Skip cursor updates for numeric inputs to avoid crashes in apps with buggy
+        // Compose TextFields (e.g., banking apps) - see issue #3100
+        if (editorInfo.inputAttributes.type != InputAttributes.Type.NUMBER) {
+            currentInputConnection()?.requestCursorUpdates(CursorUpdateAll)
+        }
     }
 
     open fun handleStartInputView(editorInfo: FlorisEditorInfo, isRestart: Boolean) {


### PR DESCRIPTION
## Description

This fix skips cursor updates for numeric inputs to prevent crashes in apps with buggy Compose TextFields such as banking apps and fixes #3100 

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [X] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [X] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
