### PR TITLE
Added Azerbaijani Alt Layout [QƏERTY] As An Alternative To Azerbaijani

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -45,6 +45,12 @@
         "direction": "ltr"
       },
       {
+        "id": "azerbaijani_alt",
+        "label": "Azerbaijani Alt",
+        "authors": [ "os-guy-original" ],
+        "direction": "ltr"
+      },
+      {
         "id": "azerty",
         "label": "AZERTY",
         "authors": [ "patrickgold" ],

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/azerbaijani_alt.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/azerbaijani_alt.json
@@ -1,0 +1,37 @@
+[
+  [
+    { "$": "auto_text_key", "code":  113, "label": "q" },
+    { "$": "auto_text_key", "code":  601, "label": "ə" },
+    { "$": "auto_text_key", "code":  101, "label": "e" },
+    { "$": "auto_text_key", "code":  114, "label": "r" },
+    { "$": "auto_text_key", "code":  116, "label": "t" },
+    { "$": "auto_text_key", "code":  121, "label": "y" },
+    { "$": "auto_text_key", "code":  117, "label": "u" },
+    { "$": "case_selector",
+      "lower": { "code":  105, "label": "i" },
+      "upper": { "code":  304, "label": "İ" }
+    },
+    { "$": "auto_text_key", "code":  111, "label": "o" },
+    { "$": "auto_text_key", "code":  112, "label": "p" }
+  ],
+  [
+    { "$": "auto_text_key", "code":   97, "label": "a" },
+    { "$": "auto_text_key", "code":  115, "label": "s" },
+    { "$": "auto_text_key", "code":  100, "label": "d" },
+    { "$": "auto_text_key", "code":  102, "label": "f" },
+    { "$": "auto_text_key", "code":  103, "label": "g" },
+    { "$": "auto_text_key", "code":  104, "label": "h" },
+    { "$": "auto_text_key", "code":  106, "label": "j" },
+    { "$": "auto_text_key", "code":  107, "label": "k" },
+    { "$": "auto_text_key", "code":  108, "label": "l" }
+  ],
+  [
+    { "$": "auto_text_key", "code":  122, "label": "z" },
+    { "$": "auto_text_key", "code":  120, "label": "x" },
+    { "$": "auto_text_key", "code":   99, "label": "c" },
+    { "$": "auto_text_key", "code":  118, "label": "v" },
+    { "$": "auto_text_key", "code":   98, "label": "b" },
+    { "$": "auto_text_key", "code":  110, "label": "n" },
+    { "$": "auto_text_key", "code":  109, "label": "m" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -28,6 +28,7 @@
     { "id": "default", "authors": [ "patrickgold" ] },
     { "id": "ar", "authors": [ "HeiWiper" ] },
     { "id": "ast", "authors": [ "Softastur" ] },
+    { "id": "az", "authors": [ "os-guy-original" ] },
     { "id": "bg", "authors": [ "iorvethe" ] },
     { "id": "bn-BD", "authors": [ "iamrasel" ] },
     { "id": "ca", "authors": [ "mikelloc" ] },

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/az.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/az.json
@@ -1,0 +1,123 @@
+{
+  "all": {
+    "ə": {
+      "main": { "$": "auto_text_key", "code":  119, "label": "w" }
+    },
+    "e": {
+      "main": { "$": "auto_text_key", "code":  601, "label": "ə" },
+      "relevant" : [
+         { "$": "auto_text_key", "code":  233, "label": "é" }
+      ]
+    },
+    "y": {
+      "main": { "$": "auto_text_key", "code":  253, "label": "ý" }
+    },
+    "u": {
+      "main": { "$": "auto_text_key", "code":  252, "label": "ü" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  251, "label": "û" },
+        { "$": "auto_text_key", "code":  363, "label": "ū" },
+        { "$": "auto_text_key", "code":  249, "label": "ù" },
+        { "$": "auto_text_key", "code":  250, "label": "ú" }
+      ]
+    },
+    "i": {
+      "main": { "$": "case_selector",
+        "lower": { "code":  305, "label": "ı" },
+        "upper": { "code":   73, "label": "I" }
+      },
+      "relevant": [
+        { "$": "auto_text_key", "code":  238, "label": "î" },
+        { "$": "auto_text_key", "code":  303, "label": "į" },
+        { "$": "auto_text_key", "code":  236, "label": "ì" },
+        { "$": "auto_text_key", "code":  237, "label": "í" },
+        { "$": "auto_text_key", "code":  299, "label": "ī" },
+        { "$": "auto_text_key", "code":  239, "label": "ï" }
+      ]
+    },
+    "o": {
+      "main": { "$": "auto_text_key", "code":  246, "label": "ö" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  248, "label": "ø" },
+        { "$": "auto_text_key", "code":  243, "label": "ó" },
+        { "$": "auto_text_key", "code":  245, "label": "õ" },
+        { "$": "auto_text_key", "code":  333, "label": "ō" },
+        { "$": "auto_text_key", "code":  242, "label": "ò" },
+        { "$": "auto_text_key", "code":  244, "label": "ô" },
+        { "$": "auto_text_key", "code":  339, "label": "œ" }
+      ]
+    },
+    "a": {
+      "main": { "$": "auto_text_key", "code":  226, "label": "â" },
+      "relevant" : [
+        { "$": "auto_text_key", "code":  228, "label": "ä" },
+        { "$": "auto_text_key", "code":  225, "label": "á" }
+      ]
+    },
+    "s": {
+      "main": { "$": "auto_text_key", "code":  351, "label": "ş" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  347, "label": "ś" },
+        { "$": "auto_text_key", "code":  223, "label": "ß" },
+        { "$": "auto_text_key", "code":  353, "label": "š" }
+      ]
+    },
+    "g": {
+      "main": { "$": "auto_text_key", "code":  287, "label": "ğ" }
+    },
+    "z": {
+      "main": { "$": "auto_text_key", "code":  382, "label": "ž" }
+    },
+    "c": {
+      "main": { "$": "auto_text_key", "code":  231, "label": "ç" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  269, "label": "č" },
+        { "$": "auto_text_key", "code":  263, "label": "ć" }
+      ]
+    },
+    "n": {
+      "main": { "$": "auto_text_key", "code":  328, "label": "ň" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  241, "label": "ñ" }
+      ]
+    },
+    "~right": {
+      "main": { "code":   44, "label": "," },
+      "relevant": [
+        { "code":   38, "label": "&" },
+        { "code":   37, "label": "%" },
+        { "code":   43, "label": "+" },
+        { "code":   34, "label": "\"" },
+        { "code":   45, "label": "-" },
+        { "code":   58, "label": ":" },
+        { "code":   39, "label": "'" },
+        { "code":   64, "label": "@" },
+        { "code":   59, "label": ";" },
+        { "code":   47, "label": "/" },
+        { "$": "layout_direction_selector",
+          "ltr": { "code":   40, "label": "(" },
+          "rtl": { "code":   41, "label": "(" }
+        },
+        { "$": "layout_direction_selector",
+          "ltr": { "code":   41, "label": ")" },
+          "rtl": { "code":   40, "label": ")" }
+        },
+        { "code":   35, "label": "#" },
+        { "code":   33, "label": "!" },
+        { "code":   63, "label": "?" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".com" },
+      "relevant": [
+        { "code": -255, "label": ".gov.az" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".edu.az" },
+        { "code": -255, "label": ".com.az" },
+        { "code": -255, "label": ".net" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

Some people in Azerbaijan uses the QƏERTY keyboard layout.
It's also known as the "Azərbaycan dili" in the GBoard, which is the first option.

<img width="738" height="1600" alt="image" src="https://github.com/user-attachments/assets/5bedada3-b508-4b50-8067-9f79b57785fe" />

It appears on the Samsung Keyboard when user chooses the Azerbaijani language with the QWERTY layout.

<img width="738" height="1600" alt="image" src="https://github.com/user-attachments/assets/9a3ada43-2b27-4858-af95-de3adc178a01" />

The current Azerbaijani layout is mostly suitable for PC keyboards, not mobile.

This layout is more usable in Azerbaijan since the letter "ə" is used in a lot of words in Azerbaijani and is more accessible in this layout.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
