### PR TITLE
Fix RTL language layout in settings messed up

### DIFF
--- a/lib/compose/src/main/kotlin/org/florisboard/lib/compose/Resources.kt
+++ b/lib/compose/src/main/kotlin/org/florisboard/lib/compose/Resources.kt
@@ -63,7 +63,11 @@ fun ProvideLocalizedResources(
     forceLayoutDirection: LayoutDirection? = null,
     content: @Composable () -> Unit,
 ) {
-    val actualLayoutDirection = LocalLayoutDirection.current
+    val actualLayoutDirection = when (resourcesContext.resources.configuration.layoutDirection) {
+        View.LAYOUT_DIRECTION_LTR -> LayoutDirection.Ltr
+        View.LAYOUT_DIRECTION_RTL -> LayoutDirection.Rtl
+        else -> error("Given configuration specifies invalid layout direction!")
+    }
     val layoutDirection = forceLayoutDirection ?: actualLayoutDirection
     val localeList = resourcesContext.resources.configuration.locales
     val dateTimeFormatter = remember(resourcesContext) {
@@ -75,7 +79,7 @@ fun ProvideLocalizedResources(
     CompositionLocalProvider(
         LocalResourcesContext provides resourcesContext,
         LocalLocalizedDateTimeFormatter provides dateTimeFormatter,
-        LocalActualLayoutDirection provides LocalLayoutDirection.current,
+        LocalActualLayoutDirection provides actualLayoutDirection,
         LocalLayoutDirection provides layoutDirection,
         LocalAppNameString provides stringResource(appName),
     ) {


### PR DESCRIPTION
## Description

Fixes #3196 by inferring the layout direction from the language instead of system itself.
Additionally also clean up state logic regarding IME resources context.

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
