### PR TITLE
Include a check for the latest version in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,6 +13,7 @@ body:
         • Describe the bug in a short but concise way.
         • If you have a screenshot or screen recording of the bug, link them at the end of this issue.
         • Also make sure to fill out the environment information. This info is valuable when trying to fix your described bug.
+        • Always test if the bug is present in the [latest preview version](https://github.com/florisboard/florisboard/releases).
   - type: textarea
     id: description
     attributes:
@@ -69,6 +70,8 @@ body:
       label: "Checklist"
       options:
         - label: "I made sure that there are *no existing issues* - [open](https://github.com/florisboard/florisboard/issues) or [closed](https://github.com/florisboard/florisboard/issues?q=is%3Aissue+is%3Aclosed) - which I could contribute my information to."
+          required: true
+        - label: "I made sure that the bug is present in the [latest preview version](https://github.com/florisboard/florisboard/releases)."
           required: true
         - label: "I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md)."
           required: true


### PR DESCRIPTION
## Description

This PR adds a checkbox that is required to open the bug report which requires the user to check if the bug exists in the latest (preview) version.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).
