### PR TITLE
Tentative fix for android resource linking error, benchmark app name replacement

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,11 @@ android {
                 java {
                     srcDirs("src/main/kotlin")
                 }
+                maybeCreate("androidTest").apply {
+                    res {
+                        srcDirs("src/main/res")
+                    }
+                }
             }
         }
     }
@@ -152,15 +157,12 @@ android {
         }
 
         create("benchmark") {
-            initWith(getByName("release"))
-
             applicationIdSuffix = ".bench"
             versionNameSuffix = "-bench+${getGitCommitHash(short = true).get()}"
-
             signingConfig = signingConfigs.getByName("debug")
             matchingFallbacks += listOf("release")
 
-            resValue("string", "floris_app_name", "FlorisBoard Bench")
+            resValue("string", "floris_app_name", "FlorisBoard Benchmark")
         }
     }
 
@@ -243,6 +245,7 @@ dependencies {
     testImplementation(libs.turbine)
     androidTestImplementation(libs.androidx.test.ext)
     androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.core.splashscreen)
 }
 
 fun getGitCommitHash(short: Boolean = false): Provider<String> {


### PR DESCRIPTION
## Description

Okay, so this is a fix for two things: 

1) The benchmark app name string gets replaced, and the compiler doesn't like that, so I just deleted the initwith(getByName("release")) statement (and changed Bench in the name to benchmark, for clarity.

2) The main thing this does is fixes the Android Resource Linking Errors that occur whenever I try to build the project. This happens on the main branch with a freshly cloned Florisboard repo (aka no changes other than the ones you've made). It occurs in Android Studio and IntelliJ IDEA on both Windows and Linux (I have a dual-boot Kubuntu and it also happens there when I try to build).

Without the sourceSet addition:
<img width="2560" height="490" alt="BuildOutputLog1" src="https://github.com/user-attachments/assets/aac00d3e-d726-472a-b4ea-e419d01d956c" />

Without the androidTesImplementation addition:
<img width="2560" height="504" alt="BuildOutputLog2" src="https://github.com/user-attachments/assets/fd61cd53-9a7b-4402-9cbc-51e33daf1b38" />

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
