### PR TITLE
Upgrade NDK to r29 & Upgrade tooling

### DIFF
--- a/gradle/tools.versions.toml
+++ b/gradle/tools.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-buildTools = "35.0.0"
-cmake = "4.0.2"
+buildTools = "36.0.0"
+cmake = "4.1.2"
 jdk = "17"
-ndk = "26.1.10909125"
-rustup = "1.24.3"
-rustToolchain = "1.83.0"
+ndk = "29.0.14206865"
+rustup = "1.28.2"
+rustToolchain = "1.93.0"
 
 ### Command line tools ###
 # See: https://developer.android.com/studio#command-line-tools-only
-cmdlineTools = "13114758"
-cmdlineToolsChecksum = "7ec965280a073311c339e571cd5de778b9975026cfcbe79f2b1cdcb1e15317ee"
+cmdlineTools = "14742923"
+cmdlineToolsChecksum = "04453066b540409d975c676d781da1477479dde3761310f1a7eb92a1dfb15af7"


### PR DESCRIPTION
## Description

See title.
Fixes CMake deprecation warnings.
Additionally, NDK r29 defaults to 16kB page size, thus complying with Google Play requirements.

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
