### PR TITLE
fix: prevent IllegalStateException in InlineSuggestionsUi on recomposition

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/InlineSuggestionsUi.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/smartbar/InlineSuggestionsUi.kt
@@ -18,6 +18,7 @@ package dev.patrickgold.florisboard.ime.smartbar
 
 import android.os.Build
 import android.view.View
+import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -29,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.key
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -84,29 +86,35 @@ fun InlineSuggestionsUi(
             if (inlineSuggestion.view == null) {
                 continue
             }
-            var chipPos by remember { mutableStateOf(IntOffset.Zero) }
-            val corderRadius = dimensionResource(R.dimen.suggestions_chip_corner_radius)
-            val shape = remember(corderRadius) { RoundedCornerShape(corderRadius) }
-            AndroidView(
-                modifier = Modifier
-                    .onGloballyPositioned { chipPos = it.positionInParent().toIntOffset() }
-                    .padding(InlineSuggestionsChipMargin)
-                    .clip(shape),
-                factory = { inlineSuggestion.view },
-                update = { view ->
-                    view.isZOrderedOnTop = isZOrderedOnTop
-                    // TODO scroll clip can probably also be done in Jetpack Compose
-                    val xMin = scrollState.value
-                    val xMax = scrollState.value + scrollState.viewportSize
-                    view.clipBounds = android.graphics.Rect(
-                        (xMin - chipPos.x).coerceAtLeast(0),
-                        0,
-                        (xMax - chipPos.x).coerceAtMost(view.width),
-                        view.height,
-                    )
-                    view.visibility = if (view.clipBounds.isEmpty) View.INVISIBLE else View.VISIBLE
-                }
-            )
+            key(System.identityHashCode(inlineSuggestion.view)) {
+                var chipPos by remember { mutableStateOf(IntOffset.Zero) }
+                val corderRadius = dimensionResource(R.dimen.suggestions_chip_corner_radius)
+                val shape = remember(corderRadius) { RoundedCornerShape(corderRadius) }
+                AndroidView(
+                    modifier = Modifier
+                        .onGloballyPositioned { chipPos = it.positionInParent().toIntOffset() }
+                        .padding(InlineSuggestionsChipMargin)
+                        .clip(shape),
+                    factory = {
+                        val view = inlineSuggestion.view
+                        (view.parent as? ViewGroup)?.removeView(view)
+                        view
+                    },
+                    update = { view ->
+                        view.isZOrderedOnTop = isZOrderedOnTop
+                        // TODO scroll clip can probably also be done in Jetpack Compose
+                        val xMin = scrollState.value
+                        val xMax = scrollState.value + scrollState.viewportSize
+                        view.clipBounds = android.graphics.Rect(
+                            (xMin - chipPos.x).coerceAtLeast(0),
+                            0,
+                            (xMax - chipPos.x).coerceAtMost(view.width),
+                            view.height,
+                        )
+                        view.visibility = if (view.clipBounds.isEmpty) View.INVISIBLE else View.VISIBLE
+                    }
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`InlineSuggestionsUi` crashes with `IllegalStateException: The specified child already has a parent` on Android 16 (API 36) when inline autofill suggestions trigger a recomposition.

The `AndroidView` factory directly returns `inlineSuggestion.view`, which may still be attached to a previous parent `ViewGroup`. On recomposition, Compose creates a new `AndroidViewHolder` and attempts to add the same view again.

### Stacktrace
```
java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
  at android.view.ViewGroup.addViewInner(ViewGroup.java:5297)
  at android.view.ViewGroup.addView(ViewGroup.java:5126)
  at androidx.compose.ui.viewinterop.AndroidViewHolder.<init>(...)
  at androidx.compose.ui.viewinterop.ViewFactoryHolder.<init>(...)
```

### Environment
- Device: Pixel 10 Pro (blazer)
- Android: 16 (BAKLAVA, SDK 36)
- FlorisBoard: 0.6.0-alpha02 (119)
- Inline autofill enabled

## Fix

1. Wrap each inline suggestion in `key(System.identityHashCode(view))` to stabilize Compose identity tracking across recompositions
2. Call `removeView()` on the old parent in the factory block as a safety net before the view is re-added

## Changes

Single file: `InlineSuggestionsUi.kt` — no other files touched.