### PR TITLE
Fix FlorisBoard requesting a composing region on number-only inputs

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -138,7 +138,7 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
     }
 
     override fun determineComposingEnabled(): Boolean {
-        return nlpManager.isSuggestionOn()
+        return activeState.isComposingEnabled && nlpManager.isSuggestionOn()
     }
 
     override fun determineComposer(composerName: ExtensionComponentName): Composer {


### PR DESCRIPTION
## Description

This PR fixes a bug in the editor instance logic, requesting a composing region by accident for numeric-only input fields, which confuses some apps.

Fixes #3094
Fixes #3100
Fixes _potentially_ #2965

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
