### PR TITLE
Fix clipboard entry dedup ignoring isSensitive flag

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardManager.kt
@@ -233,7 +233,9 @@ class ClipboardManager(
      */
     private fun insertOrMoveBeginning(newItem: ClipboardItem) {
         if (prefs.clipboard.historyEnabled.get()) {
-            val historyElement = currentHistory.all.firstOrNull { it.type == ItemType.TEXT && it.text == newItem.text }
+            val historyElement = currentHistory.all.firstOrNull { item ->
+                item.type == ItemType.TEXT && item.text == newItem.text && item.isSensitive == newItem.isSensitive
+            }
             if (historyElement != null) {
                 moveToTheBeginning(
                     oldItem = historyElement,


### PR DESCRIPTION
## Description

Fixes #3112

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
