### PR TITLE
feat: support icon hints for system_gui keys

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/Key.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/Key.kt
@@ -95,6 +95,11 @@ abstract class Key(open val data: AbstractKeyData) {
     open var hintedLabel: String? = null
 
     /**
+     * The computed UI hint ImageVector of this key. Used when the hint has an icon instead of a text label.
+     */
+    open var hintedImageVector: ImageVector? = null
+
+    /**
      * The computed ImageVector of this key. This value is used by the keyboard view to temporarily save the
      * ImageVector for UI rendering and should not be set manually.
      */

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/LayoutManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/LayoutManager.kt
@@ -301,7 +301,9 @@ class LayoutManager(context: Context) {
     private fun addRowHints(main: Array<TextKey>, hint: Array<TextKey>, hintType: KeyType) {
         for ((k,key) in main.withIndex()) {
             val hintKey = hint.getOrNull(k)?.data?.compute(DefaultComputingEvaluator)
-            if (hintKey?.type != hintType) {
+            val typeMatch = hintKey?.type == hintType ||
+                (hintType == KeyType.CHARACTER && hintKey?.type == KeyType.SYSTEM_GUI)
+            if (!typeMatch) {
                 continue
             }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKey.kt
@@ -228,6 +228,7 @@ class TextKey(override val data: AbstractKeyData) : Key(data) {
     fun computeLabelsAndDrawables(evaluator: ComputingEvaluator) {
         label = evaluator.computeLabel(computedData)
         hintedLabel = null
+        hintedImageVector = null
         foregroundImageVector = evaluator.computeImageVector(computedData)
 
         val data = computedData
@@ -249,11 +250,27 @@ class TextKey(override val data: AbstractKeyData) : Key(data) {
             val prefs by FlorisPreferenceStore
             computedPopups.getPopupKeys(prefs.keyboard.keyHintConfiguration()).hint.let { hintData ->
                 if (hintData?.isSpaceKey() == false) {
-                    hintedLabel = hintData.asString(isForDisplay = true)
+                    if (hintData.code < 0) {
+                        hintedImageVector = evaluator.computeImageVector(hintData)
+                    } else {
+                        hintedLabel = hintData.asString(isForDisplay = true)
+                    }
                     computedHintData = hintData
                 } else {
-                    hintedLabel = null
-                    computedHintData = TextKeyData.UNSPECIFIED
+                    val mainData = computedPopups.main
+                    if (mainData != null && mainData.code < 0) {
+                        val icon = evaluator.computeImageVector(mainData)
+                        if (icon != null) {
+                            hintedImageVector = icon
+                            computedHintData = mainData
+                        } else {
+                            hintedLabel = null
+                            computedHintData = TextKeyData.UNSPECIFIED
+                        }
+                    } else {
+                        hintedLabel = null
+                        computedHintData = TextKeyData.UNSPECIFIED
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -56,6 +57,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import dev.patrickgold.florisboard.FlorisImeService
 import dev.patrickgold.florisboard.app.FlorisPreferenceStore
@@ -368,6 +370,18 @@ private fun TextKeyButton(
                     .wrapContentSize()
                     .align(if (isTelPadKey) BiasAlignment(0.5f, 0f) else Alignment.TopEnd),
                 text = hintedLabel,
+            )
+        }
+        key.hintedImageVector?.let { hintedImageVector ->
+            SnyggIcon(
+                elementName = FlorisImeUi.KeyHint.elementName,
+                attributes = attributes,
+                selector = selector,
+                modifier = Modifier
+                    .size(11.dp)
+                    .align(if (isTelPadKey) BiasAlignment(0.5f, 0f) else BiasAlignment(0.85f, -0.7f)),
+                imageVector = hintedImageVector,
+                contentDescription = null,
             )
         }
         key.foregroundImageVector?.let { imageVector ->


### PR DESCRIPTION
I extended florisboard to add support for icons in the hints (see keys `a`, `s`, `,`, `.` and `ENTER`):
<img width="570" height="251" alt="image" src="https://github.com/user-attachments/assets/30c9756d-de51-49ae-a136-38f587f8bcaa" />

## Summary

This PR enables keyboard layout authors to assign **icon hints** to character
keys by placing `system_gui` action keys in the symbols layout row that aligns
with the character row.

Previously, hints were always rendered as text labels. Special action keys
(clipboard, smartbar toggle, settings, etc.) have icons via `computeImageVector`
but no meaningful text label — so they either showed an internal label string or
nothing at all in the hint position.

## Ceavat:
I made it with AI which is clearly disallowed according to the guidelines.
My Kotlin skills are very limited. I reviewed the code and it looks ok for me, but I did not write it myself.
I understand your reasons regarding AI, but I propose on rethinking the strictness of the AI guidelines!

## Changes

### `Key.kt`
Added `hintedImageVector: ImageVector?` field alongside the existing `hintedLabel`.
This stores the icon to render in the hint position when the hint key is a
system action rather than a character.

### `TextKey.kt`
In `computeLabelsAndDrawables`:
- When the resolved hint (`symbolHint` / `numberHint`) has a **negative key
  code** (all system_gui action keys use negative codes), `computeImageVector`
  is called and the result stored in `hintedImageVector` instead of setting
  `hintedLabel`.
- When no symbol/number hint exists, the existing fallback to `computedPopups.main`
  is extended: if `main` has a negative code and `computeImageVector` returns a
  non-null icon, that icon is used as the hint (e.g. a key whose only popup is a
  smartbar-toggle action will show the keyboard icon as its hint).
- `hintedImageVector` is cleared alongside `hintedLabel` on each recompute.

### `TextKeyboardLayout.kt`
Added rendering of `hintedImageVector` as a `SnyggIcon` in the hint position
(`BiasAlignment(0.85f, -0.7f)`, 11dp) when present, using the `KeyHint` style
element — consistent with how the text hint is styled.

Added missing imports: `androidx.compose.foundation.layout.size` and
`androidx.compose.ui.unit.dp`.

### `LayoutManager.kt`
`addRowHints` previously skipped any hint key whose `type != hintType`.
For symbol hints (`hintType = KeyType.CHARACTER`), `KeyType.SYSTEM_GUI` keys
are now also accepted. This allows a symbols layout to include system action
keys at specific column positions, causing those columns' character keys to
display the action's icon as a hint.

## Use Case Example

A symbols layout row can place `{ "code": -241, "type": "system_gui" }` (smartbar
toggle) at a specific column. The character key in the same column will then
show the smartbar-toggle icon as a hint and execute the action on long-press.

Similarly, clipboard paste (`-33`), settings (`-301`), or any other action with
a registered icon in `computeImageVector` can be used as a hint.

## Backwards Compatibility

- Keys with positive-code hints continue to render text labels exactly as before.
- Keys with no applicable hint are unaffected.
- No JSON schema changes required; existing layouts are unaffected.

## Testing

- Verified icon hints render correctly at the hint position for smartbar toggle,
  clipboard paste, and settings keys.
- Verified text hints on all existing character keys are unaffected.
- Verified no hint is shown when `computeImageVector` returns null for a
  negative-code hint key.
- Manually Tested on my device (Android 16)

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
