### PR TITLE
Fix and remove dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ different ways to help out, please see the [contribution guidelines](CONTRIBUTIN
 
 ## Addons Store
 The official [Addons Store](https://beta.addons.florisboard.org) offers the possibility for the community to share and download FlorisBoard extensions.
-Instructions on how to publish addons can be found [here](https://github.com/florisboard/florisboard/wiki/How-to-publish-on-FlorisBoard-Addons).
+Instructions on how to publish addons can be found [here](https://docs.florisboard.org/publishing).
 
 Many thanks to Ali ([@4H1R](https://github.com/4H1R)) for implementing the store!
 
@@ -96,7 +96,7 @@ Many thanks to Ali ([@4H1R](https://github.com/4H1R)) for implementing the store
 > Later on we plan to add support for language packs and keyboard extensions.
 
 ## List of permissions FlorisBoard requests
-Please refer to this [page](https://github.com/florisboard/florisboard/wiki/List-of-permissions-FlorisBoard-requests)
+Please refer to this [page](https://docs.florisboard.org/permissions)
 to get more information on this topic.
 
 ## APK signing certificate hashes

--- a/app/src/main/res/values/strings_dont_translate.xml
+++ b/app/src/main/res/values/strings_dont_translate.xml
@@ -6,8 +6,6 @@
     <string name="florisboard__privacy_policy_url" translatable="false">https://florisboard.org/legal/privacy/</string>
     <string name="florisboard__changelog_url" translatable="false">https://github.com/florisboard/florisboard/releases/v{version}</string>
     <string name="florisboard__commit_by_hash_url" translatable="false">https://github.com/florisboard/florisboard/commit/{hash}</string>
-    <string name="florisboard__spell_checker_wiki_url" translatable="false">https://github.com/florisboard/florisboard/wiki/System-spell-checker-service</string>
-    <string name="florisboard__theme_editor_wiki_url" translatable="false">https://github.com/florisboard/florisboard/wiki/Using-the-new-Theme-Editor</string>
     <string name="florisboard__internal_key_codes_url" translatable="false">https://github.com/florisboard/florisboard/blob/main/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/key/KeyCode.kt</string>
     <string name="florisboard__character_key_codes_url" translatable="false">https://unicode-table.com/en</string>
 


### PR DESCRIPTION
## Description

Since the migration to our own docs and the deactivation of the wiki here on github there were dead links in the `README.md`. This PR fixes the dead links by pointing over at https://docs.florisboard.org.

I've also removed some unused links that were heavily outdated in `strings_dont_translate.xml`

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
