### PR TITLE
Fix crash in clipboard view caused by to long text

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardInputLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/ClipboardInputLayout.kt
@@ -128,6 +128,7 @@ import org.florisboard.lib.snygg.ui.SnyggIcon
 import org.florisboard.lib.snygg.ui.SnyggIconButton
 import org.florisboard.lib.snygg.ui.SnyggRow
 import org.florisboard.lib.snygg.ui.SnyggText
+import kotlin.time.Duration.Companion.milliseconds
 
 private val ItemWidth = 200.dp
 private val DialogWidth = 240.dp
@@ -169,7 +170,7 @@ fun ClipboardInputLayout(
     fun isPopupSurfaceActive() = popupItem != null || showClearAllHistory
 
     LaunchedEffect(isFilterRowShown) {
-        delay(AnimationDuration.toLong())
+        delay(AnimationDuration.milliseconds)
         if (!isFilterRowShown) {
             activeFilterTypes.clear()
         }
@@ -346,7 +347,7 @@ fun ClipboardInputLayout(
                     )
                 }
             } else {
-                val text = item.stringRepresentation()
+                val text = remember(item) { item.stringRepresentation() }
                 Column {
                     ClipTextItemDescription(
                         elementName = FlorisImeUi.ClipboardItemDescription.elementName,

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
@@ -27,6 +27,7 @@ import android.provider.BaseColumns
 import android.provider.MediaStore.Images.Media
 import android.provider.OpenableColumns
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.database.getStringOrNull
 import androidx.core.net.toUri
@@ -104,6 +105,7 @@ data class ClipboardItem @OptIn(ExperimentalSerializationApi::class) constructor
          */
         private val TEXT_PLAIN = listOf("text/plain")
         private val MEDIA_PROJECTION = arrayOf(OpenableColumns.DISPLAY_NAME)
+        private const val CLIPBAORD_TEXT_MAX_DISPLAY_LENGTH = 5000
 
         const val FLORIS_CLIP_LABEL = "florisboard/clipboard_item"
 
@@ -187,7 +189,7 @@ data class ClipboardItem @OptIn(ExperimentalSerializationApi::class) constructor
     @Composable
     inline fun displayText(): String {
         val context = LocalContext.current
-        return displayText(context)
+        return remember(this) { displayText(context) }
     }
 
     fun displayText(context: Context): String {
@@ -231,7 +233,11 @@ data class ClipboardItem @OptIn(ExperimentalSerializationApi::class) constructor
 
     fun stringRepresentation(): String {
         return when {
-            text != null -> text
+            text != null -> if (text.length > CLIPBAORD_TEXT_MAX_DISPLAY_LENGTH) {
+                text.take(CLIPBAORD_TEXT_MAX_DISPLAY_LENGTH) + Typography.ellipsis
+            } else {
+                text
+            }
             uri != null -> "(Image) $uri"
             else -> "#ERROR"
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/clipboard/provider/ClipboardDatabase.kt
@@ -27,6 +27,7 @@ import android.provider.BaseColumns
 import android.provider.MediaStore.Images.Media
 import android.provider.OpenableColumns
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.database.getStringOrNull
 import androidx.core.net.toUri
@@ -104,6 +105,7 @@ data class ClipboardItem @OptIn(ExperimentalSerializationApi::class) constructor
          */
         private val TEXT_PLAIN = listOf("text/plain")
         private val MEDIA_PROJECTION = arrayOf(OpenableColumns.DISPLAY_NAME)
+        private const val CLIPBAORD_TEXT_MAX_DISPLAY_LENGTH = 5000
 
         const val FLORIS_CLIP_LABEL = "florisboard/clipboard_item"
 
@@ -187,7 +189,7 @@ data class ClipboardItem @OptIn(ExperimentalSerializationApi::class) constructor
     @Composable
     inline fun displayText(): String {
         val context = LocalContext.current
-        return displayText(context)
+        return remember(this) { displayText(context) }
     }
 
     fun displayText(context: Context): String {
@@ -231,7 +233,12 @@ data class ClipboardItem @OptIn(ExperimentalSerializationApi::class) constructor
 
     fun stringRepresentation(): String {
         return when {
-            text != null -> text
+            text != null -> text.take(CLIPBAORD_TEXT_MAX_DISPLAY_LENGTH).let {
+                if (it != text) {
+                    return@let it.plus(Typography.ellipsis)
+                }
+                it
+            }
             uri != null -> "(Image) $uri"
             else -> "#ERROR"
         }


### PR DESCRIPTION
## Description

This PR limits the display length to 5000 chars. If the length is exceeded the string will get truncated with an ellipsis. The content of the text and stringRepresentation() are now properly remembered by compose.

Closes: #3117 

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
