### PR TITLE
Fix validate-strings not fetching all files for large PRs

### DIFF
--- a/.github/workflows/validate-strings-no-translations.yml
+++ b/.github/workflows/validate-strings-no-translations.yml
@@ -27,8 +27,17 @@ jobs:
         id: fetch_changed_files
         if: steps.precheck.outputs.require_validation == 'true'
         run: |
-          pr_files="$(curl -sSf https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=1000)" || exit 11
-          changed_files="$(jq -r '.[].filename' <<< "$pr_files")" || exit 12
+          pr_info="$(curl -sSf https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }})" || exit 11
+          num_changed_files="$(jq -r '.changed_files' <<< "$pr_info")" || exit 12
+          num_pages=$(((num_changed_files + 99) / 100))
+          changed_files=""
+          echo "Num changed files: $num_changed_files ($num_pages page(s))"
+          for ((page=1; page<=num_pages; page++)); do
+            pr_files="$(curl -sSf https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100\&page=$page)" || exit 11
+            changed_files_iter="$(jq -r '.[].filename' <<< "$pr_files")" || exit 12
+            changed_files+="$changed_files_iter"
+          done
+          echo "Changed files:\n$changed_files"
           illegal_changes_list="$(grep -E '^app/src/main/res/values-.+/strings.xml$' <<< "$changed_files")" || true
           if [ -n "$illegal_changes_list" ]; then
             echo -e "Illegal changes detected:\n$illegal_changes_list"


### PR DESCRIPTION
## Description

This PR fixes the issue that the validade-strings action does not fetch all files for large PRs by properly using the pagination of the GitHub API.

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
