### PR TITLE
docs: add local build and deploy instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,95 @@ Feature roadmap: See [ROADMAP.md](ROADMAP.md)
 Want to contribute to FlorisBoard? That's great to hear! There are lots of
 different ways to help out, please see the [contribution guidelines](CONTRIBUTING.md) for more info.
 
+## Building and deploying locally
+
+### Prerequisites
+
+| Tool | Required version |
+|------|-----------------|
+| JDK | 17 |
+| Android SDK (compile) | API 36 |
+| Android NDK | 29.0.14206865 |
+| CMake | 3.22+ (4.1.2 recommended) |
+| Clang | 15+ |
+| Rust / rustup | 1.28.2+ (toolchain 1.93.0) |
+| Git | any recent version |
+
+The easiest way to get the Android SDK and NDK is through **Android Studio** (or IntelliJ IDEA with the Android + Compose plugins). Rust can be installed via [rustup](https://www.rust-lang.org/tools/install).
+
+> [!NOTE]
+> IntelliJ IDEA users must enable **Future AGP Versions** support for AGP 9.0.0 to work.
+> See [this YouTrack comment](https://youtrack.jetbrains.com/issue/IDEA-348937/2024.1-Beta-missing-option-to-enable-sync-with-future-AGP-versions#focus=Comments-27-11721710.0-0) for instructions.
+
+### Clone the repository
+
+```bash
+git clone https://github.com/florisboard/florisboard.git
+cd florisboard
+```
+
+### Build a debug APK (development / sideload)
+
+```bash
+./gradlew assembleDebug
+```
+
+The resulting APK is written to:
+
+```
+app/build/outputs/apk/debug/app-debug.apk
+```
+
+> [!NOTE]
+> The debug build appends `.debug` to the application ID (`dev.patrickgold.florisboard.debug`), so it installs alongside the release version without conflicts.
+
+### Build a release APK
+
+Unsigned (for local testing):
+
+```bash
+./gradlew assembleRelease
+```
+
+To sign the APK, configure a keystore in `app/build.gradle.kts` or pass signing properties on the command line, then run the same command. The output is at:
+
+```
+app/build/outputs/apk/release/app-release.apk
+```
+
+### Install directly to a connected device / emulator
+
+Ensure ADB is in your `PATH` and a device is connected (or an emulator is running), then:
+
+```bash
+# Debug build – build + install in one step
+./gradlew installDebug
+```
+
+Verify the installation succeeded:
+
+```bash
+adb shell pm list packages | grep florisboard
+```
+
+### Enable FlorisBoard after installation
+
+1. Open **Settings → System → Language & Input → On-screen keyboard** (path may vary by manufacturer).
+2. Enable **FlorisBoard** in the keyboard list.
+3. Switch to FlorisBoard from the keyboard selector in any text field.
+
+### Run unit tests
+
+```bash
+./gradlew test
+```
+
+### Clean the build
+
+```bash
+./gradlew clean
+```
+
 ## Addons Store
 The official [Addons Store](https://beta.addons.florisboard.org) offers the possibility for the community to share and download FlorisBoard extensions.
 Instructions on how to publish addons can be found [here](https://github.com/florisboard/florisboard/wiki/How-to-publish-on-FlorisBoard-Addons).


### PR DESCRIPTION
## Description

Extends the readme with instructions to build it locally and deploy it onto a device.

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [ ] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
