### PR TITLE
Fix raw/rich input method detection

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/FlorisEditorInfo.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/FlorisEditorInfo.kt
@@ -26,7 +26,7 @@ class FlorisEditorInfo private constructor(val base: EditorInfo) {
     val imeOptions = ImeOptions.wrap(base.imeOptions)
 
     val isRichInputEditor: Boolean
-        get() = inputAttributes.type != InputAttributes.Type.NULL || initialSelection.isValid
+        get() = inputAttributes.type != InputAttributes.Type.NULL
 
     val isRawInputEditor: Boolean
         get() = !isRichInputEditor


### PR DESCRIPTION
## Description

Fixes #3204 by adjusting the raw input method detection. Acode intends to be interacted with as a raw input method editor, but FlorisBoard falsely detected it as rich, resulting in many inconsistencies and state bugs.

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
