### PR TITLE
Add key spacing scale factor & Improve font scaling

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -525,13 +525,13 @@ abstract class FlorisPreferenceModel : PreferenceModel() {
             key = "keyboard__landscape_input_ui_mode",
             default = LandscapeInputUiMode.DYNAMICALLY_SHOW,
         )
-        val keySpacingVertical = float(
+        val keySpacingVertical = int(
             key = "keyboard__key_spacing_vertical",
-            default = 5.0f,
+            default = 100,
         )
-        val keySpacingHorizontal = float(
+        val keySpacingHorizontal = int(
             key = "keyboard__key_spacing_horizontal",
-            default = 2.0f,
+            default = 100,
         )
         val popupEnabled = boolean(
             key = "keyboard__popup_enabled",
@@ -897,6 +897,23 @@ abstract class FlorisPreferenceModel : PreferenceModel() {
             }
             "clipboard__clear_primary_clip_deletes_last_item" -> {
                 entry.transform(key = "clipboard__clear_primary_clip_affects_history_if_unpinned")
+            }
+
+            // Migrate key spacing rules
+            // Keep migration rules until: 0.8 dev cycle
+            "keyboard__key_spacing_horizontal" -> {
+                if (entry.type.isFloat()) {
+                    entry.reset()
+                } else {
+                    entry.keepAsIs()
+                }
+            }
+            "keyboard__key_spacing_vertical" -> {
+                if (entry.type.isFloat()) {
+                    entry.reset()
+                } else {
+                    entry.keepAsIs()
+                }
             }
 
             // Default: keep entry

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/keyboard/KeyboardScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/keyboard/KeyboardScreen.kt
@@ -115,10 +115,10 @@ fun KeyboardScreen() = FlorisScreen {
                 title = stringRes(R.string.pref__keyboard__key_spacing__label),
                 primaryLabel = stringRes(R.string.screen_orientation__vertical),
                 secondaryLabel = stringRes(R.string.screen_orientation__horizontal),
-                valueLabel = { stringRes(R.string.unit__display_pixel__symbol, "v" to it) },
-                min = 0.0f,
-                max = 10.0f,
-                stepIncrement = 0.5f,
+                valueLabel = { stringRes(R.string.unit__percent__symbol, "v" to it) },
+                min = 50,
+                max = 150,
+                stepIncrement = 5,
             )
         }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
@@ -32,6 +32,8 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
@@ -77,6 +79,7 @@ import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyType
 import dev.patrickgold.florisboard.ime.text.key.KeyVariation
 import dev.patrickgold.florisboard.ime.theme.FlorisImeUi
+import dev.patrickgold.florisboard.ime.window.LocalWindowController
 import dev.patrickgold.florisboard.keyboardManager
 import dev.patrickgold.florisboard.lib.FlorisRect
 import dev.patrickgold.florisboard.lib.Pointer
@@ -212,9 +215,12 @@ fun TextKeyboardLayout(
         // FIXME (when rewriting TextKeyboardLayout): constrains.maxWidth is not stable!
         val keyboardWidth = constraints.maxWidth.toFloat()
         val keyboardHeight = constraints.maxHeight.toFloat()
-        val keyMarginH by prefs.keyboard.keySpacingHorizontal.observeAsTransformingState { it.dp.toPx() }
-        val keyMarginV by prefs.keyboard.keySpacingVertical.observeAsTransformingState { it.dp.toPx() }
         val keyboardRowBaseHeight = FlorisImeSizing.keyboardRowBaseHeight
+
+        val windowController = LocalWindowController.current
+        val windowSpec by windowController.activeWindowSpec.collectAsState()
+        val keyMarginH by remember { derivedStateOf { windowSpec.keyMarginH.toPx() } }
+        val keyMarginV by remember { derivedStateOf { windowSpec.keyMarginV.toPx() } }
 
         val desiredKey = remember(
             keyboard, keyboardWidth, keyboardHeight, keyMarginH, keyMarginV,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/window/ImeWindowConstraints.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/window/ImeWindowConstraints.kt
@@ -57,6 +57,9 @@ sealed class ImeWindowConstraints(rootInsets: ImeInsets.Root) {
     abstract val maxKeyboardHeight: Dp
     abstract val defKeyboardHeight: Dp
 
+    abstract val defKeyMarginH: Dp
+    abstract val defKeyMarginV: Dp
+
     open val baselineRowCount: Float = 4f
     open val smartbarDynamicScalingFactor = 0.20f
     open val smartbarStaticScalingFactor by calculation { 0.753f - smartbarDynamicScalingFactor }
@@ -136,6 +139,27 @@ sealed class ImeWindowConstraints(rootInsets: ImeInsets.Root) {
                 ImeFormFactor.Type.PHONE_PORTRAIT -> 0.26f
             }
             (baselineScreen.height * factor).coerceIn(minKeyboardHeight, maxKeyboardHeight)
+        }
+
+        override val defKeyMarginH by calculation {
+            when (formFactor.typeGuess) {
+                ImeFormFactor.Type.DESKTOP,
+                ImeFormFactor.Type.LARGE_TABLET -> 6.dp
+                ImeFormFactor.Type.TABLET_LANDSCAPE -> 2.dp
+                ImeFormFactor.Type.TABLET_PORTRAIT -> 5.dp
+                ImeFormFactor.Type.PHONE_LANDSCAPE -> 2.dp
+                ImeFormFactor.Type.PHONE_PORTRAIT -> 2.dp
+            }
+        }
+        override val defKeyMarginV by calculation {
+            when (formFactor.typeGuess) {
+                ImeFormFactor.Type.DESKTOP,
+                ImeFormFactor.Type.LARGE_TABLET -> 6.dp
+                ImeFormFactor.Type.TABLET_LANDSCAPE -> 5.dp
+                ImeFormFactor.Type.TABLET_PORTRAIT -> 5.dp
+                ImeFormFactor.Type.PHONE_LANDSCAPE -> 5.dp
+                ImeFormFactor.Type.PHONE_PORTRAIT -> 5.dp
+            }
         }
 
         open val snapToCenterWidth: Dp by lazy {
@@ -239,7 +263,7 @@ sealed class ImeWindowConstraints(rootInsets: ImeInsets.Root) {
                 ImeFormFactor.Type.LARGE_TABLET,
                 ImeFormFactor.Type.TABLET_LANDSCAPE -> 0.30f
                 ImeFormFactor.Type.TABLET_PORTRAIT -> 0.45f
-                ImeFormFactor.Type.PHONE_LANDSCAPE -> 0.28f
+                ImeFormFactor.Type.PHONE_LANDSCAPE -> 0.30f
                 ImeFormFactor.Type.PHONE_PORTRAIT -> 0.65f
             }
             (baselineScreen.width * factor).coerceIn(minKeyboardWidth, maxKeyboardWidth)
@@ -248,10 +272,10 @@ sealed class ImeWindowConstraints(rootInsets: ImeInsets.Root) {
         override val minKeyboardHeight by calculation {
             val factor = when (formFactor.typeGuess) {
                 ImeFormFactor.Type.DESKTOP,
-                ImeFormFactor.Type.LARGE_TABLET,
+                ImeFormFactor.Type.LARGE_TABLET -> 0.25f
                 ImeFormFactor.Type.TABLET_LANDSCAPE -> 0.30f
                 ImeFormFactor.Type.TABLET_PORTRAIT -> 0.18f
-                ImeFormFactor.Type.PHONE_LANDSCAPE -> 0.35f
+                ImeFormFactor.Type.PHONE_LANDSCAPE -> 0.28f
                 ImeFormFactor.Type.PHONE_PORTRAIT -> 0.20f
             }
             (baselineScreen.height * factor).coerceAtMost(rootBounds.height)
@@ -262,7 +286,7 @@ sealed class ImeWindowConstraints(rootInsets: ImeInsets.Root) {
                 ImeFormFactor.Type.LARGE_TABLET,
                 ImeFormFactor.Type.TABLET_LANDSCAPE -> 0.55f
                 ImeFormFactor.Type.TABLET_PORTRAIT -> 0.35f
-                ImeFormFactor.Type.PHONE_LANDSCAPE -> 0.55f
+                ImeFormFactor.Type.PHONE_LANDSCAPE -> 0.60f
                 ImeFormFactor.Type.PHONE_PORTRAIT -> 0.40f
             }
             (baselineScreen.height * factor).coerceIn(minKeyboardHeight, rootBounds.height)
@@ -273,10 +297,31 @@ sealed class ImeWindowConstraints(rootInsets: ImeInsets.Root) {
                 ImeFormFactor.Type.LARGE_TABLET,
                 ImeFormFactor.Type.TABLET_LANDSCAPE -> 0.35f
                 ImeFormFactor.Type.TABLET_PORTRAIT -> 0.22f
-                ImeFormFactor.Type.PHONE_LANDSCAPE -> 0.25f
+                ImeFormFactor.Type.PHONE_LANDSCAPE -> 0.45f
                 ImeFormFactor.Type.PHONE_PORTRAIT -> 0.22f
             }
             (baselineScreen.height * factor).coerceIn(minKeyboardHeight, maxKeyboardHeight)
+        }
+
+        override val defKeyMarginH by calculation {
+            when (formFactor.typeGuess) {
+                ImeFormFactor.Type.DESKTOP,
+                ImeFormFactor.Type.LARGE_TABLET,
+                ImeFormFactor.Type.TABLET_LANDSCAPE -> 2.dp
+                ImeFormFactor.Type.TABLET_PORTRAIT -> 2.dp
+                ImeFormFactor.Type.PHONE_LANDSCAPE -> 1.5.dp
+                ImeFormFactor.Type.PHONE_PORTRAIT -> 2.dp
+            }
+        }
+        override val defKeyMarginV by calculation {
+            when (formFactor.typeGuess) {
+                ImeFormFactor.Type.DESKTOP,
+                ImeFormFactor.Type.LARGE_TABLET,
+                ImeFormFactor.Type.TABLET_LANDSCAPE -> 5.dp
+                ImeFormFactor.Type.TABLET_PORTRAIT -> 5.dp
+                ImeFormFactor.Type.PHONE_LANDSCAPE -> 3.dp
+                ImeFormFactor.Type.PHONE_PORTRAIT -> 5.dp
+            }
         }
 
         abstract override val defaultProps: ImeWindowProps.Floating

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/window/ImeWindowProps.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/window/ImeWindowProps.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.width
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import org.florisboard.lib.compose.DpSizeSerializer
+import kotlin.math.sqrt
 
 /**
  * The window props describe the necessary properties for window placement and sizing.
@@ -38,7 +39,22 @@ sealed interface ImeWindowProps {
      */
     val keyboardHeight: Dp
 
-    fun calcFontScale(constraints: ImeWindowConstraints): Float
+    fun keyboardWidth(constraints: ImeWindowConstraints): Dp
+
+    fun calcKeyMarginH(constraints: ImeWindowConstraints): Dp {
+        val factor = keyboardWidth(constraints) / constraints.defKeyboardWidth
+        return constraints.defKeyMarginH * sqrt(factor)
+    }
+
+    fun calcKeyMarginV(constraints: ImeWindowConstraints): Dp {
+        val factor = keyboardHeight / constraints.defKeyboardHeight
+        return constraints.defKeyMarginV * sqrt(factor)
+    }
+
+    fun calcFontScale(constraints: ImeWindowConstraints): Float {
+        val factor = keyboardHeight / constraints.defKeyboardHeight
+        return sqrt(factor)
+    }
 
     /**
      * The window props for fixed mode. It assumes the window is docked to the bottom root window edge and
@@ -91,9 +107,9 @@ sealed interface ImeWindowProps {
             )
         }
 
-        override fun calcFontScale(constraints: ImeWindowConstraints): Float {
-            val fontScale = keyboardHeight / constraints.defKeyboardHeight
-            return fontScale.coerceAtMost(1f)
+        override fun keyboardWidth(constraints: ImeWindowConstraints): Dp {
+            val rootBounds = constraints.rootBounds
+            return (rootBounds.width - paddingLeft - paddingRight).coerceIn(0.dp, rootBounds.width)
         }
     }
 
@@ -142,9 +158,8 @@ sealed interface ImeWindowProps {
             )
         }
 
-        override fun calcFontScale(constraints: ImeWindowConstraints): Float {
-            val fontScale = keyboardHeight / constraints.defKeyboardHeight
-            return fontScale.coerceAtMost(1f)
+        override fun keyboardWidth(constraints: ImeWindowConstraints): Dp {
+            return keyboardWidth
         }
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/window/ImeWindowSpec.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/window/ImeWindowSpec.kt
@@ -36,14 +36,17 @@ sealed class ImeWindowSpec {
     abstract val props: ImeWindowProps
 
     /**
-     * TODO rework
-     */
-    abstract val fontScale: Float
-
-    /**
      * The constraints accompanying the root bounds and props.
      */
     abstract val constraints: ImeWindowConstraints
+
+    abstract val userPreferredOptions: UserPreferredOptions
+
+    val keyMarginH: Dp by lazy { props.calcKeyMarginH(constraints) * userPreferredOptions.keySpacingFactorH }
+
+    val keyMarginV: Dp by lazy { props.calcKeyMarginV(constraints) * userPreferredOptions.keySpacingFactorV }
+
+    val fontScale: Float by lazy { props.calcFontScale(constraints) * userPreferredOptions.fontScale }
 
     /**
      * Calculate how a move gesture would change the computed props.
@@ -117,8 +120,8 @@ sealed class ImeWindowSpec {
     data class Fixed(
         val fixedMode: ImeWindowMode.Fixed,
         override val props: ImeWindowProps.Fixed,
-        override val fontScale: Float,
         override val constraints: ImeWindowConstraints.Fixed,
+        override val userPreferredOptions: UserPreferredOptions,
     ) : ImeWindowSpec() {
         override fun movedBy(
             offset: DpOffset,
@@ -219,8 +222,8 @@ sealed class ImeWindowSpec {
     data class Floating(
         val floatingMode: ImeWindowMode.Floating,
         override val props: ImeWindowProps.Floating,
-        override val fontScale: Float,
         override val constraints: ImeWindowConstraints.Floating,
+        override val userPreferredOptions: UserPreferredOptions,
     ) : ImeWindowSpec() {
         override fun movedBy(
             offset: DpOffset,
@@ -282,6 +285,12 @@ sealed class ImeWindowSpec {
         }
     }
 
+    data class UserPreferredOptions(
+        val keySpacingFactorH: Float,
+        val keySpacingFactorV: Float,
+        val fontScale: Float,
+    )
+
     companion object {
         /**
          * The fallback window spec. It does not guarantee the window fits into the root window, and assumes
@@ -296,7 +305,11 @@ sealed class ImeWindowSpec {
                 paddingRight = 0.dp,
                 paddingBottom = 0.dp,
             ),
-            fontScale = 1f,
+            userPreferredOptions = UserPreferredOptions(
+                keySpacingFactorH = 1f,
+                keySpacingFactorV = 1f,
+                fontScale = 1f,
+            ),
             constraints = ImeWindowConstraints.Fixed.Normal(ImeInsets.Root.Zero),
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,7 +452,7 @@
     <string name="pref__keyboard__font_size_multiplier__label" comment="Preference title">Font size multiplier</string>
     <string name="pref__keyboard__group_layout__label" comment="Preference group title">Layout</string>
     <string name="pref__keyboard__landscape_input_ui_mode__label" comment="Preference value">Landscape fullscreen input</string>
-    <string name="pref__keyboard__key_spacing__label" comment="Preference title">Key spacing</string>
+    <string name="pref__keyboard__key_spacing__label" comment="Preference title">Key spacing factor</string>
     <string name="pref__keyboard__group_keypress__label" comment="Preference group title">Key press</string>
     <string name="pref__keyboard__popup_enabled__label" comment="Preference title">Popup Visibility</string>
     <string name="pref__keyboard__popup_enabled__summary" comment="Preference summary">Show popup when you press a key</string>


### PR DESCRIPTION
## Description

This PR allows the key space to scale with the actual window size, improving the visual appearance significantly on edge-case sizes.

Additionally the font scale has been improved, and it now updates continuously on resize.

Related #3180 

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
