### PR TITLE
Add Kaitag (`xdq`) layout

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -275,6 +275,12 @@
         "modifier": "org.florisboard.layouts:jis"
       },
       {
+        "id": "kaitag_jcuken",
+        "label": "Kaitag (ЙЦУКЕН)",
+        "authors": [ "alkaitagi" ],
+        "direction": "ltr"
+      },
+      {
         "id": "korean",
         "label": "South Korean standard",
         "authors": [ "patrickgold", "Hayleia" ],

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/kaitag_jcuken.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/kaitag_jcuken.json
@@ -1,0 +1,39 @@
+[
+  [
+    { "$": "auto_text_key", "code": 1081, "label": "й" },
+    { "$": "auto_text_key", "code": 1094, "label": "ц" },
+    { "$": "auto_text_key", "code": 1091, "label": "у" },
+    { "$": "auto_text_key", "code": 1082, "label": "к" },
+    { "$": "auto_text_key", "code": 1077, "label": "е" },
+    { "$": "auto_text_key", "code": 1085, "label": "н" },
+    { "$": "auto_text_key", "code": 1075, "label": "г" },
+    { "$": "auto_text_key", "code": 1096, "label": "ш" },
+    { "$": "auto_text_key", "code": 1185, "label": "ҡ" },
+    { "$": "auto_text_key", "code": 1079, "label": "з" },
+    { "$": "auto_text_key", "code": 1093, "label": "х" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1203, "label": "ҳ" },
+    { "$": "auto_text_key", "code": 1171, "label": "ғ" },
+    { "$": "auto_text_key", "code": 1074, "label": "в" },
+    { "$": "auto_text_key", "code": 1072, "label": "а" },
+    { "$": "auto_text_key", "code": 1087, "label": "п" },
+    { "$": "auto_text_key", "code": 1088, "label": "р" },
+    { "$": "auto_text_key", "code": 1086, "label": "о" },
+    { "$": "auto_text_key", "code": 1083, "label": "л" },
+    { "$": "auto_text_key", "code": 1076, "label": "д" },
+    { "$": "auto_text_key", "code": 1078, "label": "ж" },
+    { "$": "auto_text_key", "code": 1098, "label": "ъ" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1103, "label": "я" },
+    { "$": "auto_text_key", "code": 1095, "label": "ч" },
+    { "$": "auto_text_key", "code": 1089, "label": "с" },
+    { "$": "auto_text_key", "code": 1084, "label": "м" },
+    { "$": "auto_text_key", "code": 1080, "label": "и" },
+    { "$": "auto_text_key", "code": 1090, "label": "т" },
+    { "$": "auto_text_key", "code": 1100, "label": "ь" },
+    { "$": "auto_text_key", "code": 1073, "label": "б" },
+    { "$": "auto_text_key", "code": 1231, "label": "ӏ" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -80,7 +80,8 @@
     { "id": "uk", "authors": [ "williamtheaker", "33kk", "honsiorovskyi" ] },
     { "id": "uk-cyr-ext", "authors": [ "williamtheaker", "33kk", "honsiorovskyi" ] },
     { "id": "ur-PK", "authors": [ "mubashir-rehman", "mirfatif" ] },
-    { "id": "vi-VN", "authors": [ "patrickgold", "Hayleia" ] }
+    { "id": "vi-VN", "authors": [ "patrickgold", "Hayleia" ] },
+    { "id": "xdq", "authors": [ "alkaitagi" ] }
   ],
   "subtypePresets": [
     {
@@ -449,6 +450,15 @@
       "popupMapping": "org.florisboard.localization:ru",
       "preferred": {
         "characters": "org.florisboard.layouts:jcuken_russian"
+      }
+    },
+    {
+      "languageTag": "xdq",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:russian_ruble",
+      "popupMapping": "org.florisboard.localization:xdq",
+      "preferred": {
+        "characters": "org.florisboard.layouts:kaitag_jcuken"
       }
     },
     {

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/xdq.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/xdq.json
@@ -1,0 +1,103 @@
+{
+  "all": {
+    "а": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "multi_text_key", "codePoints": [1072, 769], "label": "а́" },
+          "upper": { "$": "multi_text_key", "codePoints": [1040, 769], "label": "А́" }
+        }
+      ]
+    },
+    "е": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 1101, "label": "э" },
+        { "$": "case_selector",
+          "lower": { "$": "multi_text_key", "codePoints": [1077, 769], "label": "е́" },
+          "upper": { "$": "multi_text_key", "codePoints": [1045, 769], "label": "Е́" }
+        },
+        { "$": "auto_text_key", "code": 1105, "label": "ё" }
+      ]
+    },
+    "и": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 1099, "label": "ы" },
+        { "$": "case_selector",
+          "lower": { "$": "multi_text_key", "codePoints": [1080, 769], "label": "и́" },
+          "upper": { "$": "multi_text_key", "codePoints": [1048, 769], "label": "И́" }
+        }
+      ]
+    },
+    "о": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "multi_text_key", "codePoints": [1086, 769], "label": "о́" },
+          "upper": { "$": "multi_text_key", "codePoints": [1054, 769], "label": "О́" }
+        }
+      ]
+    },
+    "у": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 1102, "label": "ю" },
+        { "$": "case_selector",
+          "lower": { "$": "multi_text_key", "codePoints": [1091, 769], "label": "у́" },
+          "upper": { "$": "multi_text_key", "codePoints": [1059, 769], "label": "У́" }
+        }
+      ]
+    },
+    "я": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "multi_text_key", "codePoints": [1103, 769], "label": "я́" },
+          "upper": { "$": "multi_text_key", "codePoints": [1071, 769], "label": "Я́" }
+        }
+      ]
+    },
+    "ш": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 1097, "label": "щ" }
+      ]
+    },
+    "п": {
+      "relevant": [
+        { "$": "auto_text_key", "code": 1092, "label": "ф" }
+      ]
+    },
+    "~right": {
+      "main": { "code": 44, "label": "," },
+      "relevant": [
+        { "code": 38, "label": "&" },
+        { "code": 37, "label": "%" },
+        { "code": 43, "label": "+" },
+        { "code": 34, "label": "\"" },
+        { "code": 45, "label": "-" },
+        { "code": 58, "label": ":" },
+        { "code": 39, "label": "'" },
+        { "code": 64, "label": "@" },
+        { "code": 59, "label": ";" },
+        { "code": 47, "label": "/" },
+        { "$": "layout_direction_selector",
+          "ltr": { "code": 40, "label": "(" },
+          "rtl": { "code": 41, "label": "(" }
+        },
+        { "$": "layout_direction_selector",
+          "ltr": { "code": 41, "label": ")" },
+          "rtl": { "code": 40, "label": ")" }
+        },
+        { "code": 35, "label": "#" },
+        { "code": 33, "label": "!" },
+        { "code": 63, "label": "?" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".com" },
+      "relevant": [
+        { "code": -255, "label": ".ru" },
+        { "code": -255, "label": ".edu" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".net" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds Kaitag (ISO-639 `xdq`) layout along with long-press keys. The spec can be found [in this repo](https://github.com/urssivar/script).

There's an important issue with displaying the language name though. Because it's a small minority language unknown to the OS, naturally both the language list entry and the layout's whitespace key fallback to `xdq`. We need some sort of name overwriting mechanism; it will be needed for other small languages as well.

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
