### PR TITLE
Feature: Add Nogai and Kazakh layouts

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -276,6 +276,18 @@
         "modifier": "org.florisboard.layouts:jis"
       },
       {
+        "id": "kazakh_cyrillic",
+        "label": "Қазақша",
+        "authors": [ "murza-enikeeff" ],
+        "direction": "ltr"
+      },
+      {
+        "id": "kazakh_latin",
+        "label": "Qazaqşa",
+        "authors": [ "murza-enikeeff" ],
+        "direction": "ltr"
+      },
+      {
         "id": "korean",
         "label": "South Korean standard",
         "authors": [ "patrickgold", "Hayleia" ],
@@ -319,6 +331,31 @@
         "authors": [ "ostrya" ],
         "direction": "ltr",
         "modifier": "org.florisboard.layouts:neo2"
+      },
+      {
+        "id": "nogai_cyrillic",
+        "label": "Ногъайша",
+        "authors": [ "murza-enikeeff" ],
+        "direction": "ltr"
+      },
+      {
+        "id": "nogai_latin",
+        "label": "Noğayşa",
+        "authors": [ "murza-enikeeff" ],
+        "direction": "ltr"
+      },
+      {
+        "id": "nogai_arabic",
+        "label": "نوغاي",
+        "authors": [ "murza-enikeeff" ],
+        "direction": "rtl",
+        "modifier": "org.florisboard.layouts:arabic"
+      },
+      {
+        "id": "nogai_runic",
+        "label": "Nogai (Runic)",
+        "authors": [ "murza-enikeeff" ],
+        "direction": "ltr"
       },
       {
         "id": "norwegian",

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/kazakh_cyrillic.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/kazakh_cyrillic.json
@@ -1,0 +1,39 @@
+[
+  [
+    { "$": "auto_text_key", "code": 1081, "label": "й" },
+    { "$": "auto_text_key", "code": 1094, "label": "ц" },
+    { "$": "auto_text_key", "code": 1091, "label": "у" },
+    { "$": "auto_text_key", "code": 1082, "label": "к" },
+    { "$": "auto_text_key", "code": 1077, "label": "е" },
+    { "$": "auto_text_key", "code": 1085, "label": "н" },
+    { "$": "auto_text_key", "code": 1075, "label": "г" },
+    { "$": "auto_text_key", "code": 1096, "label": "ш" },
+    { "$": "auto_text_key", "code": 1097, "label": "щ" },
+    { "$": "auto_text_key", "code": 1079, "label": "з" },
+    { "$": "auto_text_key", "code": 1093, "label": "х" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1092, "label": "ф" },
+    { "$": "auto_text_key", "code": 1099, "label": "ы" },
+    { "$": "auto_text_key", "code": 1074, "label": "в" },
+    { "$": "auto_text_key", "code": 1072, "label": "а" },
+    { "$": "auto_text_key", "code": 1087, "label": "п" },
+    { "$": "auto_text_key", "code": 1088, "label": "р" },
+    { "$": "auto_text_key", "code": 1086, "label": "о" },
+    { "$": "auto_text_key", "code": 1083, "label": "л" },
+    { "$": "auto_text_key", "code": 1076, "label": "д" },
+    { "$": "auto_text_key", "code": 1078, "label": "ж" },
+    { "$": "auto_text_key", "code": 1101, "label": "э" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1103, "label": "я" },
+    { "$": "auto_text_key", "code": 1095, "label": "ч" },
+    { "$": "auto_text_key", "code": 1089, "label": "с" },
+    { "$": "auto_text_key", "code": 1084, "label": "м" },
+    { "$": "auto_text_key", "code": 1080, "label": "и" },
+    { "$": "auto_text_key", "code": 1090, "label": "т" },
+    { "$": "auto_text_key", "code": 1100, "label": "ь" },
+    { "$": "auto_text_key", "code": 1073, "label": "б" },
+    { "$": "auto_text_key", "code": 1102, "label": "ю" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/kazakh_latin.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/kazakh_latin.json
@@ -1,0 +1,34 @@
+[
+  [
+    { "$": "auto_text_key", "code":  113, "label": "q" },
+    { "$": "auto_text_key", "code":  119, "label": "w" },
+    { "$": "auto_text_key", "code":  101, "label": "e" },
+    { "$": "auto_text_key", "code":  114, "label": "r" },
+    { "$": "auto_text_key", "code":  116, "label": "t" },
+    { "$": "auto_text_key", "code":  121, "label": "y" },
+    { "$": "auto_text_key", "code":  117, "label": "u" },
+    { "$": "auto_text_key", "code":  105, "label": "i" },
+    { "$": "auto_text_key", "code":  111, "label": "o" },
+    { "$": "auto_text_key", "code":  112, "label": "p" }
+  ],
+  [
+    { "$": "auto_text_key", "code":   97, "label": "a" },
+    { "$": "auto_text_key", "code":  115, "label": "s" },
+    { "$": "auto_text_key", "code":  100, "label": "d" },
+    { "$": "auto_text_key", "code":  102, "label": "f" },
+    { "$": "auto_text_key", "code":  103, "label": "g" },
+    { "$": "auto_text_key", "code":  104, "label": "h" },
+    { "$": "auto_text_key", "code":  106, "label": "j" },
+    { "$": "auto_text_key", "code":  107, "label": "k" },
+    { "$": "auto_text_key", "code":  108, "label": "l" }
+  ],
+  [
+    { "$": "auto_text_key", "code":  122, "label": "z" },
+    { "$": "auto_text_key", "code":  120, "label": "x" },
+    { "$": "auto_text_key", "code":   99, "label": "c" },
+    { "$": "auto_text_key", "code":  118, "label": "v" },
+    { "$": "auto_text_key", "code":   98, "label": "b" },
+    { "$": "auto_text_key", "code":  110, "label": "n" },
+    { "$": "auto_text_key", "code":  109, "label": "m" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/nogai_arabic.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/nogai_arabic.json
@@ -1,0 +1,40 @@
+[
+  [
+    { "code": 1709, "label": "ڭ" },
+    { "code": 1734, "label": "ۆ" },
+    { "code": 1735, "label": "ۇ" },
+    { "code": 1602, "label": "ق" },
+    { "code": 1601, "label": "ف" },
+    { "code": 1594, "label": "غ" },
+    { "code": 1593, "label": "ع" },
+    { "code": 1607, "label": "ه" },
+    { "code": 1582, "label": "خ" },
+    { "code": 1581, "label": "ح" },
+    { "code": 1580, "label": "ج" }
+  ],
+  [
+    { "code": 1588, "label": "ش" },
+    { "code": 1587, "label": "س" },
+    { "code": 1610, "label": "ي" },
+    { "code": 1576, "label": "ب" },
+    { "code": 1604, "label": "ل" },
+    { "code": 1575, "label": "ا" },
+    { "code": 1578, "label": "ت" },
+    { "code": 1606, "label": "ن" },
+    { "code": 1605, "label": "م" },
+    { "code": 1603, "label": "ك" },
+    { "code": 1662, "label": "پ" }
+  ],
+  [
+    { "code": 1670, "label": "چ" },
+    { "code": 1749, "label": "ە" },
+    { "code": 1574, "label": "ئ" },
+    { "code": 1585, "label": "ر" },
+    { "code": 1609, "label": "ى" },
+    { "code": 1736, "label": "ۈ" },
+    { "code": 1608, "label": "و" },
+    { "code": 1586, "label": "ز" },
+    { "code": 1711, "label": "گ" },
+    { "code": 1583, "label": "د" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/nogai_cyrillic.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/nogai_cyrillic.json
@@ -1,0 +1,40 @@
+[
+  [
+    { "$": "auto_text_key", "code": 1081, "label": "й" },
+    { "$": "auto_text_key", "code": 1094, "label": "ц" },
+    { "$": "auto_text_key", "code": 1091, "label": "у" },
+    { "$": "auto_text_key", "code": 1082, "label": "к" },
+    { "$": "auto_text_key", "code": 1077, "label": "е" },
+    { "$": "auto_text_key", "code": 1085, "label": "н" },
+    { "$": "auto_text_key", "code": 1075, "label": "г" },
+    { "$": "auto_text_key", "code": 1096, "label": "ш" },
+    { "$": "auto_text_key", "code": 1097, "label": "щ" },
+    { "$": "auto_text_key", "code": 1079, "label": "з" },
+    { "$": "auto_text_key", "code": 1093, "label": "х" },
+    { "$": "auto_text_key", "code": 1098, "label": "ъ" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1092, "label": "ф" },
+    { "$": "auto_text_key", "code": 1099, "label": "ы" },
+    { "$": "auto_text_key", "code": 1074, "label": "в" },
+    { "$": "auto_text_key", "code": 1072, "label": "а" },
+    { "$": "auto_text_key", "code": 1087, "label": "п" },
+    { "$": "auto_text_key", "code": 1088, "label": "р" },
+    { "$": "auto_text_key", "code": 1086, "label": "о" },
+    { "$": "auto_text_key", "code": 1083, "label": "л" },
+    { "$": "auto_text_key", "code": 1076, "label": "д" },
+    { "$": "auto_text_key", "code": 1078, "label": "ж" },
+    { "$": "auto_text_key", "code": 1101, "label": "э" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1103, "label": "я" },
+    { "$": "auto_text_key", "code": 1095, "label": "ч" },
+    { "$": "auto_text_key", "code": 1089, "label": "с" },
+    { "$": "auto_text_key", "code": 1084, "label": "м" },
+    { "$": "auto_text_key", "code": 1080, "label": "и" },
+    { "$": "auto_text_key", "code": 1090, "label": "т" },
+    { "$": "auto_text_key", "code": 1100, "label": "ь" },
+    { "$": "auto_text_key", "code": 1073, "label": "б" },
+    { "$": "auto_text_key", "code": 1102, "label": "ю" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/nogai_latin.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/nogai_latin.json
@@ -1,0 +1,48 @@
+[
+  [
+    { "$": "auto_text_key", "code":  113, "label": "q" },
+    { "$": "auto_text_key", "code":  119, "label": "w" },
+    { "$": "auto_text_key", "code":  101, "label": "e" },
+    { "$": "auto_text_key", "code":  114, "label": "r" },
+    { "$": "auto_text_key", "code":  116, "label": "t" },
+    { "$": "auto_text_key", "code":  121, "label": "y" },
+    { "$": "auto_text_key", "code":  117, "label": "u" },
+    { "$": "case_selector",
+      "lower": { "code":  305, "label": "ı" },
+      "upper": { "code":   73, "label": "I" }
+    },
+    { "$": "auto_text_key", "code":  111, "label": "o" },
+    { "$": "auto_text_key", "code":  112, "label": "p" },
+    { "$": "auto_text_key", "code":  287, "label": "ğ" },
+    { "$": "auto_text_key", "code":  252, "label": "ü" }
+  ],
+  [
+    { "$": "auto_text_key", "code":   97, "label": "a" },
+    { "$": "auto_text_key", "code":  115, "label": "s" },
+    { "$": "auto_text_key", "code":  100, "label": "d" },
+    { "$": "auto_text_key", "code":  102, "label": "f" },
+    { "$": "auto_text_key", "code":  103, "label": "g" },
+    { "$": "auto_text_key", "code":  104, "label": "h" },
+    { "$": "auto_text_key", "code":  106, "label": "j" },
+    { "$": "auto_text_key", "code":  107, "label": "k" },
+    { "$": "auto_text_key", "code":  108, "label": "l" },
+    { "$": "auto_text_key", "code":  351, "label": "ş" },
+    { "$": "case_selector",
+      "lower": { "code":  105, "label": "i" },
+      "upper": { "code":  304, "label": "İ" }
+    },
+    { "$": "auto_text_key", "code":  228, "label": "ä" }
+  ],
+  [
+    { "$": "auto_text_key", "code":  122, "label": "z" },
+    { "$": "auto_text_key", "code":  120, "label": "x" },
+    { "$": "auto_text_key", "code":   99, "label": "c" },
+    { "$": "auto_text_key", "code":  118, "label": "v" },
+    { "$": "auto_text_key", "code":   98, "label": "b" },
+    { "$": "auto_text_key", "code":  110, "label": "n" },
+    { "$": "auto_text_key", "code":  109, "label": "m" },
+    { "$": "auto_text_key", "code":  246, "label": "ö" },
+    { "$": "auto_text_key", "code":  231, "label": "ç" },
+    { "$": "auto_text_key", "code":  241, "label": "ñ" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/nogai_runic.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/nogai_runic.json
@@ -1,0 +1,39 @@
+[
+  [
+    { "code": 68608, "label": "𐰀" },
+    { "code": 68610, "label": "𐰂" },
+    { "code": 68611, "label": "𐰃" },
+    { "code": 68614, "label": "𐰆" },
+    { "code": 68615, "label": "𐰇" },
+    { "code": 68630, "label": "𐰖" },
+    { "code": 68632, "label": "𐰘" },
+    { "code": 68666, "label": "𐰺" },
+    { "code": 68668, "label": "𐰼" },
+    { "code": 68675, "label": "𐱃" },
+    { "code": 68677, "label": "𐱅" }
+  ],
+  [
+    { "code": 68621, "label": "𐰍" },
+    { "code": 68623, "label": "𐰏" },
+    { "code": 68660, "label": "𐰴" },
+    { "code": 68634, "label": "𐰚" },
+    { "code": 68638, "label": "𐰞" },
+    { "code": 68640, "label": "𐰠" },
+    { "code": 68643, "label": "𐰣" },
+    { "code": 68644, "label": "𐰤" },
+    { "code": 68625, "label": "𐰑" },
+    { "code": 68627, "label": "𐰓" },
+    { "code": 68653, "label": "𐰭" }
+  ],
+  [
+    { "code": 68669, "label": "𐰽" },
+    { "code": 68670, "label": "𐰾" },
+    { "code": 68617, "label": "𐰉" },
+    { "code": 68619, "label": "𐰋" },
+    { "code": 68642, "label": "𐰢" },
+    { "code": 68655, "label": "𐰯" },
+    { "code": 68658, "label": "𐰲" },
+    { "code": 68673, "label": "𐱁" },
+    { "code": 68628, "label": "𐰔" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -59,12 +59,18 @@
     { "id": "ja-JP-jis", "authors": [ "waelwindows" ] },
     { "id": "ka-std", "authors": [ "nE" ] },
     { "id": "kab", "authors": [ "yanis867" ] },
+    { "id": "kk-cyrl", "authors": [ "murza-enikeeff" ] },
+    { "id": "kk-latn", "authors": [ "murza-enikeeff" ] },
     { "id": "ko", "authors": [ "patrickgold", "Hayleia" ] },
     { "id": "ko-KR", "authors": [ "Shunnuo" ] },
     { "id": "ku", "authors": [ "GoRaN" ] },
     { "id": "lt", "authors": [ "patrickgold" ] },
     { "id": "lv", "authors": [ "patrickgold", "eandersons" ] },
     { "id": "nb", "authors": [ "patrickgold" ] },
+    { "id": "nog-cyrl", "authors": [ "murza-enikeeff" ] },
+    { "id": "nog-arab", "authors": [ "murza-enikeeff" ] },
+    { "id": "nog-latn", "authors": [ "murza-enikeeff" ] },
+    { "id": "nog-orkh", "authors": [ "murza-enikeeff" ] },
     { "id": "nn", "authors": [ "patrickgold" ] },
     { "id": "pl", "authors": [ "Mikołaj Biel" ] },
     { "id": "pt", "authors": [ "patrickgold" ] },
@@ -257,6 +263,42 @@
       }
     },
     {
+      "languageTag": "nog-Cyrl",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:russian_ruble",
+      "popupMapping": "org.florisboard.localization:nog-cyrl",
+      "preferred": {
+        "characters": "org.florisboard.layouts:nogai_cyrillic"
+      }
+    },
+    {
+      "languageTag": "nog-Latn",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:russian_ruble",
+      "popupMapping": "org.florisboard.localization:nog-latn",
+      "preferred": {
+        "characters": "org.florisboard.layouts:nogai_latin"
+      }
+    },
+    {
+      "languageTag": "nog-Arab",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:russian_ruble",
+      "popupMapping": "org.florisboard.localization:nog-arab",
+      "preferred": {
+        "characters": "org.florisboard.layouts:nogai_arabic"
+      }
+    },
+    {
+      "languageTag": "nog-Orkh",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:russian_ruble",
+      "popupMapping": "org.florisboard.localization:nog-orkh",
+      "preferred": {
+        "characters": "org.florisboard.layouts:nogai_runic"
+      }
+    },
+    {
       "languageTag": "nn-NO",
       "composer": "org.florisboard.composers:appender",
       "currencySet": "org.florisboard.currencysets:dollar",
@@ -440,6 +482,24 @@
       "popupMapping": "org.florisboard.localization:ka-std",
       "preferred": {
         "characters": "org.florisboard.layouts:georgian_standard"
+      }
+    },
+    {
+      "languageTag": "kk-Cyrl",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:kazakhstani_tenge",
+      "popupMapping": "org.florisboard.localization:kk-cyrl",
+      "preferred": {
+        "characters": "org.florisboard.layouts:kazakh_cyrillic"
+      }
+    },
+    {
+      "languageTag": "kk-Latn",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:kazakhstani_tenge",
+      "popupMapping": "org.florisboard.localization:kk-latn",
+      "preferred": {
+        "characters": "org.florisboard.layouts:kazakh_latin"
       }
     },
     {

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/kk-cyrl.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/kk-cyrl.json
@@ -1,0 +1,76 @@
+{
+  "all": {
+    "а": {
+      "main": { "$": "auto_text_key", "code": 1241, "label": "ә" }
+    },
+    "г": {
+      "main": { "$": "auto_text_key", "code": 1171, "label": "ғ" }
+    },
+    "е": {
+      "main": { "$": "auto_text_key", "code": 1105, "label": "ё" }
+    },
+    "и": {
+      "main": { "$": "auto_text_key", "code": 1110, "label": "і" }
+    },
+    "к": {
+      "main": { "$": "auto_text_key", "code": 1179, "label": "қ" }
+    },
+    "н": {
+      "main": { "$": "auto_text_key", "code": 1187, "label": "ң" }
+    },
+    "о": {
+      "main": { "$": "auto_text_key", "code": 1257, "label": "ө" }
+    },
+    "у": {
+      "main": { "$": "auto_text_key", "code": 1201, "label": "ұ" },
+      "relevant": [
+        { "$": "auto_text_key", "code": 1199, "label": "ү" }
+      ]
+    },
+    "х": {
+      "main": { "$": "auto_text_key", "code": 1211, "label": "һ" }
+    },
+    "ь": {
+      "main": { "$": "auto_text_key", "code": 1098, "label": "ъ" }
+    },
+    "~right": {
+      "main": { "code": 44, "label": "," },
+      "relevant": [
+        { "code": 38, "label": "&" },
+        { "code": 37, "label": "%" },
+        { "code": 43, "label": "+" },
+        { "code": 34, "label": "\"" },
+        { "code": 45, "label": "-" },
+        { "code": 58, "label": ":" },
+        { "code": 39, "label": "'" },
+        { "code": 64, "label": "@" },
+        { "code": 59, "label": ";" },
+        { "code": 47, "label": "/" },
+        { "$": "layout_direction_selector",
+          "ltr": { "code": 40, "label": "(" },
+          "rtl": { "code": 41, "label": "(" }
+        },
+        { "$": "layout_direction_selector",
+          "ltr": { "code": 41, "label": ")" },
+          "rtl": { "code": 40, "label": ")" }
+        },
+        { "code": 35, "label": "#" },
+        { "code": 33, "label": "!" },
+        { "code": 63, "label": "?" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".kz"},
+      "relevant": [
+        { "code": -255, "label": ".com" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".net" },
+        { "code": -255, "label": ".edu" },
+        { "code": -255, "label": ".gov" },
+        { "code": -255, "label": ".ru" }
+      ]
+    }
+  }
+}

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/kk-latn.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/kk-latn.json
@@ -1,0 +1,85 @@
+{
+  "all": {
+    "a": {
+      "main": { "$": "auto_text_key", "code":  228, "label": "ä" }
+    },
+    "g": {
+      "main": { "$": "auto_text_key", "code":  287, "label": "ğ" }
+    },
+    "h": {
+      "main": { "$": "case_selector",
+        "lower": { "code": 1211, "label": "һ" },
+        "upper": { "code": 1210, "label": "Һ" }
+      }
+    },
+    "i": {
+      "main": { "$": "case_selector",
+        "lower": { "code":  305, "label": "ı" },
+        "upper": { "code":   73, "label": "I" }
+      }
+    },
+    "ı": {
+      "main": { "$": "case_selector",
+        "lower": { "code":  105, "label": "i" },
+        "upper": { "code":  304, "label": "İ" }
+      }
+    },
+    "n": {
+      "main": { "$": "auto_text_key", "code":  331, "label": "ŋ" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  241, "label": "ñ" }
+      ]
+    },
+    "o": {
+      "main": { "$": "auto_text_key", "code":  246, "label": "ö" }
+    },
+    "s": {
+      "main": { "$": "auto_text_key", "code":  351, "label": "ş" }
+    },
+    "u": {
+      "main": { "$": "auto_text_key", "code":  363, "label": "ū" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  252, "label": "ü" }
+      ]
+    },
+    "~right": {
+      "main": { "code": 44, "label": "," },
+      "relevant": [
+        { "code": 38, "label": "&" },
+        { "code": 37, "label": "%" },
+        { "code": 43, "label": "+" },
+        { "code": 34, "label": "\"" },
+        { "code": 45, "label": "-" },
+        { "code": 58, "label": ":" },
+        { "code": 39, "label": "'" },
+        { "code": 64, "label": "@" },
+        { "code": 59, "label": ";" },
+        { "code": 47, "label": "/" },
+        { "$": "layout_direction_selector",
+          "ltr": { "code": 40, "label": "(" },
+          "rtl": { "code": 41, "label": "(" }
+        },
+        { "$": "layout_direction_selector",
+          "ltr": { "code": 41, "label": ")" },
+          "rtl": { "code": 40, "label": ")" }
+        },
+        { "code": 35, "label": "#" },
+        { "code": 33, "label": "!" },
+        { "code": 63, "label": "?" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".kz"},
+      "relevant": [
+        { "code": -255, "label": ".com" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".net" },
+        { "code": -255, "label": ".edu" },
+        { "code": -255, "label": ".gov" },
+        { "code": -255, "label": ".ru" }
+      ]
+    }
+  }
+}

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/nog-arab.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/nog-arab.json
@@ -1,0 +1,100 @@
+{
+  "all": {
+    "س": {
+      "relevant": [
+        { "code": 1589, "label": "ص" },
+        { "code": 1579, "label": "ث" }
+      ]
+    },
+    "ز": {
+      "relevant": [
+        { "code": 1592, "label": "ظ" },
+        { "code": 1584, "label": "ذ" },
+        { "code": 1688, "label": "ژ" }
+      ]
+    },
+    "ت": {
+      "relevant": [
+        { "code": 1591, "label": "ط" },
+        { "code": 1577, "label": "ة" }
+      ]
+    },
+    "ا": {
+      "main": { "code": 1571, "label": "أ" },
+      "relevant": [
+        { "code": 1570, "label": "آ" },
+        { "code": 1569, "label": "ء" },
+        { "code": 1573, "label": "إ" },
+        { "code": 1649, "label": "ٱ" }
+      ]
+    },
+
+    "ۈ": {
+      "relevant": [
+        { "code": 1737, "label": "ۉ" }
+      ]
+    },
+    "و": {
+      "relevant": [
+        { "code": 1739, "label": "ۋ" },
+        { "code": 1572, "label": "ؤ" },
+        { "code": 1737, "label": "ۉ" }
+      ]
+    },
+    "ه": {
+      "relevant": [
+        { "code": 1726, "label": "ھ" }
+      ]
+    },
+    "ە": {
+      "relevant": [
+        { "$": "auto_text_key", "label": "ئە" }
+      ]
+    },
+
+    "ئ": {
+      "relevant": [
+        { "code": 1652, "label": "ٴ" }
+      ]
+    },
+    "ل": {
+      "relevant": [
+        { "code": 65275, "label": "لا" },
+        { "code": 65273, "label": "لإ" },
+        { "code": 65271, "label": "لأ" },
+        { "code": 65269, "label": "لآ" }
+      ]
+    },
+    "~right": {
+      "main": { "code": 1567, "label": "؟" },
+      "relevant": [
+        { "code": 1611, "label": "ً" },
+        { "code": 1622, "label": "ٖ" },
+        { "code": 1648, "label": "ٰ" },
+        { "code": 1619, "label": "ٓ" },
+        { "code": 1615, "label": "ُ" },
+        { "code": 1616, "label": "ِ" },
+        { "code": 1614, "label": "َ" },
+        { "code": 1600, "label": "ـ" },
+        { "code": 1621, "label": "ٕ" },
+        { "code": 1620, "label": "ٔ" },
+        { "code": 1617, "label": "ّ" },
+        { "code": 1612, "label": "ٌ" },
+        { "code": 1613, "label": "ٍ" },
+        { "code": 1618, "label": "ْ" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".ru"},
+      "relevant": [
+        { "code": -255, "label": ".com" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".net" },
+        { "code": -255, "label": ".edu" },
+        { "code": -255, "label": ".gov" }
+      ]
+    }
+  }
+}

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/nog-cyrl.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/nog-cyrl.json
@@ -1,0 +1,482 @@
+{
+  "all": {
+    "й": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 121, "label": "y" },
+          "upper": { "code": 89, "label": "Y" }
+        },
+        { "code": 1610, "label": "ي" },
+        { "code": 68630, "label": "𐰖" },
+        { "code": 68632, "label": "𐰘" }
+      ]
+    },
+    "ц": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "ts" },
+          "upper": { "$": "auto_text_key", "label": "Ts" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 99, "label": "c" },
+          "upper": { "code": 67, "label": "C" }
+        },
+        { "$": "auto_text_key", "label": "تس" },
+        { "$": "auto_text_key", "label": "𐱃𐰽" },
+        { "$": "auto_text_key", "label": "𐱅𐰾" }
+      ]
+    },
+    "у": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "уь" },
+          "upper": { "$": "auto_text_key", "label": "Уь" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 1199, "label": "ү" },
+          "upper": { "code": 1198, "label": "Ү" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 117, "label": "u" },
+          "upper": { "code": 85, "label": "U" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 252, "label": "ü" },
+          "upper": { "code": 220, "label": "Ü" }
+        },
+        { "code": 1736, "label": "ۈ" },
+        { "code": 1735, "label": "ۇ" },
+        { "code": 1575, "label": "ا" },
+        { "code": 68614, "label": "𐰆" },
+        { "code": 68615, "label": "𐰇" }
+      ]
+    },
+    "к": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "къ" },
+          "upper": { "$": "auto_text_key", "label": "Къ" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 1179, "label": "қ" },
+          "upper": { "code": 1178, "label": "Қ" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 107, "label": "k" },
+          "upper": { "code": 75, "label": "K" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 113, "label": "q" },
+          "upper": { "code": 81, "label": "Q" }
+        },
+        { "code": 1602, "label": "ق" },
+        { "code": 1603, "label": "ك" },
+        { "code": 68660, "label": "𐰴" },
+        { "code": 68634, "label": "𐰚" }
+      ]
+    },
+    "е": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 1105, "label": "ё" },
+          "upper": { "code": 1025, "label": "Ё" }
+        },
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "yo" },
+          "upper": { "$": "auto_text_key", "label": "Yo" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 101, "label": "e" },
+          "upper": { "code": 69, "label": "E" }
+        },
+        { "$": "auto_text_key", "label": "يو" },
+        { "code": 1749, "label": "ە" },
+        { "$": "auto_text_key", "label": "يە" },
+        { "code": 1575, "label": "ا" },
+        { "code": 68608, "label": "𐰀" },
+        { "code": 68611, "label": "𐰃" }
+      ]
+    },
+    "н": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "нъ" },
+          "upper": { "$": "auto_text_key", "label": "Нъ" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 1187, "label": "ң" },
+          "upper": { "code": 1186, "label": "Ң‎" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 110, "label": "n" },
+          "upper": { "code": 78, "label": "N" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 241, "label": "ñ" },
+          "upper": { "code": 209, "label": "Ñ" }
+        },
+        { "code": 1709, "label": "ڭ" },
+        { "code": 1606, "label": "ن" },
+        { "code": 68643, "label": "𐰣" },
+        { "code": 68644, "label": "𐰤" },
+        { "code": 68653, "label": "𐰭" }
+      ]
+    },
+    "г": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "гъ" },
+          "upper": { "$": "auto_text_key", "label": "Гъ" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 1171, "label": "ғ" },
+          "upper": { "code": 1170, "label": "Ғ‎" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 103, "label": "g" },
+          "upper": { "code": 71, "label": "G" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 287, "label": "ğ" },
+          "upper": { "code": 286, "label": "Ğ" }
+        },
+        { "code": 1594, "label": "غ" },
+        { "code": 1711, "label": "گ" },
+        { "code": 68621, "label": "𐰍" },
+        { "code": 68623, "label": "𐰏" }
+      ]
+    },
+    "ш": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 351, "label": "ş" },
+          "upper": { "code": 350, "label": "Ş" }
+        },
+        { "code": 1588, "label": "ش" },
+        { "code": 68673, "label": "𐱁" }
+      ]
+    },
+    "щ": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "şç" },
+          "upper": { "$": "auto_text_key", "label": "Şç" }
+        },
+        { "$": "auto_text_key", "label": "شچ" },
+        { "$": "auto_text_key", "label": "𐱁𐰲" }
+      ]
+    },
+    "з": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 122, "label": "z" },
+          "upper": { "code": 90, "label": "Z" }
+        },
+        { "code": 1586, "label": "ز" },
+        { "code": 68628, "label": "𐰔" }
+      ]
+    },
+    "х": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 1211, "label": "һ‎" },
+          "upper": { "code": 1210, "label": "Һ‎" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 104, "label": "h" },
+          "upper": { "code": 72, "label": "H" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 120, "label": "x" },
+          "upper": { "code": 88, "label": "X" }
+        },
+        { "code": 1582, "label": "خ" },
+        { "code": 1581, "label": "ح" },
+        { "code": 1607, "label": "ه" },
+        { "code": 68660, "label": "𐰴" },
+        { "code": 68634, "label": "𐰚" },
+        { "code": 68621, "label": "𐰍" }
+      ]
+    },
+    "ъ": {
+      "relevant": [
+        { "code": 39, "label": "'" },
+        { "code": 1569, "label": "ء" },
+        { "code": 1593, "label": "ع" },
+        { "code": 1618, "label": "ْ" },
+        { "code": 8282, "label": "⁚" }
+      ]
+    },
+    "ф": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 102, "label": "f" },
+          "upper": { "code": 70, "label": "F" }
+        },
+        { "code": 1601, "label": "ف" },
+        { "code": 68655, "label": "𐰯" }
+      ]
+    },
+    "ы": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code":  305, "label": "ı" },
+          "upper": { "code":   73, "label": "I" }
+        },
+        { "code": 1609, "label": "ى" },
+        { "code": 1574, "label": "ئ" },
+        { "code": 1575, "label": "ا" },
+        { "code": 68611, "label": "𐰃" }
+      ]
+    },
+    "в": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 118, "label": "v" },
+          "upper": { "code": 86, "label": "V" }
+        },
+        { "code": 1739, "label": "ۋ" },
+        { "code": 68617, "label": "𐰉" },
+        { "code": 68619, "label": "𐰋" }
+      ]
+    },
+    "а": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "аь" },
+          "upper": { "$": "auto_text_key", "label": "Аь" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 1241, "label": "ә" },
+          "upper": { "code": 1240, "label": "Ә‎" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 97, "label": "a" },
+          "upper": { "code": 65, "label": "A" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 228, "label": "ä" },
+          "upper": { "code": 196, "label": "Ä" }
+        },
+        { "code": 1575, "label": "ا" },
+        { "code": 1569, "label": "ء" },
+        { "code": 1570, "label": "آ" },
+        { "code": 68610, "label": "𐰂" },
+        { "code": 68608, "label": "𐰀" }
+      ]
+    },
+    "п": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 112, "label": "p" },
+          "upper": { "code": 80, "label": "P" }
+        },
+        { "code": 1662, "label": "پ" },
+        { "code": 68655, "label": "𐰯" }
+      ]
+    },
+    "р": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 114, "label": "r" },
+          "upper": { "code": 82, "label": "R" }
+        },
+        { "code": 1585, "label": "ر" },
+        { "code": 68666, "label": "𐰺" },
+        { "code": 68668, "label": "𐰼" }
+      ]
+    },
+    "о": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "оь" },
+          "upper": { "$": "auto_text_key", "label": "Оь" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 1257, "label": "ө" },
+          "upper": { "code": 1256, "label": "Ө‎" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 111, "label": "o" },
+          "upper": { "code": 79, "label": "O" }
+        },
+        { "$": "case_selector",
+          "lower": { "code": 246, "label": "ö" },
+          "upper": { "code": 214, "label": "Ö" }
+        },
+        { "code": 1734, "label": "ۆ" },
+        { "code": 1608, "label": "و" },
+        { "code": 1575, "label": "ا" },
+        { "code": 68614, "label": "𐰆" },
+        { "code": 68615, "label": "𐰇" }
+      ]
+    },
+    "л": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 108, "label": "l" },
+          "upper": { "code": 76, "label": "L" }
+        },
+        { "code": 1604, "label": "ل" },
+        { "code": 68638, "label": "𐰞" },
+        { "code": 68640, "label": "𐰠" }
+      ]
+    },
+    "д": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 100, "label": "d" },
+          "upper": { "code": 68, "label": "D" }
+        },
+        { "code": 1583, "label": "د" },
+        { "code": 68625, "label": "𐰑" },
+        { "code": 68627, "label": "𐰓" }
+      ]
+    },
+    "ж": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 106, "label": "j" },
+          "upper": { "code": 74, "label": "J" }
+        },
+        { "code": 1580, "label": "ج" },
+        { "code": 68630, "label": "𐰖" },
+        { "code": 68632, "label": "𐰘" },
+        { "code": 68658, "label": "𐰲" }
+      ]
+    },
+    "э": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 101, "label": "e" },
+          "upper": { "code": 69, "label": "E" }
+        },
+        { "code": 1749, "label": "ە" },
+        { "$": "auto_text_key", "label": "ئە" },
+        { "code": 1575, "label": "ا" },
+        { "code": 68608, "label": "𐰀" }
+      ]
+    },
+    "я": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "ya" },
+          "upper": { "$": "auto_text_key", "label": "Ya" }
+        },
+        { "$": "auto_text_key", "label": "يا" },
+        { "$": "auto_text_key", "label": "𐰖𐰀" },
+        { "$": "auto_text_key", "label": "𐰘𐰀" }
+      ]
+    },
+    "ч": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 231, "label": "ç" },
+          "upper": { "code": 199, "label": "Ç" }
+        },
+        { "code": 1670, "label": "چ" },
+        { "code": 68658, "label": "𐰲" }
+      ]
+    },
+    "с": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 115, "label": "s" },
+          "upper": { "code": 83, "label": "S" }
+        },
+        { "code": 1587, "label": "س" },
+        { "code": 1589, "label": "ص" },
+        { "code": 68669, "label": "𐰽" },
+        { "code": 68670, "label": "𐰾" }
+      ]
+    },
+    "м": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 109, "label": "m" },
+          "upper": { "code": 77, "label": "M" }
+        },
+        { "code": 1605, "label": "م" },
+        { "code": 68642, "label": "𐰢" }
+      ]
+    },
+    "и": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code":  105, "label": "i" },
+          "upper": { "code":  304, "label": "İ" }
+        },
+        { "code": 1610, "label": "ي" },
+        { "code": 1574, "label": "ئ" },
+        { "code": 1575, "label": "ا" },
+        { "code": 68611, "label": "𐰃" }
+      ]
+    },
+    "т": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 116, "label": "t" },
+          "upper": { "code": 84, "label": "T" }
+        },
+        { "code": 1578, "label": "ت" },
+        { "code": 1591, "label": "ط" },
+        { "code": 68675, "label": "𐱃" },
+        { "code": 68677, "label": "𐱅" }
+      ]
+    },
+    "ь": {
+      "relevant": [
+        { "code": 39, "label": "'" },
+        { "code": 1569, "label": "ء" },
+        { "code": 1593, "label": "ع" },
+        { "code": 1618, "label": "ْ" },
+        { "code": 8282, "label": "⁚" }
+      ]
+    },
+    "б": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "code": 98, "label": "b" },
+          "upper": { "code": 66, "label": "B" }
+        },
+        { "code": 1576, "label": "ب" },
+        { "code": 68617, "label": "𐰉" },
+        { "code": 68619, "label": "𐰋" }
+      ]
+    },
+    "ю": {
+      "relevant": [
+        { "$": "case_selector",
+          "lower": { "$": "auto_text_key", "label": "yu" },
+          "upper": { "$": "auto_text_key", "label": "Yu" }
+        },
+        { "$": "auto_text_key", "label": "يۇ" },
+        { "$": "auto_text_key", "label": "𐰖𐰆" },
+        { "$": "auto_text_key", "label": "𐰘𐰇" }
+      ]
+    },
+    "~right": {
+      "main": { "code": 1548, "label": "،" },
+      "relevant": [
+        { "code": 1567, "label": "؟" },
+        { "code": 1563, "label": "؛" },
+        { "code": 8285, "label": "⁝" },
+        { "code": 8282, "label": "⁚" },
+        { "code": 11824, "label": "⸰" },
+        { "code": 124, "label": "|" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".ru"},
+      "relevant": [
+        { "code": -255, "label": ".com" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".net" },
+        { "code": -255, "label": ".edu" },
+        { "code": -255, "label": ".gov" }
+      ]
+    }
+  }
+}

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/nog-latn.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/nog-latn.json
@@ -1,0 +1,90 @@
+{
+  "all": {
+    "a": {
+      "main": { "$": "auto_text_key", "code":  228, "label": "ä" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  226, "label": "â" }
+      ]
+    },
+    "c": {
+      "main": { "$": "auto_text_key", "code":  231, "label": "ç" }
+    },
+    "g": {
+      "main": { "$": "auto_text_key", "code":  287, "label": "ğ" }
+    },
+    "i": {
+      "main": { "$": "case_selector",
+        "lower": { "code":  305, "label": "ı" },
+        "upper": { "code":   73, "label": "I" }
+      },
+      "relevant": [
+        { "$": "auto_text_key", "code":  238, "label": "î" }
+      ]
+    },
+    "ı": {
+      "main": { "$": "case_selector",
+        "lower": { "code":  105, "label": "i" },
+        "upper": { "code":  304, "label": "İ" }
+      },
+      "relevant": [
+        { "$": "auto_text_key", "code":  238, "label": "î" }
+      ]
+    },
+    "n": {
+      "main": { "$": "auto_text_key", "code":  241, "label": "ñ" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  331, "label": "ŋ" }
+      ]
+    },
+    "o": {
+      "main": { "$": "auto_text_key", "code":  246, "label": "ö" }
+    },
+    "s": {
+      "main": { "$": "auto_text_key", "code":  351, "label": "ş" }
+    },
+    "u": {
+      "main": { "$": "auto_text_key", "code":  252, "label": "ü" },
+      "relevant": [
+        { "$": "auto_text_key", "code":  251, "label": "û" }
+      ]
+    },
+    "~right": {
+      "main": { "code":   44, "label": "," },
+      "relevant": [
+        { "code":   38, "label": "&" },
+        { "code":   37, "label": "%" },
+        { "code":   43, "label": "+" },
+        { "code":   34, "label": "\"" },
+        { "code":   45, "label": "-" },
+        { "code":   58, "label": ":" },
+        { "code":   39, "label": "'" },
+        { "code":   64, "label": "@" },
+        { "code":   59, "label": ";" },
+        { "code":   47, "label": "/" },
+        { "$": "layout_direction_selector",
+          "ltr": { "code":   40, "label": "(" },
+          "rtl": { "code":   41, "label": "(" }
+        },
+        { "$": "layout_direction_selector",
+          "ltr": { "code":   41, "label": ")" },
+          "rtl": { "code":   40, "label": ")" }
+        },
+        { "code":   35, "label": "#" },
+        { "code":   33, "label": "!" },
+        { "code":   63, "label": "?" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".ru"},
+      "relevant": [
+        { "code": -255, "label": ".com" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".net" },
+        { "code": -255, "label": ".edu" },
+        { "code": -255, "label": ".gov" }
+      ]
+    }
+  }
+}

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/nog-orkh.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/popupMappings/nog-orkh.json
@@ -1,0 +1,82 @@
+{
+  "all": {
+    "𐱃": {
+      "relevant": [
+        { "$": "auto_text_key", "label": "𐱃𐰽" }
+      ]
+    },
+    "𐱁": {
+      "relevant": [
+        { "$": "auto_text_key", "label": "𐱁𐰲" },
+        { "code": 68672, "label": "𐱀" }
+      ]
+    },
+    "𐰔": {
+      "relevant": [
+        { "code": 68629, "label": "𐰕" }
+      ]
+    },
+    "𐰴": {
+      "relevant": [
+        { "code": 68664, "label": "𐰸" }
+      ]
+    },
+    "𐰣": {
+      "relevant": [
+        { "code": 68654, "label": "𐰮" }
+      ]
+    },
+    "𐰤": {
+      "relevant": [
+        { "code": 68648, "label": "𐰨" },
+        { "code": 68650, "label": "𐰪" },
+        { "code": 68649, "label": "𐰩" },
+        { "code": 68646, "label": "𐰦" }
+      ]
+    },
+    "𐰞": {
+      "relevant": [
+        { "code": 68651, "label": "𐰫" }
+      ]
+    },
+    "𐰆": {
+      "relevant": [
+        { "code": 68665, "label": "𐰹" },
+        { "code": 68631, "label": "𐰗" }
+      ]
+    },
+    "𐰇": {
+      "relevant": [
+        { "code": 68600, "label": "𐰈" },
+        { "code": 68636, "label": "𐰜" }
+      ]
+    },
+    "𐰃": {
+      "relevant": [
+        { "code": 68662, "label": "𐰶" }
+      ]
+    },
+    "~right": {
+      "main": { "code": 8282, "label": "⁚" },
+      "relevant": [
+        { "code": 8285, "label": "⁝" },
+        { "code": 46, "label": "." },
+        { "code": 44, "label": "," },
+        { "code": 63, "label": "?" },
+        { "code": 33, "label": "!" }
+      ]
+    }
+  },
+  "uri": {
+    "~right": {
+      "main": { "code": -255, "label": ".ru"},
+      "relevant": [
+        { "code": -255, "label": ".com" },
+        { "code": -255, "label": ".org" },
+        { "code": -255, "label": ".net" },
+        { "code": -255, "label": ".edu" },
+        { "code": -255, "label": ".gov" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description
*Note: I have closed my previous PR #3302 to open this completely clean version (squashing the 20 intermediate commits), and to include the newly added Kazakh layouts and localization updates.*

**Feature: Nogai (`nog`) & Kazakh (`kk`) Language Layouts and Translations**

This PR adds comprehensive native support for both Nogai and Kazakh languages. Key features include:

### 1. Nogai Language Support (`nog`)
* **Extended Multi-Script Layouts:** Added support for **4 scripts**: an extended Cyrillic layout (`nog-Cyrl`), alongside Arabic (`nog-Arab`), Latin (`nog-Latn`), and Runic (`nog-Runr`) scripts for future-proofing and academic/historical use.
* **A Decolonial Tool for Cultural Reclamation:** The proposed `nog-Cyrl` layout is designed not merely as a typing utility, but as a decolonial tool for cultural reclamation and linguistic self-determination. While the base layer conforms to the currently enforced Cyrillic orthography to meet immediate practical needs, the long-press (pop-up) functionality strategically bridges the fractured historical layers of the language. It integrates Arabic graphics, Old Turkic Runes, Latin graphics, and Kazakh letters (for digraphs) directly into the extended hold menus.
* **Linguistic Accuracy:** Complete adherence to Nogai language rules and orthographic standards, ensuring users can study and type with historical and modern accuracy.

### 2. Kazakh Language Support (`kk`)
* Added complete keyboard layouts for both Kazakh Cyrillic and Latin alphabets.
* Included all necessary pop-up mappings.

### 3. Localization & Translations
* **Kazakh:** The UI translation is ready and already available on Crowdin.
* **Nogai:** As we discussed, `nog` is the correct three-letter ISO 639-3 code. **Please add the `nog` language to the FlorisBoard Crowdin project.** Once added, I will immediately upload the ready translation.
*(Note: I currently have `res/values-nog/strings.xml` and `res/values-kk/strings.xml` ready locally, but did not include them in this PR's files to avoid conflicts with your Crowdin workflow).*

---

### A Note on the `k3lp` Engine and the Add-on Store
I read your comment in the previous PR regarding the upcoming `k3lp` engine and the plan to move specialized layouts to an add-on store rather than bundling them. I completely understand and respect this architectural direction.

However, I would like to strongly advocate for keeping Nogai bundled **"out of the box"**:
1. **Accessibility for the Community:** Realistically, the level of technical literacy among the Nogai-speaking population is not high. Asking users to figure out and navigate an add-on/plugin system just to type in their native language would create a significant barrier to entry. An out-of-the-box solution is absolutely vital for actual adoption.
2. **A World First (Killer Feature):** Having Nogai support right out of the box would be an incredible killer feature, making FlorisBoard the absolute first keyboard in the world to officially support it across all 4 historical and modern scripts.
3. **Cultural Preservation:** Nogai is currently listed by UNESCO as an endangered language. Frictionless, native digital support in a privacy-focused open-source keyboard is a massive step toward preserving and revitalizing this language.

I hope you might consider bundling this as an exception given the language's vulnerable status and the community's needs.

---

### My APK testing
* Tested locally using `app-debug.apk` on Android.
* All switchers, layouts, and pop-up mappings are fully functional.

### File Changes
**New files:**
* `layouts/characters/kazakh_cyrillic.json`
* `layouts/characters/kazakh_latin.json`
* `layouts/characters/nogai_arabic.json`
* `layouts/characters/nogai_cyrillic.json`
* `layouts/characters/nogai_latin.json`
* `layouts/characters/nogai_runic.json`
* `popupMappings/kk-cyrl.json`
* `popupMappings/kk-latn.json`
* `popupMappings/nog-arab.json`
* `popupMappings/nog-cyrl.json`
* `popupMappings/nog-latn.json`
* `popupMappings/nog-runr.json`

**Modified files:**
* `org.florisboard.layouts/extension.json`
* `org.florisboard.localization/extension.json`

## APK testing

For each change in the pull request, a workflow is run, which produces a debug artifact APK. Go to Checks -> FlorisBoard CI -> `app-debug.apk` and download the APK. It installs under the `dev.patrickgold.florisboard.debug` namespace and will not mess with your main installation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/florisboard/florisboard/blob/main/CONTRIBUTING.md).
- [x] I have read and understood the [AI policy](https://github.com/florisboard/florisboard/blob/main/AI_POLICY.md).